### PR TITLE
RLN: Update API

### DIFF
--- a/rln/src/circuit.rs
+++ b/rln/src/circuit.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{Cursor, Error, ErrorKind, Result, Write};
+use std::option::Option;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -44,11 +45,11 @@ pub fn VK() -> Result<VerifyingKey<Bn254>> {
     }
 }
 
-pub fn CIRCOM() -> CircomBuilder<Bn254> {
+pub fn CIRCOM() -> Option<CircomBuilder<Bn254>> {
     // Load the WASM and R1CS for witness and proof generation
     let cfg = CircomConfig::<Bn254>::new(WASM_PATH, R1CS_PATH).unwrap(); // should be )?; but need to address "the trait `From<ErrReport>` is not implemented for `protocol::ProofError`"
                                                                          // We build and return the circuit
-    CircomBuilder::new(cfg)
+    Some(CircomBuilder::new(cfg))
 }
 
 // Utilities to convert a json verification key in a groth16::VerificationKey

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -55,10 +55,25 @@ pub extern "C" fn set_tree(ctx: *mut RLN, tree_height: usize) -> bool {
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
+pub extern "C" fn delete_leaf(ctx: *mut RLN, index: usize) -> bool {
+    let rln = unsafe { &mut *ctx };
+    rln.delete_leaf(index).is_ok()
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
 pub extern "C" fn set_leaf(ctx: *mut RLN, index: usize, input_buffer: *const Buffer) -> bool {
     let rln = unsafe { &mut *ctx };
     let input_data = <&[u8]>::from(unsafe { &*input_buffer });
     rln.set_leaf(index, input_data).is_ok()
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn set_next_leaf(ctx: *mut RLN, input_buffer: *const Buffer) -> bool {
+    let rln = unsafe { &mut *ctx };
+    let input_data = <&[u8]>::from(unsafe { &*input_buffer });
+    rln.set_next_leaf(input_data).is_ok()
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -105,11 +120,11 @@ pub extern "C" fn get_proof(ctx: *const RLN, index: usize, output_buffer: *mut B
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn prove(
-    ctx: *const RLN,
+    ctx: *mut RLN,
     input_buffer: *const Buffer,
     output_buffer: *mut Buffer,
 ) -> bool {
-    let rln = unsafe { &*ctx };
+    let rln = unsafe { &mut *ctx };
     let input_data = <&[u8]>::from(unsafe { &*input_buffer });
     let mut output_data: Vec<u8> = Vec::new();
 
@@ -143,16 +158,97 @@ pub extern "C" fn verify(
     true
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn generate_rln_proof(
+    ctx: *mut RLN,
+    input_buffer: *const Buffer,
+    output_buffer: *mut Buffer,
+) -> bool {
+    let rln = unsafe { &mut *ctx };
+    let input_data = <&[u8]>::from(unsafe { &*input_buffer });
+    let mut output_data: Vec<u8> = Vec::new();
+
+    if rln.generate_rln_proof(input_data, &mut output_data).is_ok() {
+        unsafe { *output_buffer = Buffer::from(&output_data[..]) };
+        std::mem::forget(output_data);
+        true
+    } else {
+        std::mem::forget(output_data);
+        false
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn verify_rln_proof(
+    ctx: *const RLN,
+    proof_buffer: *const Buffer,
+    proof_is_valid_ptr: *mut bool,
+) -> bool {
+    let rln = unsafe { &*ctx };
+    let proof_data = <&[u8]>::from(unsafe { &*proof_buffer });
+    if match rln.verify_rln_proof(proof_data) {
+        Ok(verified) => verified,
+        Err(_) => return false,
+    } {
+        unsafe { *proof_is_valid_ptr = true };
+    } else {
+        unsafe { *proof_is_valid_ptr = false };
+    };
+    true
+}
+
+////////////////////////////////////////////////////////
+// Utils
+////////////////////////////////////////////////////////
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn key_gen(ctx: *const RLN, output_buffer: *mut Buffer) -> bool {
+    let rln = unsafe { &*ctx };
+    let mut output_data: Vec<u8> = Vec::new();
+    if rln.key_gen(&mut output_data).is_ok() {
+        unsafe { *output_buffer = Buffer::from(&output_data[..]) };
+        std::mem::forget(output_data);
+        true
+    } else {
+        std::mem::forget(output_data);
+        false
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn hash(
+    ctx: *mut RLN,
+    input_buffer: *const Buffer,
+    output_buffer: *mut Buffer,
+) -> bool {
+    let rln = unsafe { &mut *ctx };
+    let input_data = <&[u8]>::from(unsafe { &*input_buffer });
+    let mut output_data: Vec<u8> = Vec::new();
+
+    if rln.hash(input_data, &mut output_data).is_ok() {
+        unsafe { *output_buffer = Buffer::from(&output_data[..]) };
+        std::mem::forget(output_data);
+        true
+    } else {
+        std::mem::forget(output_data);
+        false
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::circuit::*;
     use crate::protocol::*;
     use crate::utils::*;
+    use ark_bn254::{Bn254, Fr};
     use ark_groth16::Proof as ArkProof;
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-    use ark_std::rand::thread_rng;
     use ark_std::str::FromStr;
+    use ark_std::{rand::thread_rng, UniformRand};
     use rand::Rng;
     use semaphore::{identity::Identity, poseidon_hash, Field};
     use serde::{Deserialize, Serialize};
@@ -161,14 +257,15 @@ mod test {
 
     #[test]
     // We test merkle batch Merkle tree additions
-    fn test_merkle_batch_additions_ffi() {
+    fn test_merkle_operations_ffi() {
         let tree_height = 16;
+        let no_of_leaves = 256;
 
         // We generate a vector of random leaves
         let mut leaves: Vec<Field> = Vec::new();
         let mut rng = thread_rng();
-        for _ in 0..256 {
-            leaves.push(hash_to_field(&rng.gen::<[u8; 32]>()));
+        for _ in 0..no_of_leaves {
+            leaves.push(to_field(&Fr::rand(&mut rng)));
         }
 
         // We create a RLN instance
@@ -177,7 +274,7 @@ mod test {
         assert!(success, "RLN object creation failed");
         let rln_pointer = unsafe { &mut *rln_pointer.assume_init() };
 
-        // We first add leaves one by one
+        // We first add leaves one by one specifying the index
         for (i, leaf) in leaves.iter().enumerate() {
             // We prepare id_commitment and we set the leaf at provided index
             let leaf_ser = field_to_bytes_le(&leaf);
@@ -198,11 +295,34 @@ mod test {
         let success = set_tree(rln_pointer, tree_height);
         assert!(success, "set tree call failed");
 
+        // We add leaves one by one using the internal index (new leaves goes in next available position)
+        for leaf in &leaves {
+            let leaf_ser = field_to_bytes_le(&leaf);
+            let input_buffer = &Buffer::from(leaf_ser.as_ref());
+            let success = set_next_leaf(rln_pointer, input_buffer);
+            assert!(success, "set next leaf call failed");
+        }
+
+        // We get the root of the tree obtained adding leaves using the internal index
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = get_root(rln_pointer, output_buffer.as_mut_ptr());
+        assert!(success, "get root call failed");
+        let output_buffer = unsafe { output_buffer.assume_init() };
+        let result_data = <&[u8]>::from(&output_buffer).to_vec();
+        let (root_next, _) = bytes_le_to_field(&result_data);
+
+        // We check if roots are the same
+        assert_eq!(root_single, root_next);
+
+        // We reset the tree to default
+        let success = set_tree(rln_pointer, tree_height);
+        assert!(success, "set tree call failed");
+
         // We add leaves in a batch into the tree
         let leaves_ser = vec_field_to_bytes_le(&leaves);
         let input_buffer = &Buffer::from(leaves_ser.as_ref());
         let success = set_leaves(rln_pointer, input_buffer);
-        assert!(success, "set leaf call failed");
+        assert!(success, "set leaves call failed");
 
         // We get the root of the tree obtained adding leaves in batch
         let mut output_buffer = MaybeUninit::<Buffer>::uninit();
@@ -212,7 +332,38 @@ mod test {
         let result_data = <&[u8]>::from(&output_buffer).to_vec();
         let (root_batch, _) = bytes_le_to_field(&result_data);
 
+        // We check if roots are the same
         assert_eq!(root_single, root_batch);
+
+        // We now delete all leaves set and check if the root corresponds to the empty tree root
+        // delete calls over indexes higher than no_of_leaves are ignored and will not increase self.tree.next_index
+        for i in 0..2 * no_of_leaves {
+            let success = delete_leaf(rln_pointer, i);
+            assert!(success, "delete leaf call failed");
+        }
+
+        // We get the root of the tree obtained deleting all leaves
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = get_root(rln_pointer, output_buffer.as_mut_ptr());
+        assert!(success, "get root call failed");
+        let output_buffer = unsafe { output_buffer.assume_init() };
+        let result_data = <&[u8]>::from(&output_buffer).to_vec();
+        let (root_delete, _) = bytes_le_to_field(&result_data);
+
+        // We reset the tree to default
+        let success = set_tree(rln_pointer, tree_height);
+        assert!(success, "set tree call failed");
+
+        // We get the root of the empty tree
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = get_root(rln_pointer, output_buffer.as_mut_ptr());
+        assert!(success, "get root call failed");
+        let output_buffer = unsafe { output_buffer.assume_init() };
+        let result_data = <&[u8]>::from(&output_buffer).to_vec();
+        let (root_empty, _) = bytes_le_to_field(&result_data);
+
+        // We check if roots are the same
+        assert_eq!(root_delete, root_empty);
     }
 
     #[test]
@@ -305,7 +456,7 @@ mod test {
 
         // We double check that the proof computed from public API is correct
         let root_from_proof =
-            get_tree_root(&id_commitment, &path_elements, &identity_path_index, false);
+            compute_tree_root(&id_commitment, &path_elements, &identity_path_index, false);
 
         assert_eq!(root, root_from_proof);
     }
@@ -346,5 +497,116 @@ mod test {
         let success = verify(rln_pointer, input_buffer, proof_is_valid_ptr);
         assert!(success, "verify call failed");
         assert_eq!(proof_is_valid, true);
+    }
+
+    #[test]
+    fn test_rln_proof_ffi() {
+        let tree_height = 16;
+        let no_of_leaves = 256;
+
+        // We generate a vector of random leaves
+        let mut leaves: Vec<Field> = Vec::new();
+        let mut rng = thread_rng();
+        for _ in 0..no_of_leaves {
+            leaves.push(to_field(&Fr::rand(&mut rng)));
+        }
+
+        // We create a RLN instance
+        let mut rln_pointer = MaybeUninit::<*mut RLN>::uninit();
+        let success = new(tree_height, rln_pointer.as_mut_ptr());
+        assert!(success, "RLN object creation failed");
+        let rln_pointer = unsafe { &mut *rln_pointer.assume_init() };
+
+        // We add leaves in a batch into the tree
+        let leaves_ser = vec_field_to_bytes_le(&leaves);
+        let input_buffer = &Buffer::from(leaves_ser.as_ref());
+        let success = set_leaves(rln_pointer, input_buffer);
+        assert!(success, "set leaves call failed");
+
+        // We generate a new identity pair
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = key_gen(rln_pointer, output_buffer.as_mut_ptr());
+        assert!(success, "key gen call failed");
+        let output_buffer = unsafe { output_buffer.assume_init() };
+        let result_data = <&[u8]>::from(&output_buffer).to_vec();
+        let (identity_secret, read) = bytes_le_to_field(&result_data);
+        let (id_commitment, _) = bytes_le_to_field(&result_data[read..].to_vec());
+
+        // We set as leaf id_commitment, its index would be equal to no_of_leaves
+        let leaf_ser = field_to_bytes_le(&id_commitment);
+        let input_buffer = &Buffer::from(leaf_ser.as_ref());
+        let success = set_next_leaf(rln_pointer, input_buffer);
+        assert!(success, "set next leaf call failed");
+
+        let identity_index: u64 = no_of_leaves;
+
+        // We generate a random signal
+        let mut rng = rand::thread_rng();
+        let signal: [u8; 32] = rng.gen();
+        let signal_len = u64::try_from(signal.len()).unwrap();
+
+        // We generate a random epoch
+        let epoch = hash_to_field(b"test-epoch");
+
+        // We prepare input for generate_rln_proof API
+        // input_data is [ id_key<32> | id_index<8> | epoch<32> | signal_len<8> | signal<var> ]
+        let mut serialized: Vec<u8> = Vec::new();
+        serialized.append(&mut field_to_bytes_le(&identity_secret));
+        serialized.append(&mut identity_index.to_le_bytes().to_vec());
+        serialized.append(&mut field_to_bytes_le(&epoch));
+        serialized.append(&mut signal_len.to_le_bytes().to_vec());
+        serialized.append(&mut signal.to_vec());
+
+        // We call generate_rln_proof
+        let input_buffer = &Buffer::from(serialized.as_ref());
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = generate_rln_proof(rln_pointer, input_buffer, output_buffer.as_mut_ptr());
+        assert!(success, "set leaves call failed");
+        let output_buffer = unsafe { output_buffer.assume_init() };
+        // result_data is [ proof<128> | share_y<32> | nullifier<32> | root<32> | epoch<32> | share_x<32> | rln_identifier<32> ]
+        let mut proof_data = <&[u8]>::from(&output_buffer).to_vec();
+
+        // We prepare input for verify_rln_proof API
+        // input_data is [ proof<128> | share_y<32> | nullifier<32> | root<32> | epoch<32> | share_x<32> | rln_identifier<32> | signal_len<8> | signal<var> ]
+        // that is [ proof_data | signal_len<8> | signal<var> ]
+        proof_data.append(&mut signal_len.to_le_bytes().to_vec());
+        proof_data.append(&mut signal.to_vec());
+
+        // We call generate_rln_proof
+        let input_buffer = &Buffer::from(proof_data.as_ref());
+        let mut proof_is_valid: bool = false;
+        let proof_is_valid_ptr = &mut proof_is_valid as *mut bool;
+        let success = verify_rln_proof(rln_pointer, input_buffer, proof_is_valid_ptr);
+        assert!(success, "verify call failed");
+        assert_eq!(proof_is_valid, true);
+    }
+
+    #[test]
+    fn test_hash_to_field_ffi() {
+        let tree_height: usize = 16;
+
+        // We create a RLN instance
+        let mut rln_pointer = MaybeUninit::<*mut RLN>::uninit();
+        let success = new(tree_height, rln_pointer.as_mut_ptr());
+        assert!(success, "RLN object creation failed");
+        let rln_pointer = unsafe { &mut *rln_pointer.assume_init() };
+
+        let mut rng = rand::thread_rng();
+        let signal: [u8; 32] = rng.gen();
+
+        // We prepare id_commitment and we set the leaf at provided index
+        let input_buffer = &Buffer::from(signal.as_ref());
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = hash(rln_pointer, input_buffer, output_buffer.as_mut_ptr());
+        assert!(success, "hash call failed");
+        let output_buffer = unsafe { output_buffer.assume_init() };
+
+        // We read the returned proof and we append proof values for verify
+        let serialized_hash = <&[u8]>::from(&output_buffer).to_vec();
+        let (hash1, _) = bytes_le_to_field(&serialized_hash);
+
+        let hash2 = hash_to_field(&signal);
+
+        assert_eq!(hash1, hash2);
     }
 }

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -8,23 +8,20 @@ use ark_std::str::FromStr;
 
 pub mod circuit;
 pub mod ffi;
+pub mod merkle_tree;
+pub mod poseidon_tree;
 pub mod protocol;
 pub mod public;
 pub mod utils;
-pub mod merkle_tree;
-pub mod poseidon_tree;
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::poseidon_tree::PoseidonTree;
     use crate::protocol::*;
     use hex_literal::hex;
     use num_bigint::BigInt;
-    use semaphore::{
-        hash::Hash, hash_to_field, identity::Identity, poseidon_hash,
-        Field,
-    };
-    use crate::poseidon_tree::PoseidonTree;
+    use semaphore::{hash::Hash, identity::Identity, poseidon_hash, Field};
 
     // Input generated with https://github.com/oskarth/zk-kit/commit/b6a872f7160c7c14e10a0ea40acab99cbb23c9a8
     const WITNESS_JSON: &str = r#"
@@ -96,8 +93,8 @@ mod test {
         );
 
         let merkle_proof = tree.proof(leaf_index).expect("proof should exist");
-        let path_elements = get_path_elements(&merkle_proof);
-        let identity_path_index = get_identity_path_index(&merkle_proof);
+        let path_elements = merkle_proof.get_path_elements();
+        let identity_path_index = merkle_proof.get_path_index();
 
         // We check correct computation of the path and indexes
         let expected_path_elements = vec![
@@ -149,7 +146,7 @@ mod test {
         // We generate all relevant keys
         let proving_key = ZKEY().unwrap();
         let verification_key = VK().unwrap();
-        let builder = CIRCOM();
+        let builder = CIRCOM().unwrap();
 
         // We compute witness from the json input example
         let rln_witness = rln_witness_from_json(WITNESS_JSON);
@@ -171,11 +168,8 @@ mod test {
         let tree_height = 16;
         let leaf_index = 3;
 
-        // Generate identity
-        // We follow zk-kit approach for identity generation
-        let id = Identity::from_seed(b"hello");
-        let identity_secret = poseidon_hash(&vec![id.trapdoor, id.nullifier]);
-        let id_commitment = poseidon_hash(&vec![identity_secret]);
+        // Generate identity pair
+        let (identity_secret, id_commitment) = keygen();
 
         //// generate merkle tree
         let default_leaf = Field::from(0);
@@ -189,15 +183,19 @@ mod test {
 
         // We set the remaining values to random ones
         let epoch = hash_to_field(b"test-epoch");
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        //let rln_identifier = hash_to_field(b"test-rln-identifier");
 
-        let rln_witness: RLNWitnessInput =
-            rln_witness_from_values(identity_secret, &merkle_proof, x, epoch, rln_identifier);
+        let rln_witness: RLNWitnessInput = rln_witness_from_values(
+            identity_secret,
+            &merkle_proof,
+            x,
+            epoch, /*, rln_identifier*/
+        );
 
         // We generate all relevant keys
         let proving_key = ZKEY().unwrap();
         let verification_key = VK().unwrap();
-        let builder = CIRCOM();
+        let builder = CIRCOM().unwrap();
 
         // Let's generate a zkSNARK proof
         let proof = generate_proof(builder, &proving_key, &rln_witness).unwrap();
@@ -215,13 +213,13 @@ mod test {
         // We test witness serialization
         let rln_witness = rln_witness_from_json(WITNESS_JSON);
         let ser = serialize_witness(&rln_witness);
-        let deser = deserialize_witness(&ser);
+        let (deser, _) = deserialize_witness(&ser);
         assert_eq!(rln_witness, deser);
 
         // We test Proof values serialization
         let proof_values = proof_values_from_witness(&rln_witness);
         let ser = serialize_proof_values(&proof_values);
-        let deser = deserialize_proof_values(&ser);
+        let (deser, _) = deserialize_proof_values(&ser);
         assert_eq!(proof_values, deser);
     }
 }

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -11,6 +11,8 @@ pub mod ffi;
 pub mod protocol;
 pub mod public;
 pub mod utils;
+pub mod merkle_tree;
+pub mod poseidon_tree;
 
 #[cfg(test)]
 mod test {
@@ -19,9 +21,10 @@ mod test {
     use hex_literal::hex;
     use num_bigint::BigInt;
     use semaphore::{
-        hash::Hash, hash_to_field, identity::Identity, poseidon_hash, poseidon_tree::PoseidonTree,
+        hash::Hash, hash_to_field, identity::Identity, poseidon_hash,
         Field,
     };
+    use crate::poseidon_tree::PoseidonTree;
 
     // Input generated with https://github.com/oskarth/zk-kit/commit/b6a872f7160c7c14e10a0ea40acab99cbb23c9a8
     const WITNESS_JSON: &str = r#"

--- a/rln/src/merkle_tree.rs
+++ b/rln/src/merkle_tree.rs
@@ -1,0 +1,357 @@
+// Implementation from https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/merkle_tree.rs
+//! Implements basic binary Merkle trees
+//!
+//! # To do
+//!
+//! * Disk based storage backend (using mmaped files should be easy)
+
+use semaphore::Field;
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::Debug,
+    iter::{once, repeat, successors},
+};
+
+/// Hash types, values and algorithms for a Merkle tree
+pub trait Hasher {
+    /// Type of the leaf and node hashes
+    type Hash: Clone + Eq + Serialize;
+
+    /// Compute the hash of an intermediate node
+    fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash;
+}
+
+/// Merkle tree with all leaf and intermediate hashes stored
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MerkleTree<H: Hasher> {
+    /// Depth of the tree, # of layers including leaf layer
+    depth: usize,
+
+    /// Hash value of empty subtrees of given depth, starting at leaf level
+    empty: Vec<H::Hash>,
+
+    /// Hash values of tree nodes and leaves, breadth first order
+    nodes: Vec<H::Hash>,
+}
+
+/// Element of a Merkle proof
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Branch<H: Hasher> {
+    /// Left branch taken, value is the right sibling hash.
+    Left(H::Hash),
+
+    /// Right branch taken, value is the left sibling hash.
+    Right(H::Hash),
+}
+
+/// Merkle proof path, bottom to top.
+#[derive(Clone, PartialEq, Eq, Serialize)]
+pub struct Proof<H: Hasher>(pub Vec<Branch<H>>);
+
+/// For a given node index, return the parent node index
+/// Returns None if there is no parent (root node)
+const fn parent(index: usize) -> Option<usize> {
+    if index == 0 {
+        None
+    } else {
+        Some(((index + 1) >> 1) - 1)
+    }
+}
+
+/// For a given node index, return index of the first (left) child.
+const fn first_child(index: usize) -> usize {
+    (index << 1) + 1
+}
+
+const fn depth(index: usize) -> usize {
+    // `n.next_power_of_two()` will return `n` iff `n` is a power of two.
+    // The extra offset corrects this.
+    (index + 2).next_power_of_two().trailing_zeros() as usize - 1
+}
+
+impl<H: Hasher> MerkleTree<H> {
+    /// Creates a new `MerkleTree`
+    /// * `depth` - The depth of the tree, including the root. This is 1 greater
+    ///   than the `treeLevels` argument to the Semaphore contract.
+    pub fn new(depth: usize, initial_leaf: H::Hash) -> Self {
+        // Compute empty node values, leaf to root
+        let empty = successors(Some(initial_leaf), |prev| Some(H::hash_node(prev, prev)))
+            .take(depth)
+            .collect::<Vec<_>>();
+
+        // Compute node values
+        let nodes = empty
+            .iter()
+            .rev()
+            .enumerate()
+            .flat_map(|(depth, hash)| repeat(hash).take(1 << depth))
+            .cloned()
+            .collect::<Vec<_>>();
+        debug_assert!(nodes.len() == (1 << depth) - 1);
+
+        Self {
+            depth,
+            empty,
+            nodes,
+        }
+    }
+
+    #[must_use]
+    pub fn num_leaves(&self) -> usize {
+        self.depth
+            .checked_sub(1)
+            .map(|n| 1 << n)
+            .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn root(&self) -> H::Hash {
+        self.nodes[0].clone()
+    }
+
+    pub fn set(&mut self, leaf: usize, hash: H::Hash) {
+        self.set_range(leaf, once(hash));
+    }
+
+    pub fn set_range<I: IntoIterator<Item = H::Hash>>(&mut self, start: usize, hashes: I) {
+        let index = self.num_leaves() + start - 1;
+        let mut count = 0;
+        // TODO: Error/panic when hashes is longer than available leafs
+        for (leaf, hash) in self.nodes[index..].iter_mut().zip(hashes) {
+            *leaf = hash;
+            count += 1;
+        }
+        if count != 0 {
+            self.update_nodes(index, index + (count - 1));
+        }
+    }
+
+    fn update_nodes(&mut self, start: usize, end: usize) {
+        debug_assert_eq!(depth(start), depth(end));
+        if let (Some(start), Some(end)) = (parent(start), parent(end)) {
+            for parent in start..=end {
+                let child = first_child(parent);
+                self.nodes[parent] = H::hash_node(&self.nodes[child], &self.nodes[child + 1]);
+            }
+            self.update_nodes(start, end);
+        }
+    }
+
+    #[must_use]
+    pub fn proof(&self, leaf: usize) -> Option<Proof<H>> {
+        if leaf >= self.num_leaves() {
+            return None;
+        }
+        let mut index = self.num_leaves() + leaf - 1;
+        let mut path = Vec::with_capacity(self.depth);
+        while let Some(parent) = parent(index) {
+            // Add proof for node at index to parent
+            path.push(match index & 1 {
+                1 => Branch::Left(self.nodes[index + 1].clone()),
+                0 => Branch::Right(self.nodes[index - 1].clone()),
+                _ => unreachable!(),
+            });
+            index = parent;
+        }
+        Some(Proof(path))
+    }
+
+    #[must_use]
+    pub fn verify(&self, hash: H::Hash, proof: &Proof<H>) -> bool {
+        proof.root(hash) == self.root()
+    }
+
+    #[must_use]
+    pub fn leaves(&self) -> &[H::Hash] {
+        &self.nodes[(self.num_leaves() - 1)..]
+    }
+}
+
+impl<H: Hasher> Proof<H> {
+    /// Compute the leaf index for this proof
+    #[must_use]
+    pub fn leaf_index(&self) -> usize {
+        self.0.iter().rev().fold(0, |index, branch| match branch {
+            Branch::Left(_) => index << 1,
+            Branch::Right(_) => (index << 1) + 1,
+        })
+    }
+
+    /// Compute path index (TODO: do we want to keep this here?)
+    #[must_use]
+    pub fn path_index(&self) -> Vec<Field> {
+        self.0
+            .iter()
+            .map(|branch| match branch {
+                Branch::Left(_) => Field::from(0),
+                Branch::Right(_) => Field::from(1),
+            })
+            .collect()
+    }
+
+    /// Compute the Merkle root given a leaf hash
+    #[must_use]
+    pub fn root(&self, hash: H::Hash) -> H::Hash {
+        self.0.iter().fold(hash, |hash, branch| match branch {
+            Branch::Left(sibling) => H::hash_node(&hash, sibling),
+            Branch::Right(sibling) => H::hash_node(sibling, &hash),
+        })
+    }
+}
+
+impl<H> Debug for Branch<H>
+where
+    H: Hasher,
+    H::Hash: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Left(arg0) => f.debug_tuple("Left").field(arg0).finish(),
+            Self::Right(arg0) => f.debug_tuple("Right").field(arg0).finish(),
+        }
+    }
+}
+
+impl<H> Debug for Proof<H>
+where
+    H: Hasher,
+    H::Hash: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Proof").field(&self.0).finish()
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use hex_literal::hex;
+    use tiny_keccak::{Hasher as _, Keccak};
+
+    struct Keccak256;
+
+    impl Hasher for Keccak256 {
+        type Hash = [u8; 32];
+
+        fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
+            let mut output = [0; 32];
+            let mut hasher = Keccak::v256();
+            hasher.update(left);
+            hasher.update(right);
+            hasher.finalize(&mut output);
+            output
+        }
+    }
+
+    #[test]
+    fn test_index_calculus() {
+        assert_eq!(parent(0), None);
+        assert_eq!(parent(1), Some(0));
+        assert_eq!(parent(2), Some(0));
+        assert_eq!(parent(3), Some(1));
+        assert_eq!(parent(4), Some(1));
+        assert_eq!(parent(5), Some(2));
+        assert_eq!(parent(6), Some(2));
+        assert_eq!(first_child(0), 1);
+        assert_eq!(first_child(2), 5);
+        assert_eq!(depth(0), 0);
+        assert_eq!(depth(1), 1);
+        assert_eq!(depth(2), 1);
+        assert_eq!(depth(3), 2);
+        assert_eq!(depth(6), 2);
+    }
+
+    #[test]
+    fn test_root() {
+        let mut tree = MerkleTree::<Keccak256>::new(3, [0; 32]);
+        assert_eq!(
+            tree.root(),
+            hex!("b4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30")
+        );
+        tree.set(
+            0,
+            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+        );
+        assert_eq!(
+            tree.root(),
+            hex!("c1ba1812ff680ce84c1d5b4f1087eeb08147a4d510f3496b2849df3a73f5af95")
+        );
+        tree.set(
+            1,
+            hex!("0000000000000000000000000000000000000000000000000000000000000002"),
+        );
+        assert_eq!(
+            tree.root(),
+            hex!("893760ec5b5bee236f29e85aef64f17139c3c1b7ff24ce64eb6315fca0f2485b")
+        );
+        tree.set(
+            2,
+            hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+        );
+        assert_eq!(
+            tree.root(),
+            hex!("222ff5e0b5877792c2bc1670e2ccd0c2c97cd7bb1672a57d598db05092d3d72c")
+        );
+        tree.set(
+            3,
+            hex!("0000000000000000000000000000000000000000000000000000000000000004"),
+        );
+        assert_eq!(
+            tree.root(),
+            hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
+        );
+    }
+
+    #[test]
+    fn test_proof() {
+        let mut tree = MerkleTree::<Keccak256>::new(3, [0; 32]);
+        tree.set(
+            0,
+            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+        );
+        tree.set(
+            1,
+            hex!("0000000000000000000000000000000000000000000000000000000000000002"),
+        );
+        tree.set(
+            2,
+            hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+        );
+        tree.set(
+            3,
+            hex!("0000000000000000000000000000000000000000000000000000000000000004"),
+        );
+
+        let proof = tree.proof(2).expect("proof should exist");
+        assert_eq!(proof.leaf_index(), 2);
+        assert!(tree.verify(
+            hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+            &proof
+        ));
+        assert!(!tree.verify(
+            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+            &proof
+        ));
+    }
+
+    #[test]
+    fn test_position() {
+        let mut tree = MerkleTree::<Keccak256>::new(3, [0; 32]);
+        tree.set(
+            0,
+            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+        );
+        tree.set(
+            1,
+            hex!("0000000000000000000000000000000000000000000000000000000000000002"),
+        );
+        tree.set(
+            2,
+            hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+        );
+        tree.set(
+            3,
+            hex!("0000000000000000000000000000000000000000000000000000000000000004"),
+        );
+    }
+}

--- a/rln/src/poseidon_tree.rs
+++ b/rln/src/poseidon_tree.rs
@@ -1,0 +1,24 @@
+// Implementation from https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/poseidon_tree.rs
+use crate::merkle_tree::{self, Hasher, MerkleTree};
+use semaphore::{Field, poseidon_hash};
+
+use serde::{Deserialize, Serialize};
+
+
+#[allow(dead_code)]
+pub type PoseidonTree = MerkleTree<PoseidonHash>;
+#[allow(dead_code)]
+pub type Branch = merkle_tree::Branch<PoseidonHash>;
+#[allow(dead_code)]
+pub type Proof = merkle_tree::Proof<PoseidonHash>;
+
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PoseidonHash;
+
+impl Hasher for PoseidonHash {
+    type Hash = Field;
+
+    fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash {
+        poseidon_hash(&[*left, *right])
+    }
+}

--- a/rln/src/poseidon_tree.rs
+++ b/rln/src/poseidon_tree.rs
@@ -1,9 +1,8 @@
 // Implementation from https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/poseidon_tree.rs
 use crate::merkle_tree::{self, Hasher, MerkleTree};
-use semaphore::{Field, poseidon_hash};
+use semaphore::{poseidon_hash, Field};
 
 use serde::{Deserialize, Serialize};
-
 
 #[allow(dead_code)]
 pub type PoseidonTree = MerkleTree<PoseidonHash>;

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -18,11 +18,11 @@ use primitive_types::U256;
 use rand::Rng;
 use semaphore::{
     identity::Identity,
-    merkle_tree::{self, Branch},
     poseidon_hash,
-    poseidon_tree::PoseidonHash,
     Field,
 };
+use crate::merkle_tree::{self, Branch};
+use crate::poseidon_tree::PoseidonHash;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::time::Instant;

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -8,7 +8,8 @@ use ark_groth16::{ProvingKey, VerifyingKey};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::thread_rng;
 use num_bigint::BigInt;
-use semaphore::{hash_to_field, identity::Identity, poseidon_tree::PoseidonTree, Field};
+use semaphore::{hash_to_field, identity::Identity, Field};
+use crate::poseidon_tree::PoseidonTree;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::io::{self, Error, ErrorKind, Result}; //default read/write

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -1,3 +1,4 @@
+use crate::poseidon_tree::PoseidonTree;
 /// This is the main public API for RLN. It is used by the FFI, and should be
 /// used by tests etc as well
 ///
@@ -6,13 +7,15 @@ use ark_circom::{CircomBuilder, CircomCircuit, CircomConfig};
 use ark_groth16::Proof as ArkProof;
 use ark_groth16::{ProvingKey, VerifyingKey};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::rand::thread_rng;
+use ark_std::{rand::thread_rng, str::FromStr, UniformRand};
 use num_bigint::BigInt;
-use semaphore::{hash_to_field, identity::Identity, Field};
-use crate::poseidon_tree::PoseidonTree;
+use semaphore::{identity::Identity, Field};
 use serde::{Deserialize, Serialize};
 use serde_json;
+use std::default::Default;
+use std::io::Cursor;
 use std::io::{self, Error, ErrorKind, Result}; //default read/write
+use std::option::Option;
 
 // For the ToBytes implementation of groth16::Proof
 use ark_ec::bn::Bn;
@@ -20,24 +23,24 @@ use ark_ff::bytes::ToBytes;
 use ark_serialize::{Read, Write};
 
 use crate::circuit::{CIRCOM, VK, ZKEY};
-use crate::protocol::*;
+use crate::protocol::{self, *};
 use crate::utils::*;
+
+// Application specific RLN identifier
+pub const RLN_IDENTIFIER: &[u8] = b"zerokit/rln/010203040506070809";
 
 // TODO Add Engine here? i.e. <E: Engine> not <Bn254>
 // TODO Assuming we want to use IncrementalMerkleTree, figure out type/trait conversions
 pub struct RLN {
-    pub circom: CircomBuilder<Bn254>,
+    pub circom: Option<CircomBuilder<Bn254>>,
     pub proving_key: Result<ProvingKey<Bn254>>,
     pub verification_key: Result<VerifyingKey<Bn254>>,
     pub tree: PoseidonTree,
 }
 
-use crate::utils::{to_field, to_fr};
-use std::io::Cursor;
-
 impl RLN {
     pub fn new(tree_height: usize) -> RLN {
-        let circom = CIRCOM();
+        let circom = None::<CircomBuilder<Bn254>>; //CIRCOM();
 
         let proving_key = ZKEY();
         let verification_key = VK();
@@ -93,6 +96,30 @@ impl RLN {
         Ok(())
     }
 
+    // Set input leaf to the next available index
+    pub fn set_next_leaf<R: Read>(&mut self, mut input_data: R) -> io::Result<()> {
+        // We read input
+        let mut leaf_byte: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut leaf_byte)?;
+
+        // We set the leaf at input index
+        let (leaf, _) = bytes_le_to_field(&leaf_byte);
+        self.tree.set(self.tree.next_index, leaf);
+
+        Ok(())
+    }
+
+    // Deleting a leaf corresponds to set its value to the default 0 leaf
+    pub fn delete_leaf(&mut self, index: usize) -> io::Result<()> {
+        // We reset the leaf only if we previously set a leaf at that index
+        if index < self.tree.next_index {
+            let leaf = Field::from(0);
+            self.tree.set(index, leaf);
+        }
+
+        Ok(())
+    }
+
     /// returns current membership root
     /// * `root` is a scalar field element in 32 bytes
     pub fn get_root<W: Write>(&self, mut output_data: W) -> io::Result<()> {
@@ -106,8 +133,8 @@ impl RLN {
     /// * `root` is a scalar field element in 32 bytes
     pub fn get_proof<W: Write>(&self, index: usize, mut output_data: W) -> io::Result<()> {
         let merkle_proof = self.tree.proof(index).expect("proof should exist");
-        let path_elements = get_path_elements(&merkle_proof);
-        let identity_path_index = get_identity_path_index(&merkle_proof);
+        let path_elements = merkle_proof.get_path_elements();
+        let identity_path_index = merkle_proof.get_path_index();
 
         output_data.write_all(&vec_field_to_bytes_le(&path_elements))?;
         output_data.write_all(&vec_u8_to_bytes_le(&identity_path_index))?;
@@ -119,17 +146,21 @@ impl RLN {
     // zkSNARK APIs
     ////////////////////////////////////////////////////////
     pub fn prove<R: Read, W: Write>(
-        &self,
+        &mut self,
         mut input_data: R,
         mut output_data: W,
     ) -> io::Result<()> {
         // We read input RLN witness and we deserialize it
-        let mut witness_byte: Vec<u8> = Vec::new();
-        input_data.read_to_end(&mut witness_byte)?;
-        let rln_witness = deserialize_witness(&witness_byte);
+        let mut serialized: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut serialized)?;
+        let (rln_witness, _) = deserialize_witness(&serialized);
+
+        if self.circom.is_none() {
+            self.circom = CIRCOM();
+        }
 
         let proof = generate_proof(
-            self.circom.clone(),
+            self.circom.as_ref().unwrap().clone(),
             self.proving_key.as_ref().unwrap(),
             &rln_witness,
         )
@@ -146,10 +177,11 @@ impl RLN {
         // serialized_proof (compressed, 4*32 bytes) || serialized_proof_values (6*32 bytes)
         let mut input_byte: Vec<u8> = Vec::new();
         input_data.read_to_end(&mut input_byte)?;
-        let proof: Proof = ArkProof::deserialize(&mut Cursor::new(&input_byte[..128].to_vec()))
-            .unwrap()
-            .into();
-        let proof_values = deserialize_proof_values(&input_byte[128..].to_vec());
+        let proof: protocol::Proof =
+            ArkProof::deserialize(&mut Cursor::new(&input_byte[..128].to_vec()))
+                .unwrap()
+                .into();
+        let (proof_values, _) = deserialize_proof_values(&input_byte[128..].to_vec());
 
         let verified = verify_proof(
             self.verification_key.as_ref().unwrap(),
@@ -159,6 +191,98 @@ impl RLN {
         .unwrap();
 
         Ok(verified)
+    }
+
+    // This API keeps partial compatibility with kilic's rln public API https://github.com/kilic/rln/blob/7ac74183f8b69b399e3bc96c1ae8ab61c026dc43/src/public.rs#L148
+    // input_data is [ id_key<32> | id_index<8> | epoch<32> | signal_len<8> | signal<var> ]
+    // output_data is [ proof<128> | share_y<32> | nullifier<32> | root<32> | epoch<32> | share_x<32> | rln_identifier<32> ]
+    pub fn generate_rln_proof<R: Read, W: Write>(
+        &mut self,
+        mut input_data: R,
+        mut output_data: W,
+    ) -> io::Result<()> {
+        // We read input RLN witness and we deserialize it
+        let mut witness_byte: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut witness_byte)?;
+        let (rln_witness, _) = proof_inputs_to_rln_witness(&mut self.tree, &witness_byte);
+        let proof_values = proof_values_from_witness(&rln_witness);
+
+        if self.circom.is_none() {
+            self.circom = CIRCOM();
+        }
+
+        let proof = generate_proof(
+            self.circom.as_ref().unwrap().clone(),
+            self.proving_key.as_ref().unwrap(),
+            &rln_witness,
+        )
+        .unwrap();
+
+        // Note: we export a serialization of ark-groth16::Proof not semaphore::Proof
+        // This proof is compressed, i.e. 128 bytes long
+        ArkProof::from(proof).serialize(&mut output_data).unwrap();
+        output_data.write_all(&serialize_proof_values(&proof_values))?;
+
+        Ok(())
+    }
+
+    // Input data is serialized for Bn254 as:
+    // [ proof<128> | share_y<32> | nullifier<32> | root<32> | epoch<32> | share_x<32> | rln_identifier<32> | signal_len<8> | signal<var> ]
+    pub fn verify_rln_proof<R: Read>(&self, mut input_data: R) -> io::Result<bool> {
+        let mut serialized: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut serialized)?;
+        let mut all_read = 0;
+        let proof: protocol::Proof =
+            ArkProof::deserialize(&mut Cursor::new(&serialized[..128].to_vec()))
+                .unwrap()
+                .into();
+        all_read += 128;
+        let (proof_values, read) = deserialize_proof_values(&serialized[all_read..].to_vec());
+        all_read += read;
+
+        let signal_len = usize::try_from(u64::from_le_bytes(
+            serialized[all_read..all_read + 8].try_into().unwrap(),
+        ))
+        .unwrap();
+        all_read += 8;
+
+        let signal: Vec<u8> = serialized[all_read..all_read + signal_len].to_vec();
+
+        let verified = verify_proof(
+            self.verification_key.as_ref().unwrap(),
+            &proof,
+            &proof_values,
+        )
+        .unwrap();
+
+        // Consistency checks to counter proof tampering
+        let x = hash_to_field(&signal);
+        Ok(verified
+            && (self.tree.root() == proof_values.root)
+            && (x == proof_values.x)
+            && (proof_values.rln_identifier == hash_to_field(RLN_IDENTIFIER)))
+    }
+
+    ////////////////////////////////////////////////////////
+    // Utils
+    ////////////////////////////////////////////////////////
+
+    pub fn key_gen<W: Write>(&self, mut output_data: W) -> io::Result<()> {
+        let (id_key, id_commitment_key) = keygen();
+        output_data.write_all(&field_to_bytes_le(&id_key))?;
+        output_data.write_all(&field_to_bytes_le(&id_commitment_key))?;
+
+        Ok(())
+    }
+
+    pub fn hash<R: Read, W: Write>(&self, mut input_data: R, mut output_data: W) -> io::Result<()> {
+        let mut serialized: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut serialized)?;
+
+        let hash = hash_to_field(&serialized);
+        output_data.write_all(&field_to_bytes_le(&hash))?;
+
+        Ok(())
     }
 }
 
@@ -178,21 +302,25 @@ mod test {
 
     #[test]
     // We test merkle batch Merkle tree additions
-    fn test_merkle_batch_additions() {
+    fn test_merkle_operations() {
         let tree_height = 16;
+        let no_of_leaves = 256;
 
         // We generate a vector of random leaves
         let mut leaves: Vec<Field> = Vec::new();
         let mut rng = thread_rng();
-        for _ in 0..256 {
-            leaves.push(hash_to_field(&rng.gen::<[u8; 32]>()));
+        for _ in 0..no_of_leaves {
+            leaves.push(to_field(&Fr::rand(&mut rng)));
         }
 
         // We create a new tree
         let mut rln = RLN::new(tree_height);
 
-        // We first add leaves one by one
+        // We first add leaves one by one specifying the index
         for (i, leaf) in leaves.iter().enumerate() {
+            // We check if internal index is properly set
+            assert_eq!(rln.tree.next_index, i);
+
             let mut buffer = Cursor::new(field_to_bytes_le(&leaf));
             rln.set_leaf(i, &mut buffer).unwrap();
         }
@@ -205,9 +333,31 @@ mod test {
         // We reset the tree to default
         rln.set_tree(tree_height).unwrap();
 
+        // We add leaves one by one using the internal index (new leaves goes in next available position)
+        for leaf in &leaves {
+            let mut buffer = Cursor::new(field_to_bytes_le(&leaf));
+            rln.set_next_leaf(&mut buffer).unwrap();
+        }
+
+        // We check if internal index is properly set
+        assert_eq!(rln.tree.next_index, no_of_leaves);
+
+        // We get the root of the tree obtained adding leaves using the internal index
+        let mut buffer = Cursor::new(Vec::<u8>::new());
+        rln.get_root(&mut buffer).unwrap();
+        let (root_next, _) = bytes_le_to_field(&buffer.into_inner());
+
+        assert_eq!(root_single, root_next);
+
+        // We reset the tree to default
+        rln.set_tree(tree_height).unwrap();
+
         // We add leaves in a batch into the tree
         let mut buffer = Cursor::new(vec_field_to_bytes_le(&leaves));
         rln.set_leaves(&mut buffer).unwrap();
+
+        // We check if internal index is properly set
+        assert_eq!(rln.tree.next_index, no_of_leaves);
 
         // We get the root of the tree obtained adding leaves in batch
         let mut buffer = Cursor::new(Vec::<u8>::new());
@@ -215,6 +365,28 @@ mod test {
         let (root_batch, _) = bytes_le_to_field(&buffer.into_inner());
 
         assert_eq!(root_single, root_batch);
+
+        // We now delete all leaves set and check if the root corresponds to the empty tree root
+        // delete calls over indexes higher than no_of_leaves are ignored and will not increase self.tree.next_index
+        for i in 0..2 * no_of_leaves {
+            rln.delete_leaf(i).unwrap();
+        }
+
+        // We check if internal index is properly set
+        assert_eq!(rln.tree.next_index, no_of_leaves);
+
+        let mut buffer = Cursor::new(Vec::<u8>::new());
+        rln.get_root(&mut buffer).unwrap();
+        let (root_delete, _) = bytes_le_to_field(&buffer.into_inner());
+
+        // We reset the tree to default
+        rln.set_tree(tree_height).unwrap();
+
+        let mut buffer = Cursor::new(Vec::<u8>::new());
+        rln.get_root(&mut buffer).unwrap();
+        let (root_empty, _) = bytes_le_to_field(&buffer.into_inner());
+
+        assert_eq!(root_delete, root_empty);
     }
 
     #[test]
@@ -296,7 +468,7 @@ mod test {
 
         // We double check that the proof computed from public API is correct
         let root_from_proof =
-            get_tree_root(&id_commitment, &path_elements, &identity_path_index, false);
+            compute_tree_root(&id_commitment, &path_elements, &identity_path_index, false);
 
         assert_eq!(root, root_from_proof);
     }
@@ -306,7 +478,7 @@ mod test {
     fn test_groth16_proof() {
         let tree_height = 16;
 
-        let rln = RLN::new(tree_height);
+        let mut rln = RLN::new(tree_height);
 
         // Note: we only test Groth16 proof generation, so we ignore setting the tree in the RLN object
         let rln_witness = random_rln_witness(tree_height);
@@ -319,7 +491,7 @@ mod test {
         let serialized_proof = output_buffer.into_inner();
 
         // Before checking public verify API, we check that the (deserialized) proof generated by prove is actually valid
-        let proof: Proof = ArkProof::deserialize(&mut Cursor::new(&serialized_proof))
+        let proof: protocol::Proof = ArkProof::deserialize(&mut Cursor::new(&serialized_proof))
             .unwrap()
             .into();
         let verified = verify_proof(
@@ -340,5 +512,88 @@ mod test {
         let verified = rln.verify(&mut input_buffer).unwrap();
 
         assert!(verified);
+    }
+
+    #[test]
+    fn test_rln_proof() {
+        let tree_height = 16;
+        let no_of_leaves = 256;
+
+        // We generate a vector of random leaves
+        let mut leaves: Vec<Field> = Vec::new();
+        let mut rng = thread_rng();
+        for _ in 0..no_of_leaves {
+            leaves.push(to_field(&Fr::rand(&mut rng)));
+        }
+
+        // We create a new RLN instance
+        let mut rln = RLN::new(tree_height);
+
+        // We add leaves in a batch into the tree
+        let mut buffer = Cursor::new(vec_field_to_bytes_le(&leaves));
+        rln.set_leaves(&mut buffer).unwrap();
+
+        // Generate identity pair
+        let (identity_secret, id_commitment) = keygen();
+
+        // We set as leaf id_commitment after storing its index
+        let identity_index = u64::try_from(rln.tree.next_index).unwrap();
+        let mut buffer = Cursor::new(field_to_bytes_le(&id_commitment));
+        rln.set_next_leaf(&mut buffer).unwrap();
+
+        // We generate a random signal
+        let mut rng = rand::thread_rng();
+        let signal: [u8; 32] = rng.gen();
+        let signal_len = u64::try_from(signal.len()).unwrap();
+
+        // We generate a random epoch
+        let epoch = hash_to_field(b"test-epoch");
+
+        // We prepare input for generate_rln_proof API
+        // input_data is [ id_key<32> | id_index<8> | epoch<32> | signal_len<8> | signal<var> ]
+        let mut serialized: Vec<u8> = Vec::new();
+        serialized.append(&mut field_to_bytes_le(&identity_secret));
+        serialized.append(&mut identity_index.to_le_bytes().to_vec());
+        serialized.append(&mut field_to_bytes_le(&epoch));
+        serialized.append(&mut signal_len.to_le_bytes().to_vec());
+        serialized.append(&mut signal.to_vec());
+
+        let mut input_buffer = Cursor::new(serialized);
+        let mut output_buffer = Cursor::new(Vec::<u8>::new());
+        rln.generate_rln_proof(&mut input_buffer, &mut output_buffer)
+            .unwrap();
+
+        // output_data is [ proof<128> | share_y<32> | nullifier<32> | root<32> | epoch<32> | share_x<32> | rln_identifier<32> ]
+        let mut proof_data = output_buffer.into_inner();
+
+        // We prepare input for verify_rln_proof API
+        // input_data is [ proof<128> | share_y<32> | nullifier<32> | root<32> | epoch<32> | share_x<32> | rln_identifier<32> | signal_len<8> | signal<var> ]
+        // that is [ proof_data || signal_len<8> | signal<var> ]
+        proof_data.append(&mut signal_len.to_le_bytes().to_vec());
+        proof_data.append(&mut signal.to_vec());
+
+        let mut input_buffer = Cursor::new(proof_data);
+        let verified = rln.verify_rln_proof(&mut input_buffer).unwrap();
+
+        assert!(verified);
+    }
+
+    #[test]
+    fn test_hash_to_field() {
+        let rln = RLN::default();
+
+        let mut rng = rand::thread_rng();
+        let signal: [u8; 32] = rng.gen();
+
+        let mut input_buffer = Cursor::new(&signal);
+        let mut output_buffer = Cursor::new(Vec::<u8>::new());
+
+        rln.hash(&mut input_buffer, &mut output_buffer).unwrap();
+        let serialized_hash = output_buffer.into_inner();
+        let (hash1, _) = bytes_le_to_field(&serialized_hash);
+
+        let hash2 = hash_to_field(&signal);
+
+        assert_eq!(hash1, hash2);
     }
 }


### PR DESCRIPTION
This PR expands public zerokit RLN APIs by adding:

- `set_next_leaf` : set leaf to the next available free index;
- `delete_leaf`: to delete a leaf at a certain index;
- `generate_rln_proof` and `verify_rln_proof`: to verify zk proofs with input/output similar to [Kilic's RLN implementation](https://github.com/kilic/rln);
- `key_gen`: to generate a pair of `(id, commitment)`, with `commitment = PoseidonHash(id)`;
- `hash`: for hashing arbitrary signals to field elements.

Tests for each new rust and C API are also provided.

In order to implement `set_next_leaf`, the module now integrates a slightly customized version of [semaphore-rs](https://github.com/worldcoin/semaphore-rs/) [merkle tree](https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/merkle_tree.rs) and [poseidon_tree](https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/poseidon_tree.rs) implementations.

This PR will ease integration of zerokit RLN in [nwaku](https://github.com/status-im/nwaku) implementation, with minimal edits to the latter.