### PR TITLE
chore(rln): add "staticlib" to crate-type in Cargo.toml

### DIFF
--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
 


### PR DESCRIPTION
This is added to also generate a static library when building RLN