### PR TITLE
fix(rln): Fix CI by updating ethers dependency

### DIFF
--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -58,7 +58,7 @@ sha2 = "0.10.1"
 ff = { package="ff_ce", version="0.11"}
 
 zkp-u256 = { version = "0.2", optional = true }
-ethers-core = "0.6.3"
+ethers = { git = "https://github.com/gakonst/ethers-rs" }
 
 tiny-keccak = "2.0.2"
 

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -14,7 +14,7 @@ use ark_relations::r1cs::SynthesisError;
 use ark_serialize::*;
 use ark_std::{rand::thread_rng, str::FromStr, UniformRand};
 use color_eyre::Result;
-use ethers_core::utils::keccak256;
+use ethers::core::utils::keccak256;
 use num_bigint::{BigInt, BigUint, ToBigInt};
 use primitive_types::U256;
 use rand::Rng;

--- a/rln/src/utils.rs
+++ b/rln/src/utils.rs
@@ -1,7 +1,7 @@
 use ark_bn254::{Bn254, Fr, Parameters};
 use ark_ff::{BigInteger, Field as ArkField, FpParameters, PrimeField};
 use ark_std::str::FromStr;
-use ethers_core::utils::keccak256;
+use ethers::core::utils::keccak256;
 use num_bigint::{BigInt, BigUint, ToBigInt};
 use semaphore::{identity::Identity, Field};
 use std::iter::Extend;


### PR DESCRIPTION
Seems to do the trick, previously problems with `k256`, `signature` etc versions.