### PR TITLE
feat(RLN): add `new_with_params`

### DIFF
--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -47,6 +47,23 @@ pub extern "C" fn new(tree_height: usize, input_buffer: *const Buffer, ctx: *mut
     true
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn new_with_params(
+    tree_height: usize,
+    circom_buffer: *const Buffer,
+    zkey_buffer: *const Buffer,
+    vk_buffer: *const Buffer,
+    ctx: *mut *mut RLN,
+) -> bool {
+    let circom_data = <&[u8]>::from(unsafe { &*circom_buffer });
+    let zkey_data = <&[u8]>::from(unsafe { &*zkey_buffer });
+    let vk_data = <&[u8]>::from(unsafe { &*vk_buffer });
+    let rln = RLN::new_with_params(tree_height, circom_data, zkey_data, vk_data);
+    unsafe { *ctx = Box::into_raw(Box::new(rln)) };
+    true
+}
+
 ////////////////////////////////////////////////////////
 // Merkle tree APIs
 ////////////////////////////////////////////////////////

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -14,7 +14,7 @@ pub mod utils;
 mod test {
 
     use crate::circuit::{
-        CIRCOM_from_folder, Fr, VK_from_folder, ZKEY_from_folder, TEST_RESOURCES_FOLDER,
+        circom_from_folder, vk_from_folder, zkey_from_folder, Fr, TEST_RESOURCES_FOLDER,
         TEST_TREE_HEIGHT,
     };
     use crate::poseidon_hash::poseidon_hash;
@@ -330,9 +330,9 @@ mod test {
     // We test a RLN proof generation and verification
     fn test_witness_from_json() {
         // We generate all relevant keys
-        let proving_key = ZKEY_from_folder(TEST_RESOURCES_FOLDER).unwrap();
-        let verification_key = VK_from_folder(TEST_RESOURCES_FOLDER).unwrap();
-        let builder = CIRCOM_from_folder(TEST_RESOURCES_FOLDER);
+        let proving_key = zkey_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let verification_key = vk_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let builder = circom_from_folder(TEST_RESOURCES_FOLDER);
 
         // We compute witness from the json input example
         let mut witness_json: &str = "";
@@ -389,9 +389,9 @@ mod test {
         );
 
         // We generate all relevant keys
-        let proving_key = ZKEY_from_folder(TEST_RESOURCES_FOLDER).unwrap();
-        let verification_key = VK_from_folder(TEST_RESOURCES_FOLDER).unwrap();
-        let builder = CIRCOM_from_folder(TEST_RESOURCES_FOLDER);
+        let proving_key = zkey_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let verification_key = vk_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let builder = circom_from_folder(TEST_RESOURCES_FOLDER);
 
         // Let's generate a zkSNARK proof
         let proof = generate_proof(builder, &proving_key, &rln_witness).unwrap();

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -13,7 +13,10 @@ pub mod utils;
 #[cfg(test)]
 mod test {
 
-    use crate::circuit::{Fr, CIRCOM, TEST_RESOURCES_FOLDER, TEST_TREE_HEIGHT, VK, ZKEY};
+    use crate::circuit::{
+        CIRCOM_from_folder, Fr, VK_from_folder, ZKEY_from_folder, TEST_RESOURCES_FOLDER,
+        TEST_TREE_HEIGHT,
+    };
     use crate::poseidon_hash::poseidon_hash;
     use crate::poseidon_tree::PoseidonTree;
     use crate::protocol::*;
@@ -327,9 +330,9 @@ mod test {
     // We test a RLN proof generation and verification
     fn test_witness_from_json() {
         // We generate all relevant keys
-        let proving_key = ZKEY(TEST_RESOURCES_FOLDER).unwrap();
-        let verification_key = VK(TEST_RESOURCES_FOLDER).unwrap();
-        let builder = CIRCOM(TEST_RESOURCES_FOLDER);
+        let proving_key = ZKEY_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let verification_key = VK_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let builder = CIRCOM_from_folder(TEST_RESOURCES_FOLDER);
 
         // We compute witness from the json input example
         let mut witness_json: &str = "";
@@ -386,9 +389,9 @@ mod test {
         );
 
         // We generate all relevant keys
-        let proving_key = ZKEY(TEST_RESOURCES_FOLDER).unwrap();
-        let verification_key = VK(TEST_RESOURCES_FOLDER).unwrap();
-        let builder = CIRCOM(TEST_RESOURCES_FOLDER);
+        let proving_key = ZKEY_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let verification_key = VK_from_folder(TEST_RESOURCES_FOLDER).unwrap();
+        let builder = CIRCOM_from_folder(TEST_RESOURCES_FOLDER);
 
         // Let's generate a zkSNARK proof
         let proof = generate_proof(builder, &proving_key, &rln_witness).unwrap();

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -10,7 +10,10 @@ use std::io::Cursor;
 use std::io::{self, Result};
 use std::sync::Mutex;
 
-use crate::circuit::{Curve, Fr, CIRCOM, TEST_RESOURCES_FOLDER, TEST_TREE_HEIGHT, VK, ZKEY};
+use crate::circuit::{
+    CIRCOM_from_folder, Curve, Fr, VK_from_folder, ZKEY_from_folder, CIRCOM, TEST_RESOURCES_FOLDER,
+    TEST_TREE_HEIGHT, VK, ZKEY,
+};
 use crate::poseidon_tree::PoseidonTree;
 use crate::protocol::*;
 use crate::utils::*;
@@ -25,7 +28,6 @@ pub struct RLN<'a> {
     proving_key: Result<(ProvingKey<Curve>, ConstraintMatrices<Fr>)>,
     verification_key: Result<VerifyingKey<Curve>>,
     tree: PoseidonTree,
-    resources_folder: String,
 }
 
 impl RLN<'_> {
@@ -36,10 +38,10 @@ impl RLN<'_> {
 
         let resources_folder = String::from_utf8(input).expect("Found invalid UTF-8");
 
-        let witness_calculator = CIRCOM(&resources_folder);
+        let witness_calculator = CIRCOM_from_folder(&resources_folder);
 
-        let proving_key = ZKEY(&resources_folder);
-        let verification_key = VK(&resources_folder);
+        let proving_key = ZKEY_from_folder(&resources_folder);
+        let verification_key = VK_from_folder(&resources_folder);
 
         // We compute a default empty tree
         let tree = PoseidonTree::default(tree_height);
@@ -49,7 +51,36 @@ impl RLN<'_> {
             proving_key,
             verification_key,
             tree,
-            resources_folder,
+        }
+    }
+
+    pub fn new_with_params<R: Read>(
+        tree_height: usize,
+        mut circom_data: R,
+        mut zkey_data: R,
+        mut vk_data: R,
+    ) -> RLN<'static> {
+        // We read input
+        let mut circom_vec: Vec<u8> = Vec::new();
+        circom_data.read_to_end(&mut circom_vec).unwrap();
+        let mut zkey_vec: Vec<u8> = Vec::new();
+        zkey_data.read_to_end(&mut zkey_vec).unwrap();
+        let mut vk_vec: Vec<u8> = Vec::new();
+        vk_data.read_to_end(&mut vk_vec).unwrap();
+
+        let witness_calculator = CIRCOM(circom_vec);
+
+        let proving_key = ZKEY(&zkey_vec);
+        let verification_key = VK(&vk_vec, &zkey_vec);
+
+        // We compute a default empty tree
+        let tree = PoseidonTree::default(tree_height);
+
+        RLN {
+            witness_calculator,
+            proving_key,
+            verification_key,
+            tree,
         }
     }
 

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -11,8 +11,8 @@ use std::io::{self, Result};
 use std::sync::Mutex;
 
 use crate::circuit::{
-    CIRCOM_from_folder, Curve, Fr, VK_from_folder, ZKEY_from_folder, CIRCOM, TEST_RESOURCES_FOLDER,
-    TEST_TREE_HEIGHT, VK, ZKEY,
+    circom_from_folder, circom_from_raw, vk_from_folder, vk_from_raw, zkey_from_folder,
+    zkey_from_raw, Curve, Fr, TEST_RESOURCES_FOLDER, TEST_TREE_HEIGHT,
 };
 use crate::poseidon_tree::PoseidonTree;
 use crate::protocol::*;
@@ -38,10 +38,10 @@ impl RLN<'_> {
 
         let resources_folder = String::from_utf8(input).expect("Found invalid UTF-8");
 
-        let witness_calculator = CIRCOM_from_folder(&resources_folder);
+        let witness_calculator = circom_from_folder(&resources_folder);
 
-        let proving_key = ZKEY_from_folder(&resources_folder);
-        let verification_key = VK_from_folder(&resources_folder);
+        let proving_key = zkey_from_folder(&resources_folder);
+        let verification_key = vk_from_folder(&resources_folder);
 
         // We compute a default empty tree
         let tree = PoseidonTree::default(tree_height);
@@ -68,10 +68,10 @@ impl RLN<'_> {
         let mut vk_vec: Vec<u8> = Vec::new();
         vk_data.read_to_end(&mut vk_vec).unwrap();
 
-        let witness_calculator = CIRCOM(circom_vec);
+        let witness_calculator = circom_from_raw(circom_vec);
 
-        let proving_key = ZKEY(&zkey_vec);
-        let verification_key = VK(&vk_vec, &zkey_vec);
+        let proving_key = zkey_from_raw(&zkey_vec);
+        let verification_key = vk_from_raw(&vk_vec, &zkey_vec);
 
         // We compute a default empty tree
         let tree = PoseidonTree::default(tree_height);


### PR DESCRIPTION
Allows passing the wasm, zkey and verification key data as buffers, instead of using a path to a folder.
This is useful when you want to have this data embedded in a program / library, to not deal with paths to the resource folders

Required by:
- https://github.com/status-im/go-zerokit-rln/pull/1 (resources were embedded in https://github.com/status-im/go-zerokit-rln/tree/6762111dcbad7e858018e158d5162cac2b2b4427/rln/resources)