### PR TITLE
feat(rln): ability to set leaves from a given index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
-## 2022-11-02
+## Upcoming release
 
-This breaking change contains:
+Release highlights:
+- Allows consumers of zerokit RLN to set leaves to the Merkle Tree from an arbitrary index. Useful for batching updates to the Merkle Tree.
 
-- Renaming of `set_leaves` to `init_tree_with_leaves`, which is a more accurate representation of the function's utility.
+The full list of changes is below.
+
+### Features
 - Creation of `set_leaves_from`, which allows consumers to add leaves to a tree from a given starting index. `init_tree_with_leaves` internally uses `set_leaves_from`, with index 0.
+
+### Changes
+- Renaming of `set_leaves` to `init_tree_with_leaves`, which is a more accurate representation of the function's utility.
+
+### Fixes
+- None
 
 ## 2022-09-19 v0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## 2022-11-02
+
+This breaking change contains:
+
+- Renaming of `set_leaves` to `init_tree_with_leaves`, which is a more accurate representation of the function's utility.
+- Creation of `set_leaves_from`, which allows consumers to add leaves to a tree from a given starting index. `init_tree_with_leaves` internally uses `set_leaves_from`, with index 0.
+
 ## 2022-09-19 v0.1
 
 Initial beta release.
 
-This release contain:
+This release contains:
 
 - RLN Module with API to manage, compute and verify [RLN](https://rfc.vac.dev/spec/32/) zkSNARK proofs and RLN primitives.
 - This can be consumed either as a Rust API or as a C FFI. The latter means it can be easily consumed through other environments, such as [Go](https://github.com/status-im/go-zerokit-rln/blob/master/rln/librln.h) or [Nim](https://github.com/status-im/nwaku/blob/4745c7872c69b5fd5c6ddab36df9c5c3d55f57c3/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim).

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -486,8 +486,7 @@ mod test {
         let result_data = <&[u8]>::from(&output_buffer).to_vec();
         let (root_batch_with_init, _) = bytes_le_to_fr(&result_data);
 
-        // Previously, resetting the tree was required, now it is a part
-        // of the `init_tree_with_leaves` function
+        // `init_tree_with_leaves` resets the tree to the height it was initialized with, using `set_tree`
 
         // We add leaves in a batch starting from index 0..set_index
         let leaves_m = vec_fr_to_bytes_le(&leaves[0..set_index]);

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -104,7 +104,11 @@ pub extern "C" fn set_next_leaf(ctx: *mut RLN, input_buffer: *const Buffer) -> b
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
-pub extern "C" fn set_leaves_from(ctx: *mut RLN, input_buffer: *const Buffer, index: usize) -> bool {
+pub extern "C" fn set_leaves_from(
+    ctx: *mut RLN,
+    input_buffer: *const Buffer,
+    index: usize,
+) -> bool {
     let rln = unsafe { &mut *ctx };
     let input_data = <&[u8]>::from(unsafe { &*input_buffer });
     rln.set_leaves_from(index, input_data).is_ok()

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -446,6 +446,57 @@ mod test {
     }
 
     #[test]
+    // This test is similar to the one in public.rs but it uses the RLN object as a pointer
+    // Uses `set_leaves_from` to set leaves in a batch, from index `start_index`
+    // `start_index` is a variable that is set to 5
+    fn test_leaf_setting_with_index_ffi() {
+        let tree_height = 4;
+        let start_index = 5;
+        let no_of_leaves = 10;
+
+        // We create a RLN instance
+        let mut rln_pointer = MaybeUninit::<*mut RLN>::uninit();
+        let input_buffer = &Buffer::from(TEST_RESOURCES_FOLDER.as_bytes());
+        let success = new(tree_height, input_buffer, rln_pointer.as_mut_ptr());
+        assert!(success, "RLN object creation failed");
+        let rln_pointer = unsafe { &mut *rln_pointer.assume_init() };
+
+        // We create a vector of leaves
+        let mut leaves = Vec::new();
+        let mut rng = thread_rng();
+        for _ in 0..no_of_leaves {
+            leaves.push(Fr::rand(&mut rng));
+        }
+
+        // We add leaves in a batch into the tree
+        let leaves_ser = vec_fr_to_bytes_le(&leaves);
+        let input_buffer = &Buffer::from(leaves_ser.as_ref());
+        let success = set_leaves_from(rln_pointer, start_index, input_buffer);
+        assert!(success, "set leaves call failed");
+
+        // We get the root of the tree obtained adding leaves in batch
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = get_root(rln_pointer, output_buffer.as_mut_ptr());
+        assert!(success, "get root call failed");
+
+        // We reset the tree to default
+        let success = set_tree(rln_pointer, tree_height);
+        assert!(success, "set tree call failed");
+
+        // We add leaves one by one using the internal index (new leaves goes in next available position)
+        for leaf in &leaves {
+            let leaf_ser = fr_to_bytes_le(&leaf);
+            let input_buffer = &Buffer::from(leaf_ser.as_ref());
+            let success = set_next_leaf(rln_pointer, input_buffer);
+            assert!(success, "set next leaf call failed");
+        }
+
+        // We get the root of the tree obtained adding leaves using the internal index
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = get_root(rln_pointer, output_buffer.as_mut_ptr());
+        assert!(success, "get root call failed");
+    }
+    #[test]
     // This test is similar to the one in lib, but uses only public C API
     fn test_merkle_proof_ffi() {
         let tree_height = TEST_TREE_HEIGHT;

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -104,10 +104,18 @@ pub extern "C" fn set_next_leaf(ctx: *mut RLN, input_buffer: *const Buffer) -> b
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
-pub extern "C" fn set_leaves(ctx: *mut RLN, input_buffer: *const Buffer) -> bool {
+pub extern "C" fn set_leaves_from(ctx: *mut RLN, input_buffer: *const Buffer, index: usize) -> bool {
     let rln = unsafe { &mut *ctx };
     let input_data = <&[u8]>::from(unsafe { &*input_buffer });
-    rln.set_leaves(input_data).is_ok()
+    rln.set_leaves_from(index, input_data).is_ok()
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn init_tree_with_leaves(ctx: *mut RLN, input_buffer: *const Buffer) -> bool {
+    let rln = unsafe { &mut *ctx };
+    let input_data = <&[u8]>::from(unsafe { &*input_buffer });
+    rln.init_tree_with_leaves(input_data).is_ok()
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -387,7 +395,7 @@ mod test {
         // We add leaves in a batch into the tree
         let leaves_ser = vec_fr_to_bytes_le(&leaves);
         let input_buffer = &Buffer::from(leaves_ser.as_ref());
-        let success = set_leaves(rln_pointer, input_buffer);
+        let success = init_tree_with_leaves(rln_pointer, input_buffer);
         assert!(success, "set leaves call failed");
 
         // We get the root of the tree obtained adding leaves in batch
@@ -739,7 +747,7 @@ mod test {
         // We add leaves in a batch into the tree
         let leaves_ser = vec_fr_to_bytes_le(&leaves);
         let input_buffer = &Buffer::from(leaves_ser.as_ref());
-        let success = set_leaves(rln_pointer, input_buffer);
+        let success = init_tree_with_leaves(rln_pointer, input_buffer);
         assert!(success, "set leaves call failed");
 
         // We generate a new identity pair
@@ -824,7 +832,7 @@ mod test {
         // We add leaves in a batch into the tree
         let leaves_ser = vec_fr_to_bytes_le(&leaves);
         let input_buffer = &Buffer::from(leaves_ser.as_ref());
-        let success = set_leaves(rln_pointer, input_buffer);
+        let success = init_tree_with_leaves(rln_pointer, input_buffer);
         assert!(success, "set leaves call failed");
 
         // We generate a new identity pair

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -106,8 +106,8 @@ pub extern "C" fn set_next_leaf(ctx: *mut RLN, input_buffer: *const Buffer) -> b
 #[no_mangle]
 pub extern "C" fn set_leaves_from(
     ctx: *mut RLN,
-    input_buffer: *const Buffer,
     index: usize,
+    input_buffer: *const Buffer,
 ) -> bool {
     let rln = unsafe { &mut *ctx };
     let input_data = <&[u8]>::from(unsafe { &*input_buffer });

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -486,9 +486,8 @@ mod test {
         let result_data = <&[u8]>::from(&output_buffer).to_vec();
         let (root_batch_with_init, _) = bytes_le_to_fr(&result_data);
 
-        // We reset the tree to default
-        let success = set_tree(rln_pointer, tree_height);
-        assert!(success, "set tree call failed");
+        // Previously, resetting the tree was required, now it is a part
+        // of the `init_tree_with_leaves` function
 
         // We add leaves in a batch starting from index 0..set_index
         let leaves_m = vec_fr_to_bytes_le(&leaves[0..set_index]);
@@ -532,9 +531,9 @@ mod test {
 
         let output_buffer = unsafe { output_buffer.assume_init() };
         let result_data = <&[u8]>::from(&output_buffer).to_vec();
-        let (root_manual, _) = bytes_le_to_fr(&result_data);
+        let (root_single_additions, _) = bytes_le_to_fr(&result_data);
 
-        assert_eq!(root_batch_with_init, root_manual);
+        assert_eq!(root_batch_with_init, root_single_additions);
     }
     #[test]
     // This test is similar to the one in lib, but uses only public C API

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -491,13 +491,14 @@ mod test {
         assert!(success, "set tree call failed");
 
         // We add leaves in a batch starting from index 0..set_index
-        let leaves_m = leaves[0..set_index].to_vec();
-        let buffer = &Buffer::from(vec_fr_to_bytes_le(&leaves_m).as_ref());
+        let leaves_m = vec_fr_to_bytes_le(&leaves[0..set_index]);
+        let buffer = &Buffer::from(leaves_m.as_ref());
         let success = init_tree_with_leaves(rln_pointer, buffer);
         assert!(success, "init tree with leaves call failed");
 
-        // We add the remaining n leaves in a batch starting from index m
-        let buffer = &Buffer::from(vec_fr_to_bytes_le(&leaves[set_index..]).as_ref());
+        // We add the remaining n leaves in a batch starting from index set_index
+        let leaves_n = vec_fr_to_bytes_le(&leaves[set_index..]);
+        let buffer = &Buffer::from(leaves_n.as_ref());
         let success = set_leaves_from(rln_pointer, set_index, buffer);
         assert!(success, "set leaves from call failed");
 

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -134,6 +134,8 @@ impl RLN<'_> {
     }
 
     pub fn init_tree_with_leaves<R: Read>(&mut self, input_data: R) -> io::Result<()> {
+        // reset the tree
+        self.set_tree(self.tree.depth())?;
         return self.set_leaves_from(0, input_data);
     }
 
@@ -587,8 +589,8 @@ mod test {
         rln.get_root(&mut buffer).unwrap();
         let (root_batch_with_init, _) = bytes_le_to_fr(&buffer.into_inner());
 
-        // We reset the tree to default
-        rln.set_tree(tree_height).unwrap();
+        // Previously, resetting the tree was required, now it is a part
+        // of the `init_tree_with_leaves` function
 
         // We add leaves in a batch starting from index 0..set_index
         let mut buffer = Cursor::new(vec_fr_to_bytes_le(&leaves[0..set_index]));
@@ -623,9 +625,9 @@ mod test {
         // We get the root of the tree obtained adding leaves using the internal index
         let mut buffer = Cursor::new(Vec::<u8>::new());
         rln.get_root(&mut buffer).unwrap();
-        let (root_manual, _) = bytes_le_to_fr(&buffer.into_inner());
+        let (root_single_additions, _) = bytes_le_to_fr(&buffer.into_inner());
 
-        assert_eq!(root_batch_with_init, root_manual);
+        assert_eq!(root_batch_with_init, root_single_additions);
     }
 
     #[test]

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -135,7 +135,7 @@ impl RLN<'_> {
     }
 
     pub fn init_tree_with_leaves<R: Read>(&mut self, input_data: R) -> io::Result<()> {
-        return self.set_leaves_from(0, input_data)?;
+        return self.set_leaves_from(0, input_data);
     }
 
     // Set input leaf to the next available index

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -135,7 +135,7 @@ impl RLN<'_> {
     }
 
     pub fn init_tree_with_leaves<R: Read>(&mut self, input_data: R) -> io::Result<()> {
-        return self.set_leaves_from(0, input_data);
+        return self.set_leaves_from(0, input_data)?;
     }
 
     // Set input leaf to the next available index

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -8,7 +8,6 @@ use ark_groth16::Proof as ArkProof;
 use ark_groth16::{ProvingKey, VerifyingKey};
 use ark_relations::r1cs::ConstraintMatrices;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, Write};
-use ark_std::Zero;
 use cfg_if::cfg_if;
 use num_bigint::BigInt;
 use std::io::Cursor;
@@ -561,6 +560,7 @@ mod test {
         let tree_height = TEST_TREE_HEIGHT;
         let no_of_leaves = 256;
         let start_index = 5;
+        let default_leaf = Fr::from(0);
 
         // We generate a vector of random leaves
         let mut leaves: Vec<Fr> = Vec::new();
@@ -590,7 +590,7 @@ mod test {
 
         // add `start_index` empty leaves
         for _ in 0..start_index {
-            let mut buffer = Cursor::new(fr_to_bytes_le(&Fr::zero()));
+            let mut buffer = Cursor::new(fr_to_bytes_le(&default_leaf));
             rln.set_next_leaf(&mut buffer).unwrap();
         }
 

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -135,6 +135,8 @@ impl RLN<'_> {
 
     pub fn init_tree_with_leaves<R: Read>(&mut self, input_data: R) -> io::Result<()> {
         // reset the tree
+        // NOTE: this requires the tree to be initialized with the correct height initially
+        // TODO: accept tree_height as a parameter and initialize the tree with that height
         self.set_tree(self.tree.depth())?;
         return self.set_leaves_from(0, input_data);
     }

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -460,8 +460,10 @@ impl Default for RLN<'_> {
 mod test {
     use super::*;
     use crate::poseidon_hash::poseidon_hash;
+    use crate::poseidon_tree::PoseidonHash;
     use ark_std::{rand::thread_rng, UniformRand};
     use rand::Rng;
+    use utils::Hasher;
 
     #[test]
     // We test merkle batch Merkle tree additions
@@ -560,7 +562,7 @@ mod test {
         let tree_height = TEST_TREE_HEIGHT;
         let no_of_leaves = 256;
         let start_index = 5;
-        let default_leaf = Fr::from(0);
+        let default_leaf = PoseidonHash::default_leaf();
 
         // We generate a vector of random leaves
         let mut leaves: Vec<Fr> = Vec::new();
@@ -588,10 +590,10 @@ mod test {
         // We reset the tree to default
         rln.set_tree(tree_height).unwrap();
 
+        let zero_buffer = Cursor::new(fr_to_bytes_le(&default_leaf));
         // add `start_index` empty leaves
         for _ in 0..start_index {
-            let mut buffer = Cursor::new(fr_to_bytes_le(&default_leaf));
-            rln.set_next_leaf(&mut buffer).unwrap();
+            rln.set_next_leaf(&mut zero_buffer.clone()).unwrap();
         }
 
         // We add leaves one by one using the internal index (new leaves goes in next available position)

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -591,8 +591,7 @@ mod test {
         rln.get_root(&mut buffer).unwrap();
         let (root_batch_with_init, _) = bytes_le_to_fr(&buffer.into_inner());
 
-        // Previously, resetting the tree was required, now it is a part
-        // of the `init_tree_with_leaves` function
+        // `init_tree_with_leaves` resets the tree to the height it was initialized with, using `set_tree`
 
         // We add leaves in a batch starting from index 0..set_index
         let mut buffer = Cursor::new(vec_fr_to_bytes_le(&leaves[0..set_index]));


### PR DESCRIPTION
This PR allows the following feature - https://github.com/status-im/nwaku/issues/1266.

Changes the C FFI of `set_leaves` to `init_tree_with_leaves`, and adds a new function called `set_leaves_from`, which `init_tree_with_leaves` uses internally, with starting index 0.
