### PR TITLE
feat(rln): reset the index, and process the set_leaves atomically

### DIFF
--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -592,7 +592,8 @@ mod test {
         let result_data = <&[u8]>::from(&output_buffer).to_vec();
         let (root_after_bad_leaf_insertion, _) = bytes_le_to_fr(&result_data);
 
-        // We check if the root of the tree obtained adding leaves in batch is consistent with the empty tree root
+        // We check if the root of the tree obtained adding leaves in batch is consistent
+        // with the root of the tree obtained adding good leaves in batch
         assert_eq!(root_good_leaves, root_after_bad_leaf_insertion);
     }
 

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -686,7 +686,8 @@ mod test {
         rln.get_root(&mut buffer).unwrap();
         let (root_after_bad_leaf_insertion, _) = bytes_le_to_fr(&buffer.into_inner());
 
-        // We check if the root of the tree obtained adding leaves in batch is consistent with the empty tree root
+        // We check if the root of the tree obtained adding leaves in batch is consistent
+        // with the root of the tree obtained adding good leaves in batch
         assert_eq!(root_good_leaves, root_after_bad_leaf_insertion);
         // We check if numbers of leaves set is consistent
         assert_eq!(rln.tree.leaves_set(), good_leaf_index);

--- a/utils/src/merkle_tree/merkle_tree.rs
+++ b/utils/src/merkle_tree/merkle_tree.rs
@@ -142,6 +142,20 @@ impl<H: Hasher> OptimalMerkleTree<H> {
         Ok(())
     }
 
+    // Sets the next index
+    // WARNING: This function should be used only to reset the next index to a lower value
+    // (e.g. when deleting leaves)
+    pub fn set_next_index(&mut self, next_index: usize) -> io::Result<()> {
+        if self.next_index < next_index {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "next_index cannot be set to a higher value",
+            ));
+        }
+        self.next_index = next_index;
+        Ok(())
+    }
+
     // Computes a merkle proof the the leaf at the specified index
     pub fn proof(&self, index: usize) -> io::Result<OptimalMerkleProof<H>> {
         if index >= self.capacity() {
@@ -188,7 +202,7 @@ impl<H: Hasher> OptimalMerkleTree<H> {
         node
     }
 
-    fn get_leaf(&self, index: usize) -> H::Fr {
+    pub fn get_leaf(&self, index: usize) -> H::Fr {
         self.get_node(self.depth, index)
     }
 

--- a/utils/src/merkle_tree/merkle_tree.rs
+++ b/utils/src/merkle_tree/merkle_tree.rs
@@ -137,8 +137,10 @@ impl<H: Hasher> OptimalMerkleTree<H> {
     pub fn delete(&mut self, index: usize) -> io::Result<()> {
         // We reset the leaf only if we previously set a leaf at that index
         if index < self.next_index {
-            self.set(index, H::default_leaf())?;
+            // free up the space
+            self.nodes.remove(&(self.depth, index));
         }
+        self.recalculate_from(index);
         Ok(())
     }
 


### PR DESCRIPTION
This PR ensures that the tree is reset to previous state if any insertions during `set_leaves_from` fail. 
