### PR TITLE
fix(ci): exclude rln-wasm since it has its own step now

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Declare short sha
-        id: vars
-        shell: bash
-        run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -29,13 +24,13 @@ jobs:
           cargo build --release --workspace --exclude rln-wasm
           mkdir release
           cp target/release/librln* release/
-          tar -czvf linux-rln-${{steps.vars.outputs.sha_short}}.tar.gz release/
+          tar -czvf linux-rln.tar.gz release/
 
       - name: Upload archive artifact
         uses: actions/upload-artifact@v2
         with:
           name: linux-archive
-          path: linux-rln-${{steps.vars.outputs.sha_short}}.tar.gz
+          path: linux-rln.tar.gz
           retention-days: 2
 
   macos:
@@ -46,11 +41,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: master
-      - name: Declare short sha
-        id: vars
-        shell: bash
-        run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -64,13 +54,13 @@ jobs:
           cargo build --release --workspace --exclude rln-wasm
           mkdir release
           cp target/release/librln* release/
-          tar -czvf macos-rln-${{steps.vars.outputs.sha_short}}.tar.gz release/
+          tar -czvf macos-rln.tar.gz release/
 
       - name: Upload archive artifact
         uses: actions/upload-artifact@v2
         with:
           name: macos-archive
-          path: macos-rln-${{steps.vars.outputs.sha_short}}.tar.gz
+          path: macos-rln.tar.gz
           retention-days: 2
   
   browser-rln-wasm:
@@ -87,11 +77,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Declare short sha
-        id: vars
-        shell: bash
-        run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - run: git submodule update --init --recursive
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.3.0
@@ -102,14 +87,14 @@ jobs:
           cargo make build
           mkdir release
           cp pkg/** release/
-          tar -czvf browser-rln-wasm-${{steps.vars.outputs.sha_short}}.tar.gz release/
+          tar -czvf browser-rln-wasm.tar.gz release/
         working-directory: rln-wasm
 
       - name: Upload archive artifact
         uses: actions/upload-artifact@v2
         with:
           name: browser-rln-wasm-archive
-          path: rln-wasm/browser-rln-wasm-${{steps.vars.outputs.sha_short}}.tar.gz
+          path: rln-wasm/browser-rln-wasm.tar.gz
           retention-days: 2
 
 
@@ -137,9 +122,9 @@ jobs:
         run: |
           gh release create nightly --prerelease --target master \
             --title 'Nightly build ("master" branch)' --generate-notes \
-            linux-archive/linux-rln-*.tar.gz \
-            macos-archive/macos-rln-*.tar.gz \
-            browser-rln-wasm-archive/browser-rln-wasm-*.tar.gz
+            linux-archive/linux-rln.tar.gz \
+            macos-archive/macos-rln.tar.gz \
+            browser-rln-wasm-archive/browser-rln-wasm.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -120,8 +120,11 @@ jobs:
 
       - name: Create prerelease
         run: |
+          start_tag=$(gh release list -L 2 --exclude-drafts | grep -v nightly | cut -d$'\t' -f3)
           gh release create nightly --prerelease --target master \
-            --title 'Nightly build ("master" branch)' --generate-notes \
+            --title 'Nightly build ("master" branch)' \
+            --generate-notes \
+            --notes-start-tag $start_tag \
             linux-archive/linux-rln.tar.gz \
             macos-archive/macos-rln.tar.gz \
             browser-rln-wasm-archive/browser-rln-wasm.tar.gz

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,7 +26,7 @@ jobs:
         run: git submodule update --init --recursive
       - name: cargo build
         run: |
-          cargo build --release --workspace
+          cargo build --release --workspace --exclude rln-wasm
           mkdir release
           cp target/release/librln* release/
           tar -czvf linux-rln-${{steps.vars.outputs.sha_short}}.tar.gz release/
@@ -61,7 +61,7 @@ jobs:
         run: git submodule update --init --recursive
       - name: cargo build
         run: |
-          cargo build --release --workspace
+          cargo build --release --workspace --exclude rln-wasm
           mkdir release
           cp target/release/librln* release/
           tar -czvf macos-rln-${{steps.vars.outputs.sha_short}}.tar.gz release/

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -150,10 +150,10 @@ jobs:
       - name: Create prerelease
         run: |
           gh release create nightly --prerelease --target master \
-            --title 'Nightly build ("master" branch)' --notes-file release_notes.md \
-            linux-archive/* \
-            macos-archive/* \
-            browser-rln-wasm-archive/*
+            --title 'Nightly build ("master" branch)' --notes-file release-notes.md \
+            linux-archive/linux-rln-*.tar.gz \
+            macos-archive/macos-rln-*.tar.gz \
+            browser-rln-wasm-archive/browser-rln-wasm-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -129,6 +129,7 @@ jobs:
           echo "## Release notes" > release-notes.md
           echo "### Linux" >> release-notes.md
           tar -xvf linux-archive/linux-rln-*.tar.gz
+          tree 
           ls -l linux-archive/linux-rln-*/ >> release-notes.md
           echo "### MacOS" >> release-notes.md
           tar -xvf macos-archive/macos-rln-*.tar.gz

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -129,13 +129,13 @@ jobs:
           echo "## Release notes" > release-notes.md
           echo "### Linux" >> release-notes.md
           tar -xvf linux-archive/linux-rln-*.tar.gz
-          ls -l linux-archive/release >> release-notes.md
+          ls -l linux-archive/linux-rln-*/ >> release-notes.md
           echo "### MacOS" >> release-notes.md
           tar -xvf macos-archive/macos-rln-*.tar.gz
-          ls -l macos-archive/release >> release-notes.md
+          ls -l macos-archive/macos-rln-*/ >> release-notes.md
           echo "### Browser (RLN WASM)" >> release-notes.md
           tar -xvf browser-rln-wasm-archive/browser-rln-wasm-*.tar.gz
-          ls -l browser-rln-wasm-archive/release >> release-notes.md
+          ls -l browser-rln-wasm-archive/browser-rln-wasm-*/ >> release-notes.md
           
       - name: Delete tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.0

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,11 +16,11 @@ jobs:
         shell: bash
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - name: Update git submodules
         run: git submodule update --init --recursive
@@ -51,11 +51,11 @@ jobs:
         shell: bash
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - name: Update git submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -124,20 +124,6 @@ jobs:
           ref: master
       - name: Download artifacts
         uses: actions/download-artifact@v2
-      - name: Create release notes
-        run: |
-          echo "## Release notes" > release-notes.md
-          echo "### Linux" >> release-notes.md
-          tar -xvf linux-archive/linux-rln-*.tar.gz
-          mkdir linux-release && mv release/* linux/ && rm -rf release
-          tar -xvf macos-archive/macos-rln-*.tar.gz
-          mkdir macos-release && mv release/* macos/ && rm -rf release
-          tar -xvf browser-rln-wasm-archive/browser-rln-wasm-*.tar.gz
-          mkdir browser-rln-wasm-release && mv release/* browser-rln-wasm/ && rm -rf release
-          mkdir release && mv linux-release/* release/ && mv macos-release/* release/ && mv browser-rln-wasm-release/* release/
-          echo "```" >> release-notes.md
-          tree release >> release-notes.md
-          echo "```" >> release-notes.md
           
       - name: Delete tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
@@ -150,7 +136,7 @@ jobs:
       - name: Create prerelease
         run: |
           gh release create nightly --prerelease --target master \
-            --title 'Nightly build ("master" branch)' --notes-file release-notes.md \
+            --title 'Nightly build ("master" branch)' --generate-notes \
             linux-archive/linux-rln-*.tar.gz \
             macos-archive/macos-rln-*.tar.gz \
             browser-rln-wasm-archive/browser-rln-wasm-*.tar.gz

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -129,14 +129,15 @@ jobs:
           echo "## Release notes" > release-notes.md
           echo "### Linux" >> release-notes.md
           tar -xvf linux-archive/linux-rln-*.tar.gz
-          tree 
-          ls -l linux-archive/linux-rln-*/ >> release-notes.md
-          echo "### MacOS" >> release-notes.md
+          mkdir linux-release && mv release/* linux/ && rm -rf release
           tar -xvf macos-archive/macos-rln-*.tar.gz
-          ls -l macos-archive/macos-rln-*/ >> release-notes.md
-          echo "### Browser (RLN WASM)" >> release-notes.md
+          mkdir macos-release && mv release/* macos/ && rm -rf release
           tar -xvf browser-rln-wasm-archive/browser-rln-wasm-*.tar.gz
-          ls -l browser-rln-wasm-archive/browser-rln-wasm-*/ >> release-notes.md
+          mkdir browser-rln-wasm-release && mv release/* browser-rln-wasm/ && rm -rf release
+          mkdir release && mv linux-release/* release/ && mv macos-release/* release/ && mv browser-rln-wasm-release/* release/
+          echo "```" >> release-notes.md
+          tree release >> release-notes.md
+          echo "```" >> release-notes.md
           
       - name: Delete tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.0

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: browser-rln-wasm-archive
-          path: browser-rln-wasm-${{steps.vars.outputs.sha_short}}.tar.gz
+          path: rln-wasm/browser-rln-wasm-${{steps.vars.outputs.sha_short}}.tar.gz
           retention-days: 2
 
 
@@ -128,14 +128,14 @@ jobs:
         run: |
           echo "## Release notes" > release-notes.md
           echo "### Linux" >> release-notes.md
-          tar -xvf linux-rln-*.tar.gz
-          ls -l release >> release-notes.md
+          tar -xvf linux-archive/linux-rln-*.tar.gz
+          ls -l linux-archive/release >> release-notes.md
           echo "### MacOS" >> release-notes.md
-          tar -xvf macos-rln-*.tar.gz
-          ls -l release >> release-notes.md
+          tar -xvf macos-archive/macos-rln-*.tar.gz
+          ls -l macos-archive/release >> release-notes.md
           echo "### Browser (RLN WASM)" >> release-notes.md
-          tar -xvf browser-rln-wasm-*.tar.gz
-          ls -l release >> release-notes.md
+          tar -xvf browser-rln-wasm-archive/browser-rln-wasm-*.tar.gz
+          ls -l browser-rln-wasm-archive/release >> release-notes.md
           
       - name: Delete tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.0


### PR DESCRIPTION
Exclude rln-wasm compilation in linux and macos steps
