### PR TITLE
feat(rln): add few serialization APIs to ease user interaction

### DIFF
--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -27,7 +27,7 @@ use crate::utils::*;
 use cfg_if::cfg_if;
 
 ///////////////////////////////////////////////////////
-// RLN Witness data structure and utility functions 
+// RLN Witness data structure and utility functions
 ///////////////////////////////////////////////////////
 
 #[derive(Debug, PartialEq)]
@@ -52,7 +52,6 @@ pub struct RLNProofValues {
     pub rln_identifier: Fr,
 }
 
-
 pub fn serialize_field_element(element: Fr) -> Vec<u8> {
     return fr_to_bytes_le(&element);
 }
@@ -62,7 +61,6 @@ pub fn deserialize_field_element(serialized: Vec<u8>) -> Fr {
 
     return element;
 }
-
 
 pub fn deserialize_identity_pair(serialized: Vec<u8>) -> (Fr, Fr) {
     let (identity_secret, read) = bytes_le_to_fr(&serialized);
@@ -165,7 +163,6 @@ pub fn proof_inputs_to_rln_witness(
         all_read,
     )
 }
-
 
 pub fn rln_witness_from_json(input_json_str: &str) -> RLNWitnessInput {
     let input_json: serde_json::Value =


### PR DESCRIPTION
This PR partially addresses https://github.com/vacp2p/zerokit/issues/69, by adding new APIs to ease user interaction while using `public` APIs. 

The main goal is to reduce the cognitive overhead required to interface with public APIs, by providing helper function which automate non-RLN specific tasks (mainly I/O serialization/deserialization).

Merging this PR is a requirement for merging the documentation PR https://github.com/vacp2p/zerokit/pull/74, which was already updated to refer to such new APIs.