### PR TITLE
fix(rln-wasm): make cargo make build work on macOS and linux

### DIFF
--- a/rln-wasm/Makefile.toml
+++ b/rln-wasm/Makefile.toml
@@ -6,7 +6,7 @@ command = "wasm-pack"
 args = ["build", "--release", "--target", "web", "--scope", "waku"]
 
 [tasks.pack-rename]
-script = "sed -i 's/rln-wasm/zerokit-rln-wasm/g' pkg/package.json"
+script = "sed -i.bak 's/rln-wasm/zerokit-rln-wasm/g' pkg/package.json && rm pkg/package.json.bak"
 
 [tasks.build]
 clear = true


### PR DESCRIPTION
This PR corrects a sed command used in compilation of rln-wasm which would not work on macOS. 

Built tested on macOS.