### PR TITLE
fix(semaphore): temporarily use fixed semaphore-rs fork

### DIFF
--- a/semaphore/Cargo.toml
+++ b/semaphore/Cargo.toml
@@ -19,11 +19,12 @@ ark-std = { version = "0.3.0", default-features = false, features = ["parallel"]
 color-eyre = "0.5"
 num-bigint = { version = "0.4", default-features = false, features = ["rand"] }
 once_cell = "1.8"
-primitive-types = "0.11.1"
 rand = "0.8.4"
 # TODO: change back to original repo once https://github.com/worldcoin/semaphore-rs/pull/24 is merged
 #semaphore = { git = "https://github.com/worldcoin/semaphore-rs", rev = "d462a43"}
 semaphore = { git = "https://github.com/vacp2p/semaphore-rs", branch="fix-u256-data-type"}
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ruint = { version = "1.2.0", features = [ "serde", "num-bigint", "ark-ff" ] }
 serde = "1.0"
 thiserror = "1.0.0"
 wasmer = { version = "2.0" }


### PR DESCRIPTION
The semaphore crate wraps APIs exposed by its semaphore-rs dependency.

Recent updates to `ethers-core` broke compilation of `semaphore-rs`. Compilation results broken due to no revision hardcoded for `ark-circom`'s `ethers-core` dependency (which, in turn, is a dependency of `semaphore-rs` too), hence latest master will be used at each new compilation of `semaphore-rs`.

The reasons of the compilation failure seems to be related with a refactoring of the U256 data type, which before was in `primitive_types::U256` and now is moved to (the updated) `ethers_core::types::U256`. 

This PR prevents failure of zerokit semaphore compilation by replacing semaphore-rs dependency with a fixed fork hosted in vacp2p.
This is a **temporary** fix that will remain in place until the `semaphore-rs` PR https://github.com/worldcoin/semaphore-rs/pull/24 is merged. After that, the original `semaphore-rs` dependency will be restored and the fork deleted.

Furthermore, this PR updates some logic in the zerokit `semaphore` create in order to work with the latest version of master of the `semaphore-rs` (otherwise it would be impossible to integrate eventual fixes to semaphore-rs if zerokit implementation only works with older commits).