### PR TITLE
change: Replace profile overwrites to Workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,16 @@ members = [
   "rln-wasm",
   "utils",
 ]
+
+# Compilation profile for any non-workspace member.
+# Dependencies are optimized, even in a dev build. This improves dev performance
+# while having neglible impact on incremental build times.
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.release.package."rln-wasm"]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"
+
+[profile.release.package."semaphore"]
+codegen-units = 1

--- a/rln-wasm/Cargo.toml
+++ b/rln-wasm/Cargo.toml
@@ -31,6 +31,3 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen-test = "0.3.13"
 wasm-bindgen-futures = "0.4.33"
 
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"

--- a/semaphore/Cargo.toml
+++ b/semaphore/Cargo.toml
@@ -36,15 +36,3 @@ color-eyre = "0.5"
 wasmer = { version = "2.0" }
 wasmer-engine-dylib = { version = "2.2.1", optional = true }
 wasmer-compiler-cranelift = { version = "2.2.1", optional = true }
-
-[profile.release]
-codegen-units = 1
-lto = true
-panic = "abort"
-opt-level = 3
-
-# Compilation profile for any non-workspace member.
-# Dependencies are optimized, even in a dev build. This improves dev performance
-# while having neglible impact on incremental build times.
-[profile.dev.package."*"]
-opt-level = 3


### PR DESCRIPTION
Since profile info specified inside workspace members `Cargo.toml`'s is ignored by Cargo, this replaces the place to specify these details for the workspace-level `Cargo.toml`.

NOTE that `panic` and `rpath` aren't supported with the Overwritting feature. Therefore, the only required thing (if considered necessary) is to create a new profile which also enables these things.

Resolves: #93