### PR TITLE
fix(semaphore): revert ark-circom dependency

### DIFF
--- a/semaphore/Cargo.toml
+++ b/semaphore/Cargo.toml
@@ -11,7 +11,8 @@ dylib = [ "wasmer/dylib", "wasmer-engine-dylib", "wasmer-compiler-cranelift" ]
 
 [dependencies]
 ark-bn254 = { version = "0.3.0" }
-ark-circom = { git = "https://github.com/gakonst/ark-circom", features=["circom-2"] }
+# TODO: use latest head after feature flag is appropriately used in ark-circom
+ark-circom = { git = "https://github.com/gakonst/ark-circom", rev="e226f90", features=["circom-2"] }
 ark-ec = { version = "0.3.0", default-features = false, features = ["parallel"] }
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", rev = "765817f", features = ["parallel"] }
 ark-relations = { version = "0.3.0", default-features = false }


### PR DESCRIPTION
ark-circom with rev [746d232](https://github.com/gakonst/ark-circom/commit/746d2329e94e493560a53c41938c329d735d54ed) breaks CI for us, preventing nightly releases. This PR bumps the version of ark-circom we use back to before the commit which causes 
this issue - [e226f90](https://github.com/gakonst/ark-circom/commit/e226f90591e16429f3001edf5dfb72801fc8b6f9)

! This is a temporary fix and will need revisiting after it's fixed upstream !
