### PR TITLE
fix(ci): nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Create prerelease
         run: |
-          start_tag=$(gh release list -L 2 --exclude-drafts | grep -v nightly | cut -d$'\t' -f3)
+          start_tag=$(gh release list -L 2 --exclude-drafts | grep -v nightly | cut -d$'\t' -f3 | sed -n '1p')
           gh release create nightly --prerelease --target master \
             --title 'Nightly build ("master" branch)' \
             --generate-notes \


### PR DESCRIPTION
Nightly release CI is failing - https://github.com/vacp2p/zerokit/actions/runs/4299225323
