### PR TITLE
feat(ci): cross-compile release assets, cache deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Update git submodules
-        run: git submodule update --init --recursive
-      - name: Install cargo-make
-        run: cargo install cargo-make
+      - uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        run: make installdeps
       - name: cargo-make test
         run: |
             cargo make test --release
@@ -72,10 +71,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Update git submodules
-        run: git submodule update --init --recursive
-      - name: Install cargo-make
-        run: cargo install cargo-make
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Dependencies
+        run: make installdeps
       - name: cargo-make test
         run: |
             cargo make test --release
@@ -97,10 +95,11 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: git submodule update --init --recursive
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Dependencies
+        run: make installdeps
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.3.0
-      - run: cargo install cargo-make
       - run: cargo make build
         working-directory: rln-wasm
       - run: cargo-make test
@@ -123,10 +122,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Update git submodules
-        run: git submodule update --init --recursive
-      - name: Install cargo-make
-        run: cargo install cargo-make
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Dependencies
+        run: make installdeps
       - name: cargo-make test
         run: |
             cargo make test --release
@@ -149,10 +147,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Update git submodules
-        run: git submodule update --init --recursive
-      - name: Install cargo-make
-        run: cargo install cargo-make
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Dependencies
+        run: make installdeps
       - name: cargo-make test
         run: |
             cargo make test --release
@@ -177,8 +174,9 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-      - name: Update git submodules
-        run: git submodule update --init --recursive
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Dependencies
+        run: make installdeps
       - name: cargo fmt
         if: success() || failure()
         run: cargo fmt --all -- --check

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -10,9 +10,8 @@ jobs:
       matrix:
         target: 
           - x86_64-unknown-linux-gnu
-          # TODO: enable after https://github.com/rust-lang/cargo/issues/4133 is resolved
-          # - aarch64-unknown-linux-gnu
-          # - i686-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - i686-unknown-linux-gnu
     name: Linux build
     runs-on: ubuntu-latest
     steps:
@@ -25,11 +24,12 @@ jobs:
           toolchain: stable
           override: true
           target: ${{ matrix.target }}
-      - name: Update git submodules
-        run: git submodule update --init --recursive
-      - name: cargo build
+      - uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        run: make installdeps
+      - name: cross build
         run: |
-          cargo build --release --target ${{ matrix.target }} --workspace --exclude rln-wasm
+          cross build --release --target ${{ matrix.target }} --workspace --exclude rln-wasm
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-rln.tar.gz release/
@@ -48,13 +48,10 @@ jobs:
       matrix:
         target: 
           - x86_64-apple-darwin
-          # TODO: enable after https://github.com/rust-lang/cargo/issues/4133 is resolved
-          # - aarch64-apple-darwin
+          - aarch64-apple-darwin
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-        with:
-          ref: master
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -62,11 +59,12 @@ jobs:
           toolchain: stable
           override: true
           target: ${{ matrix.target }}
-      - name: Update git submodules
-        run: git submodule update --init --recursive
-      - name: cargo build
+      - uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        run: make installdeps
+      - name: cross build
         run: |
-          cargo build --release --target ${{ matrix.target }} --workspace --exclude rln-wasm
+          cross build --release --target ${{ matrix.target }} --workspace --exclude rln-wasm
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-rln.tar.gz release/
@@ -84,22 +82,20 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-        with:
-          ref: master
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - run: git submodule update --init --recursive
+      - uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        run: make installdeps
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.3.0
-      - name: Install cargo-make
-        run: cargo install cargo-make
-      - name: cargo make build
+      - name: cross make build
         run: |
-          cargo make build
+          cross make build
           mkdir release
           cp pkg/** release/
           tar -czvf browser-rln-wasm.tar.gz release/

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,32 @@
+[target.x86_64-pc-windows-gnu]
+image = "ghcr.io/cross-rs/x86_64-pc-windows-gnu:latest"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest"
+
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:latest"
+
+[target.arm-unknown-linux-gnueabi]
+image = "ghcr.io/cross-rs/arm-unknown-linux-gnueabi:latest"
+
+[target.i686-pc-windows-gnu]
+image = "ghcr.io/cross-rs/i686-pc-windows-gnu:latest"
+
+[target.i686-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/i686-unknown-linux-gnu:latest"
+
+[target.arm-unknown-linux-gnueabihf]
+image = "ghcr.io/cross-rs/arm-unknown-linux-gnueabihf:latest"
+
+[target.mips-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/mips-unknown-linux-gnu:latest"
+
+[target.mips64-unknown-linux-gnuabi64]
+image = "ghcr.io/cross-rs/mips64-unknown-linux-gnuabi64:latest"
+
+[target.mips64el-unknown-linux-gnuabi64]
+image = "ghcr.io/cross-rs/mips64el-unknown-linux-gnuabi64:latest"
+
+[target.mipsel-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/mipsel-unknown-linux-gnu:latest"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ all: .pre-build build
 
 .pre-build: .fetch-submodules
 	@cargo install cargo-make
+ifdef CI
 	@cargo install cross --git https://github.com/cross-rs/cross --branch main
+endif
 
 installdeps: .pre-build
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ all: .pre-build build
 	@git submodule update --init --recursive
 
 .pre-build: .fetch-submodules
-ifeq (, $(shell which cargo-make))
-	@cargo install --force cargo-make
-endif
+	@cargo install cargo-make
+	@cargo install cross --git https://github.com/cross-rs/cross --branch main
 
 installdeps: .pre-build
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ To build and test all crates, run the following commands from the root folder
 make build
 make test
 ```
+
+## Release assets
+
+We use [`cross-rs`](https://github.com/cross-rs/cross) to cross-compile and generate release assets for rln. 


### PR DESCRIPTION
Updates CI to include -
- Caching for dependencies
- Use `make installdeps` instead of manually installing submodules
- Use `cross-rs` to cross-compile for different targets