### PR TITLE
fix(rln): move std::path to cfg_if block

### DIFF
--- a/rln/src/circuit.rs
+++ b/rln/src/circuit.rs
@@ -12,7 +12,6 @@ use color_eyre::{Report, Result};
 use num_bigint::BigUint;
 use serde_json::Value;
 use std::io::Cursor;
-use std::path::Path;
 use std::str::FromStr;
 
 cfg_if! {
@@ -22,6 +21,7 @@ cfg_if! {
         use std::sync::Mutex;
         use wasmer::{Module, Store};
         use include_dir::{include_dir, Dir};
+        use std::path::Path;
     }
 }
 


### PR DESCRIPTION
std::path::Path is unused in the wasm context, therefore, moved the import to the cfg_if block