### PR TITLE
fix(ci): force draft=false for nightly releases

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -135,6 +135,7 @@ jobs:
           gh release create nightly --prerelease --target master \
             --title 'Nightly build ("master" branch)' \
             --generate-notes \
+            --draft=false \
             --notes-start-tag $start_tag \
             *-archive/*.tar.gz \
         env:


### PR DESCRIPTION
Unsure why github converted prereleases to drafts in the default behaviour of 
release creation using the gh cli, this pr fixes that.
