### PR TITLE
fix: u64 to usize conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "rln-wasm"
-version = "0.0.7"
+version = "0.0.9"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/rln-wasm/Cargo.toml
+++ b/rln-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rln-wasm"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 license = "MIT or Apache2"
 

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -155,13 +155,17 @@ pub fn proof_inputs_to_rln_witness(
     let (identity_secret, read) = bytes_le_to_fr(&serialized[all_read..]);
     all_read += read;
 
-    let id_index = usize::from_le_bytes(serialized[all_read..all_read + 8].try_into()?);
+    let id_index = usize::try_from(u64::from_le_bytes(
+        serialized[all_read..all_read + 8].try_into()?,
+    ))?;
     all_read += 8;
 
     let (epoch, read) = bytes_le_to_fr(&serialized[all_read..]);
     all_read += read;
 
-    let signal_len = usize::from_le_bytes(serialized[all_read..all_read + 8].try_into()?);
+    let signal_len = usize::try_from(u64::from_le_bytes(
+        serialized[all_read..all_read + 8].try_into()?,
+    ))?;
     all_read += 8;
 
     let signal: Vec<u8> = serialized[all_read..all_read + signal_len].to_vec();

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -607,7 +607,9 @@ impl RLN<'_> {
         let (proof_values, read) = deserialize_proof_values(&serialized[all_read..]);
         all_read += read;
 
-        let signal_len = usize::from_le_bytes(serialized[all_read..all_read + 8].try_into()?);
+        let signal_len = usize::try_from(u64::from_le_bytes(
+            serialized[all_read..all_read + 8].try_into()?,
+        ))?;
         all_read += 8;
 
         let signal: Vec<u8> = serialized[all_read..all_read + signal_len].to_vec();
@@ -683,7 +685,9 @@ impl RLN<'_> {
         let (proof_values, read) = deserialize_proof_values(&serialized[all_read..]);
         all_read += read;
 
-        let signal_len = usize::from_le_bytes(serialized[all_read..all_read + 8].try_into()?);
+        let signal_len = usize::try_from(u64::from_le_bytes(
+            serialized[all_read..all_read + 8].try_into()?,
+        ))?;
         all_read += 8;
 
         let signal: Vec<u8> = serialized[all_read..all_read + signal_len].to_vec();

--- a/rln/src/utils.rs
+++ b/rln/src/utils.rs
@@ -117,7 +117,7 @@ pub fn vec_u8_to_bytes_be(input: Vec<u8>) -> Result<Vec<u8>> {
 pub fn bytes_le_to_vec_u8(input: &[u8]) -> Result<(Vec<u8>, usize)> {
     let mut read: usize = 0;
 
-    let len = usize::from_le_bytes(input[0..8].try_into()?);
+    let len = usize::try_from(u64::from_le_bytes(input[0..8].try_into()?))?;
     read += 8;
 
     let res = input[8..8 + len].to_vec();
@@ -129,7 +129,7 @@ pub fn bytes_le_to_vec_u8(input: &[u8]) -> Result<(Vec<u8>, usize)> {
 pub fn bytes_be_to_vec_u8(input: &[u8]) -> Result<(Vec<u8>, usize)> {
     let mut read: usize = 0;
 
-    let len = usize::from_be_bytes(input[0..8].try_into()?);
+    let len = usize::try_from(u64::from_be_bytes(input[0..8].try_into()?))?;
     read += 8;
 
     let res = input[8..8 + len].to_vec();
@@ -143,7 +143,7 @@ pub fn bytes_le_to_vec_fr(input: &[u8]) -> Result<(Vec<Fr>, usize)> {
     let mut read: usize = 0;
     let mut res: Vec<Fr> = Vec::new();
 
-    let len = usize::from_le_bytes(input[0..8].try_into()?);
+    let len = usize::try_from(u64::from_le_bytes(input[0..8].try_into()?))?;
     read += 8;
 
     let el_size = fr_byte_size();
@@ -160,7 +160,7 @@ pub fn bytes_be_to_vec_fr(input: &[u8]) -> Result<(Vec<Fr>, usize)> {
     let mut read: usize = 0;
     let mut res: Vec<Fr> = Vec::new();
 
-    let len = usize::from_be_bytes(input[0..8].try_into()?);
+    let len = usize::try_from(u64::from_le_bytes(input[0..8].try_into()?))?;
     read += 8;
 
     let el_size = fr_byte_size();


### PR DESCRIPTION
`usize::from_le_bytes` will take an array of length 2, 4 or 8 bytes depending on the target pointer size. Since wasm is a 32b platform, it will take 4 bytes instead of the 8 bytes defined by the protocol, so there was a failure while reading serialized values due to the number of bytes read being incorrect. I also update version rln-wasm to 0.0.9 (npm package needs to be updated to include this fix)