### PR TITLE
fix: `len().to_le_bytes().to_vec()` contains 4 bytes on 32b and should contain 8

### DIFF
--- a/rln/src/utils.rs
+++ b/rln/src/utils.rs
@@ -75,7 +75,7 @@ pub fn fr_to_bytes_be(input: &Fr) -> Vec<u8> {
 pub fn vec_fr_to_bytes_le(input: &[Fr]) -> Result<Vec<u8>> {
     let mut bytes: Vec<u8> = Vec::new();
     //We store the vector length
-    bytes.extend(input.len().to_le_bytes().to_vec());
+    bytes.extend(u64::try_from(input.len())?.to_le_bytes().to_vec());
 
     // We store each element
     input.iter().for_each(|el| bytes.extend(fr_to_bytes_le(el)));
@@ -86,7 +86,7 @@ pub fn vec_fr_to_bytes_le(input: &[Fr]) -> Result<Vec<u8>> {
 pub fn vec_fr_to_bytes_be(input: &[Fr]) -> Result<Vec<u8>> {
     let mut bytes: Vec<u8> = Vec::new();
     //We store the vector length
-    bytes.extend(input.len().to_be_bytes().to_vec());
+    bytes.extend(u64::try_from(input.len())?.to_be_bytes().to_vec());
 
     // We store each element
     input.iter().for_each(|el| bytes.extend(fr_to_bytes_be(el)));
@@ -97,7 +97,7 @@ pub fn vec_fr_to_bytes_be(input: &[Fr]) -> Result<Vec<u8>> {
 pub fn vec_u8_to_bytes_le(input: &[u8]) -> Result<Vec<u8>> {
     let mut bytes: Vec<u8> = Vec::new();
     //We store the vector length
-    bytes.extend(input.len().to_le_bytes().to_vec());
+    bytes.extend(u64::try_from(input.len())?.to_le_bytes().to_vec());
 
     bytes.extend(input);
 
@@ -107,7 +107,7 @@ pub fn vec_u8_to_bytes_le(input: &[u8]) -> Result<Vec<u8>> {
 pub fn vec_u8_to_bytes_be(input: Vec<u8>) -> Result<Vec<u8>> {
     let mut bytes: Vec<u8> = Vec::new();
     //We store the vector length
-    bytes.extend(input.len().to_be_bytes().to_vec());
+    bytes.extend(u64::try_from(input.len())?.to_be_bytes().to_vec());
 
     bytes.extend(input);
 
@@ -160,7 +160,7 @@ pub fn bytes_be_to_vec_fr(input: &[u8]) -> Result<(Vec<Fr>, usize)> {
     let mut read: usize = 0;
     let mut res: Vec<Fr> = Vec::new();
 
-    let len = usize::try_from(u64::from_le_bytes(input[0..8].try_into()?))?;
+    let len = usize::try_from(u64::from_be_bytes(input[0..8].try_into()?))?;
     read += 8;
 
     let el_size = fr_byte_size();


### PR DESCRIPTION
In https://github.com/vacp2p/zerokit/pull/153 I forgot to commit these changes that also deal with usize length :(
Sorry