### PR TITLE
combined batch operations (insert + delete)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "pmtree"
 version = "1.0.0"
-source = "git+https://github.com/Rate-Limiting-Nullifier/pmtree?rev=b3a02216cece3e9c24e1754ea381bf784fd1df48#b3a02216cece3e9c24e1754ea381bf784fd1df48"
+source = "git+https://github.com/Rate-Limiting-Nullifier/pmtree?rev=be5b3a7b138ea26c0596734d922871d44d3da301#be5b3a7b138ea26c0596734d922871d44d3da301"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "pmtree"
 version = "1.0.0"
-source = "git+https://github.com/Rate-Limiting-Nullifier/pmtree?rev=be5b3a7b138ea26c0596734d922871d44d3da301#be5b3a7b138ea26c0596734d922871d44d3da301"
+source = "git+https://github.com/Rate-Limiting-Nullifier/pmtree?rev=8b3844363783cdcaf9d56ace9fcadfbeb232cd1a#8b3844363783cdcaf9d56ace9fcadfbeb232cd1a"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "pmtree"
 version = "1.0.0"
-source = "git+https://github.com/Rate-Limiting-Nullifier/pmtree?rev=8b3844363783cdcaf9d56ace9fcadfbeb232cd1a#8b3844363783cdcaf9d56ace9fcadfbeb232cd1a"
+source = "git+https://github.com/Rate-Limiting-Nullifier/pmtree?rev=bf27d4273b34a7f4ec3c77cdf67fb17a5602504a#bf27d4273b34a7f4ec3c77cdf67fb17a5602504a"
 dependencies = [
  "rayon",
 ]

--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -58,10 +58,7 @@ impl FromStr for PmtreeConfig {
 
         let temporary = config["temporary"].as_bool();
         let path = config["path"].as_str();
-        let path = match path {
-            Some(path) => Some(PathBuf::from(path)),
-            None => None,
-        };
+        let path = path.map(PathBuf::from);
 
         let config = pm_tree::Config::new()
             .temporary(temporary.unwrap_or(get_tmp()))

--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -205,7 +205,6 @@ impl ZerokitMerkleTree for PmTree {
     }
 
     fn compute_root(&mut self) -> Result<FrOf<Self::Hasher>> {
-        self.tree.recalculate_from(0)?;
         Ok(self.tree.root())
     }
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 ark-ff = { version = "=0.4.1", default-features = false, features = ["asm"] }
 num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"] }
 color-eyre = "=0.6.2"
-pmtree = { git = "https://github.com/Rate-Limiting-Nullifier/pmtree", rev = "b3a02216cece3e9c24e1754ea381bf784fd1df48", optional = true}
+pmtree = { git = "https://github.com/Rate-Limiting-Nullifier/pmtree", rev = "be5b3a7b138ea26c0596734d922871d44d3da301", optional = true}
 sled = "=0.34.7"
 serde = "1.0.44"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 ark-ff = { version = "=0.4.1", default-features = false, features = ["asm"] }
 num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"] }
 color-eyre = "=0.6.2"
-pmtree = { git = "https://github.com/Rate-Limiting-Nullifier/pmtree", rev = "be5b3a7b138ea26c0596734d922871d44d3da301", optional = true}
+pmtree = { git = "https://github.com/Rate-Limiting-Nullifier/pmtree", rev = "8b3844363783cdcaf9d56ace9fcadfbeb232cd1a", optional = true}
 sled = "=0.34.7"
 serde = "1.0.44"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 ark-ff = { version = "=0.4.1", default-features = false, features = ["asm"] }
 num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"] }
 color-eyre = "=0.6.2"
-pmtree = { git = "https://github.com/Rate-Limiting-Nullifier/pmtree", rev = "8b3844363783cdcaf9d56ace9fcadfbeb232cd1a", optional = true}
+pmtree = { git = "https://github.com/Rate-Limiting-Nullifier/pmtree", rev = "bf27d4273b34a7f4ec3c77cdf67fb17a5602504a", optional = true}
 sled = "=0.34.7"
 serde = "1.0.44"
 

--- a/utils/src/merkle_tree/merkle_tree.rs
+++ b/utils/src/merkle_tree/merkle_tree.rs
@@ -49,10 +49,16 @@ pub trait ZerokitMerkleTree {
     fn capacity(&self) -> usize;
     fn leaves_set(&mut self) -> usize;
     fn root(&self) -> FrOf<Self::Hasher>;
+    fn compute_root(&mut self) -> Result<FrOf<Self::Hasher>>;
     fn set(&mut self, index: usize, leaf: FrOf<Self::Hasher>) -> Result<()>;
     fn set_range<I>(&mut self, start: usize, leaves: I) -> Result<()>
     where
         I: IntoIterator<Item = FrOf<Self::Hasher>>;
+    fn get(&self, index: usize) -> Result<FrOf<Self::Hasher>>;
+    fn override_range<I, J>(&mut self, start: usize, leaves: I, to_remove_indices: J) -> Result<()>
+    where
+        I: IntoIterator<Item = FrOf<Self::Hasher>>,
+        J: IntoIterator<Item = usize>;
     fn update_next(&mut self, leaf: FrOf<Self::Hasher>) -> Result<()>;
     fn delete(&mut self, index: usize) -> Result<()>;
     fn proof(&self, index: usize) -> Result<Self::Proof>;

--- a/utils/src/pm_tree/sled_adapter.rs
+++ b/utils/src/pm_tree/sled_adapter.rs
@@ -14,8 +14,7 @@ impl Database for SledDB {
             Err(e) => {
                 return Err(PmtreeErrorKind::DatabaseError(
                     DatabaseErrorKind::CustomError(format!(
-                        "Cannot create database: {} {:#?}",
-                        e, config
+                        "Cannot create database: {e} {config:#?}",
                     )),
                 ))
             }
@@ -29,7 +28,7 @@ impl Database for SledDB {
             Ok(db) => db,
             Err(e) => {
                 return Err(PmtreeErrorKind::DatabaseError(
-                    DatabaseErrorKind::CustomError(format!("Cannot load database: {}", e)),
+                    DatabaseErrorKind::CustomError(format!("Cannot load database: {e}")),
                 ))
             }
         };

--- a/utils/tests/merkle_tree.rs
+++ b/utils/tests/merkle_tree.rs
@@ -125,4 +125,41 @@ mod test {
                 .unwrap());
         }
     }
+
+    #[test]
+    fn test_override_range() {
+        let initial_leaves = [
+            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000002"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000004"),
+        ];
+
+        let mut tree =
+            OptimalMerkleTree::<Keccak256>::new(2, [0; 32], OptimalMerkleConfig::default())
+                .unwrap();
+
+        // We set the leaves
+        tree.set_range(0, initial_leaves.iter().cloned()).unwrap();
+
+        let new_leaves = [
+            hex!("0000000000000000000000000000000000000000000000000000000000000005"),
+            hex!("0000000000000000000000000000000000000000000000000000000000000006"),
+        ];
+
+        let to_delete_indices: [usize; 2] = [0, 1];
+
+        // We override the leaves
+        tree.override_range(
+            0, // start from the end of the initial leaves
+            new_leaves.iter().cloned(),
+            to_delete_indices.iter().cloned(),
+        )
+        .unwrap();
+
+        // ensure that the leaves are set correctly
+        for i in 0..new_leaves.len() {
+            assert_eq!(tree.get_leaf(i), new_leaves[i]);
+        }
+    }
 }


### PR DESCRIPTION
Allows insertions and deletions in the same batch operation.

Note: deletion is just zeroing out a given index

- feat: batch ops in ZerokitMerkleTree


Follow up PR: 
- [ ] public, ffi api and tests using them