### PR TITLE
fix: wasm tests and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         uses: jetli/wasm-pack-action@v0.3.0
       - run: cargo make build
         working-directory: rln-wasm
-      - run: cargo-make test
+      - run: cargo make test --release
         working-directory: rln-wasm
 
   rln:

--- a/rln-wasm/tests/rln-wasm.rs
+++ b/rln-wasm/tests/rln-wasm.rs
@@ -30,7 +30,7 @@ mod tests {
         let vk = read_file(&vk_path).unwrap();
 
         // Creating an instance of RLN
-        let rln_instance = wasm_new(tree_height, zkey, vk);
+        let rln_instance = wasm_new(tree_height, zkey, vk).unwrap();
 
         // Creating membership key
         let mem_keys = wasm_key_gen(rln_instance).unwrap();
@@ -59,10 +59,10 @@ mod tests {
         let serialized_message = Uint8Array::from(&serialized_vec[..]);
 
         let serialized_rln_witness =
-            wasm_get_serialized_rln_witness(rln_instance, serialized_message);
+            wasm_get_serialized_rln_witness(rln_instance, serialized_message).unwrap();
 
         // Obtaining inputs that should be sent to circom witness calculator
-        let json_inputs = rln_witness_to_json(rln_instance, serialized_rln_witness.clone());
+        let json_inputs = rln_witness_to_json(rln_instance, serialized_rln_witness.clone()).unwrap();
 
         // Calculating witness with JS
         // (Using a JSON since wasm_bindgen does not like Result<Vec<JsBigInt>,JsValue>)

--- a/rln-wasm/tests/rln-wasm.rs
+++ b/rln-wasm/tests/rln-wasm.rs
@@ -62,7 +62,8 @@ mod tests {
             wasm_get_serialized_rln_witness(rln_instance, serialized_message).unwrap();
 
         // Obtaining inputs that should be sent to circom witness calculator
-        let json_inputs = rln_witness_to_json(rln_instance, serialized_rln_witness.clone()).unwrap();
+        let json_inputs =
+            rln_witness_to_json(rln_instance, serialized_rln_witness.clone()).unwrap();
 
         // Calculating witness with JS
         // (Using a JSON since wasm_bindgen does not like Result<Vec<JsBigInt>,JsValue>)


### PR DESCRIPTION
Unwrap result values in `rln-wasm` tests due to changed function signature
Fix CI, particularly `rl-wasm` tests were not being run

- [x] local testing