### PR TITLE
feat(rln): pmtree benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
  "ark-std 0.4.0",
  "cfg-if",
  "color-eyre 0.6.2",
+ "criterion 0.4.0",
  "include_dir",
  "num-bigint",
  "num-traits",

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -3,6 +3,7 @@ name = "rln"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+bench = false
 
 [lib]
 crate-type = ["rlib", "staticlib"]
@@ -47,6 +48,7 @@ include_dir = "=0.7.3"
 
 [dev-dependencies]
 sled = "=0.34.7"
+criterion = { version = "0.4", features = ["html_reports"] }
 
 [features]
 default = ["parallel", "wasmer/sys-default", "pmtree-ft"]
@@ -56,3 +58,7 @@ fullmerkletree = ["default"]
 
 # Note: pmtree feature is still experimental
 pmtree-ft = ["utils/pmtree-ft"]
+
+[[bench]]
+name = "pmtree_benchmark"
+harness = false

--- a/rln/Makefile.toml
+++ b/rln/Makefile.toml
@@ -5,3 +5,7 @@ args = ["build", "--release"]
 [tasks.test]
 command = "cargo"
 args = ["test", "--release"]
+
+[tasks.bench]
+command = "cargo"
+args = ["bench"]

--- a/rln/benches/pmtree_benchmark.rs
+++ b/rln/benches/pmtree_benchmark.rs
@@ -1,13 +1,12 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use utils::{ZerokitMerkleTree};
+use utils::ZerokitMerkleTree;
 
-use rln::{pm_tree_adapter::PmTree, circuit::Fr};
+use rln::{circuit::Fr, pm_tree_adapter::PmTree};
 
 pub fn pmtree_benchmark(c: &mut Criterion) {
     let mut tree = PmTree::default(2).unwrap();
 
     let leaves: Vec<Fr> = (0..4).map(|s| Fr::from(s)).collect();
-    
 
     c.bench_function("Pmtree::set", |b| {
         b.iter(|| {
@@ -23,7 +22,8 @@ pub fn pmtree_benchmark(c: &mut Criterion) {
 
     c.bench_function("Pmtree::override_range", |b| {
         b.iter(|| {
-            tree.override_range(0, leaves.clone(), [0, 1, 2, 3]).unwrap();
+            tree.override_range(0, leaves.clone(), [0, 1, 2, 3])
+                .unwrap();
         })
     });
 

--- a/rln/benches/pmtree_benchmark.rs
+++ b/rln/benches/pmtree_benchmark.rs
@@ -1,0 +1,44 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use utils::{ZerokitMerkleTree};
+
+use rln::{pm_tree_adapter::PmTree, circuit::Fr};
+
+pub fn pmtree_benchmark(c: &mut Criterion) {
+    let mut tree = PmTree::default(2).unwrap();
+
+    let leaves: Vec<Fr> = (0..4).map(|s| Fr::from(s)).collect();
+    
+
+    c.bench_function("Pmtree::set", |b| {
+        b.iter(|| {
+            tree.set(0, leaves[0]).unwrap();
+        })
+    });
+
+    c.bench_function("Pmtree:delete", |b| {
+        b.iter(|| {
+            tree.delete(0).unwrap();
+        })
+    });
+
+    c.bench_function("Pmtree::override_range", |b| {
+        b.iter(|| {
+            tree.override_range(0, leaves.clone(), [0, 1, 2, 3]).unwrap();
+        })
+    });
+
+    c.bench_function("Pmtree::compute_root", |b| {
+        b.iter(|| {
+            tree.compute_root().unwrap();
+        })
+    });
+
+    c.bench_function("Pmtree::get", |b| {
+        b.iter(|| {
+            tree.get(0).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, pmtree_benchmark);
+criterion_main!(benches);

--- a/utils/Makefile.toml
+++ b/utils/Makefile.toml
@@ -5,3 +5,7 @@ args = ["build", "--release"]
 [tasks.test]
 command = "cargo"
 args = ["test", "--release"]
+
+[tasks.bench]
+command = "cargo"
+args = ["bench"]


### PR DESCRIPTION
Closes https://github.com/vacp2p/zerokit/issues/89

<img width="948" alt="image" src="https://github.com/vacp2p/zerokit/assets/43716372/5d1cbcdc-5bc5-454a-84e1-dd1217bcce45">

pmtree using sled vs in-memory omt

