### PR TITLE
fix(cargo.toml): bench=false

### DIFF
--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -3,10 +3,10 @@ name = "rln"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-bench = false
 
 [lib]
 crate-type = ["rlib", "staticlib"]
+bench = false
 
 # This flag disable cargo doctests, i.e. testing example code-snippets in documentation
 doctest = false

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -3,6 +3,8 @@ name = "utils"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+
+[lib]
 bench = false
 
 [dependencies]


### PR DESCRIPTION
To allow criterion to be discovered by cargo 
