### PR TITLE
fix(ci): run benchmarks only in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
         # Currently not treating warnings as error, too noisy
         # -- -D warnings
   benchmark:
+    # run only in pull requests
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         # we run benchmark tests only on ubuntu


### PR DESCRIPTION
Benchmarks should only run in PRs so they have a base branch to compare
