### PR TITLE
test(rln): sled db config change

### DIFF
--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -61,10 +61,22 @@ impl FromStr for PmtreeConfig {
         let temporary = config["temporary"].as_bool();
         let path = config["path"].as_str();
         let path = path.map(PathBuf::from);
+        let cache_capacity = config["cache_capacity"].as_u64();
+        let flush_every_ms = config["flush_every_ms"].as_u64();
+        let mode = match config["mode"].as_str() {
+            Some("HighThroughput") => Mode::HighThroughput,
+            Some("LowSpace") => Mode::LowSpace,
+            _ => Mode::HighThroughput,
+        };
+        let use_compression = config["use_compression"].as_bool();
 
         let config = pm_tree::Config::new()
             .temporary(temporary.unwrap_or(get_tmp()))
-            .path(path.unwrap_or(get_tmp_path()));
+            .path(path.unwrap_or(get_tmp_path()))
+            .cache_capacity(cache_capacity.unwrap_or(1024 * 1024 * 1024))
+            .flush_every_ms(flush_every_ms)
+            .mode(mode)
+            .use_compression(use_compression.unwrap_or(false));
         Ok(PmtreeConfig(config))
     }
 }
@@ -72,7 +84,15 @@ impl FromStr for PmtreeConfig {
 impl Default for PmtreeConfig {
     fn default() -> Self {
         let tmp_path = get_tmp_path();
-        PmtreeConfig(pm_tree::Config::new().temporary(true).path(tmp_path))
+        PmtreeConfig(
+            pm_tree::Config::new()
+                .temporary(true)
+                .path(tmp_path)
+                .cache_capacity(15_000)
+                .mode(Mode::HighThroughput)
+                .use_compression(false)
+                .flush_every_ms(Some(12_000)),
+        )
     }
 }
 impl Debug for PmtreeConfig {

--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -88,7 +88,7 @@ impl Default for PmtreeConfig {
             pm_tree::Config::new()
                 .temporary(true)
                 .path(tmp_path)
-                .cache_capacity(15_000)
+                .cache_capacity(150_000)
                 .mode(Mode::HighThroughput)
                 .use_compression(false)
                 .flush_every_ms(Some(12_000)),


### PR DESCRIPTION
tuning sled db's configuration 

we are tuning for infrequent writes (once every 12 sec), and for very frequent reads
Closes https://github.com/vacp2p/zerokit/issues/151

These changes allow the clients to run their own benchmarks with their specific configurations.
