### PR TITLE
fix(rln): error out when temporary=true and path is exists

### DIFF
--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -70,13 +70,15 @@ impl FromStr for PmtreeConfig {
         };
         let use_compression = config["use_compression"].as_bool();
 
-        if temporary.is_some() && path.is_some() {
-            if temporary.unwrap() && path.as_ref().unwrap().exists() {
-                return Err(Report::msg(format!(
-                    "Path {:?} already exists, cannot use temporary",
-                    path.unwrap()
-                )));
-            }
+        if temporary.is_some()
+            && path.is_some()
+            && temporary.unwrap()
+            && path.as_ref().unwrap().exists()
+        {
+            return Err(Report::msg(format!(
+                "Path {:?} already exists, cannot use temporary",
+                path.unwrap()
+            )));
         }
 
         let config = pm_tree::Config::new()

--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -71,7 +71,7 @@ impl FromStr for PmtreeConfig {
         let use_compression = config["use_compression"].as_bool();
 
         if temporary.is_some() && path.is_some() {
-            if temporary.unwrap() && path.unwrap().exists() {
+            if temporary.unwrap() && path.as_ref().unwrap().exists() {
                 return Err(Report::msg(format!(
                     "Path {:?} already exists, cannot use temporary",
                     path.unwrap()


### PR DESCRIPTION
Fixes an edge case where the user erroneously passes in temporary = true with a valid path

