### PR TITLE
feat(rln): expose set_metadata and get_metadata public and ffi apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "pmtree"
 version = "1.0.0"
-source = "git+https://github.com/Rate-Limiting-Nullifier/pmtree?rev=bf27d4273b34a7f4ec3c77cdf67fb17a5602504a#bf27d4273b34a7f4ec3c77cdf67fb17a5602504a"
+source = "git+https://github.com/vacp2p/pmtree?rev=8b005bb44a4c51b56638ad6057b8bc90629fca59#8b005bb44a4c51b56638ad6057b8bc90629fca59"
 dependencies = [
  "rayon",
 ]

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -385,6 +385,22 @@ pub extern "C" fn recover_id_secret(
     )
 }
 
+////////////////////////////////////////////////////////
+// Persistent metadata APIs
+////////////////////////////////////////////////////////
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn set_metadata(ctx: *mut RLN, input_buffer: *const Buffer) -> bool {
+    call!(ctx, set_metadata, input_buffer)
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn get_metadata(ctx: *const RLN, output_buffer: *mut Buffer) -> bool {
+    call_with_output_arg!(ctx, get_metadata, output_buffer)
+}
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn hash(input_buffer: *const Buffer, output_buffer: *mut Buffer) -> bool {

--- a/rln/tests/ffi.rs
+++ b/rln/tests/ffi.rs
@@ -1201,4 +1201,32 @@ mod test {
         // We check that the received id_commitment is the same as the one we inserted
         assert_eq!(received_id_commitment, id_commitment);
     }
+
+    #[test]
+    fn test_metadata() {
+        // We create a RLN instance
+        let tree_height = TEST_TREE_HEIGHT;
+
+        let mut rln_pointer = MaybeUninit::<*mut RLN>::uninit();
+        let input_config = json!({ "resources_folder": TEST_RESOURCES_FOLDER }).to_string();
+        let input_buffer = &Buffer::from(input_config.as_bytes());
+        let success = new(tree_height, input_buffer, rln_pointer.as_mut_ptr());
+        assert!(success, "RLN object creation failed");
+        let rln_pointer = unsafe { &mut *rln_pointer.assume_init() };
+
+        let seed_bytes: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let input_buffer = &Buffer::from(seed_bytes);
+
+        let success = set_metadata(rln_pointer, input_buffer);
+        assert!(success, "set_metadata call failed");
+
+        let mut output_buffer = MaybeUninit::<Buffer>::uninit();
+        let success = get_metadata(rln_pointer, output_buffer.as_mut_ptr());
+        assert!(success, "get_metadata call failed");
+
+        let output_buffer = unsafe { output_buffer.assume_init() };
+        let result_data = <&[u8]>::from(&output_buffer).to_vec();
+
+        assert_eq!(result_data, seed_bytes.to_vec());
+    }
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 ark-ff = { version = "=0.4.1", default-features = false, features = ["asm"] }
 num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"] }
 color-eyre = "=0.6.2"
-pmtree = { git = "https://github.com/Rate-Limiting-Nullifier/pmtree", rev = "bf27d4273b34a7f4ec3c77cdf67fb17a5602504a", optional = true}
+pmtree = { git = "https://github.com/vacp2p/pmtree", rev = "8b005bb44a4c51b56638ad6057b8bc90629fca59", optional = true}
 sled = "=0.34.7"
 serde = "1.0.44"
 

--- a/utils/src/merkle_tree/full_merkle_tree.rs
+++ b/utils/src/merkle_tree/full_merkle_tree.rs
@@ -29,6 +29,9 @@ pub struct FullMerkleTree<H: Hasher> {
     // The next available (i.e., never used) tree index. Equivalently, the number of leaves added to the tree
     // (deletions leave next_index unchanged)
     next_index: usize,
+
+    // metadata that an application may use to store additional information
+    metadata: Vec<u8>,
 }
 
 /// Element of a Merkle proof
@@ -94,6 +97,7 @@ where
             cached_nodes,
             nodes,
             next_index,
+            metadata: Vec::new(),
         })
     }
 
@@ -233,6 +237,15 @@ where
 
     fn compute_root(&mut self) -> Result<FrOf<Self::Hasher>> {
         Ok(self.root())
+    }
+
+    fn set_metadata(&mut self, metadata: &[u8]) -> Result<()> {
+        self.metadata = metadata.to_vec();
+        Ok(())
+    }
+
+    fn metadata(&self) -> Result<Vec<u8>> {
+        Ok(self.metadata.to_vec())
     }
 }
 

--- a/utils/src/merkle_tree/merkle_tree.rs
+++ b/utils/src/merkle_tree/merkle_tree.rs
@@ -63,6 +63,8 @@ pub trait ZerokitMerkleTree {
     fn delete(&mut self, index: usize) -> Result<()>;
     fn proof(&self, index: usize) -> Result<Self::Proof>;
     fn verify(&self, leaf: &FrOf<Self::Hasher>, witness: &Self::Proof) -> Result<bool>;
+    fn set_metadata(&mut self, metadata: &[u8]) -> Result<()>;
+    fn metadata(&self) -> Result<Vec<u8>>;
 }
 
 pub trait ZerokitMerkleProof {

--- a/utils/src/merkle_tree/optimal_merkle_tree.rs
+++ b/utils/src/merkle_tree/optimal_merkle_tree.rs
@@ -30,6 +30,9 @@ where
     // The next available (i.e., never used) tree index. Equivalently, the number of leaves added to the tree
     // (deletions leave next_index unchanged)
     next_index: usize,
+
+    // metadata that an application may use to store additional information
+    metadata: Vec<u8>,
 }
 
 /// The Merkle proof
@@ -76,6 +79,7 @@ where
             depth,
             nodes: HashMap::new(),
             next_index: 0,
+            metadata: Vec::new(),
         })
     }
 
@@ -215,6 +219,15 @@ where
     fn compute_root(&mut self) -> Result<FrOf<Self::Hasher>> {
         self.recalculate_from(0)?;
         Ok(self.root())
+    }
+
+    fn set_metadata(&mut self, metadata: &[u8]) -> Result<()> {
+        self.metadata = metadata.to_vec();
+        Ok(())
+    }
+
+    fn metadata(&self) -> Result<Vec<u8>> {
+        Ok(self.metadata.to_vec())
     }
 }
 


### PR DESCRIPTION
This feature is required so that downstream users of this library can set metadata related to the usage of the tree in the underlying database. This reduces client side complexity.
