### PR TITLE
fix(rln): tree_config parsing

### DIFF
--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -87,7 +87,7 @@ impl RLN<'_> {
         let proving_key = zkey_from_folder(resources_folder)?;
         let verification_key = vk_from_folder(resources_folder)?;
 
-        let tree_config: <PoseidonTree as ZerokitMerkleTree>::Config = if tree_config == "" {
+        let tree_config: <PoseidonTree as ZerokitMerkleTree>::Config = if tree_config.is_empty() {
             <PoseidonTree as ZerokitMerkleTree>::Config::default()
         } else {
             <PoseidonTree as ZerokitMerkleTree>::Config::from_str(&tree_config)?

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -80,18 +80,17 @@ impl RLN<'_> {
         let resources_folder = rln_config["resources_folder"]
             .as_str()
             .unwrap_or(TEST_RESOURCES_FOLDER);
-        let tree_config_opt = rln_config["tree_config"].as_str();
+        let tree_config = rln_config["tree_config"].to_string();
 
         let witness_calculator = circom_from_folder(resources_folder)?;
 
         let proving_key = zkey_from_folder(resources_folder)?;
         let verification_key = vk_from_folder(resources_folder)?;
 
-        let tree_config: <PoseidonTree as ZerokitMerkleTree>::Config = match tree_config_opt {
-            Some(tree_config_str) => {
-                <PoseidonTree as ZerokitMerkleTree>::Config::from_str(tree_config_str)?
-            }
-            None => <PoseidonTree as ZerokitMerkleTree>::Config::default(),
+        let tree_config: <PoseidonTree as ZerokitMerkleTree>::Config = if tree_config == "" {
+            <PoseidonTree as ZerokitMerkleTree>::Config::default()
+        } else {
+            <PoseidonTree as ZerokitMerkleTree>::Config::from_str(&tree_config)?
         };
 
         // We compute a default empty tree


### PR DESCRIPTION
This PR resolves an error in which downstream libs were not able to pass a custom tree_config, this was due to using `as_str`, instead of 
`to_string`, which resulted in the default config to be used.
