### PR TITLE
chore: use crates.io dep of ethers-rs

### DIFF
--- a/semaphore/Cargo.toml
+++ b/semaphore/Cargo.toml
@@ -21,7 +21,7 @@ color-eyre = "0.6.1"
 once_cell = "1.8"
 rand = "0.8.4"
 semaphore = { git = "https://github.com/worldcoin/semaphore-rs", rev = "ee658c2"}
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false, rev = "030bf43" }
+ethers-core = { version = "2.0.8", default-features = false }
 ruint = { version = "1.2.0", features = [ "serde", "num-bigint", "ark-ff" ] }
 serde = "1.0"
 thiserror = "1.0.0"


### PR DESCRIPTION
Use crates.io version of ethers-rs instead of github
