### PR TITLE
chore: use our fork of circom-compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ark-circom?rev=a93c8b0#a93c8b03d4376e197ceb36aa410a8903c283dab7"
+source = "git+https://github.com/vacp2p/ark-circom?rev=f8a23cf"
 dependencies = [
  "ark-bn254 0.3.0",
  "ark-ec 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ version = "0.1.0"
 source = "git+https://github.com/worldcoin/semaphore-rs?rev=ee658c2#ee658c22684696232f68ef08beb8494280fb7da4"
 dependencies = [
  "ark-bn254 0.3.0",
- "ark-circom 0.1.0 (git+https://github.com/gakonst/ark-circom?rev=a93c8b0)",
+ "ark-circom 0.1.0 (git+https://github.com/vacp2p/ark-circom?rev=f8a23cf)",
  "ark-ec 0.3.0",
  "ark-ff 0.3.0",
  "ark-groth16 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/vacp2p/ark-circom#aa6785c48e0e23cff413f7255b738db3f23a3913"
+source = "git+https://github.com/vacp2p/ark-circom#f8a23cf"
 dependencies = [
  "ark-bn254 0.3.0",
  "ark-ec 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,33 +128,6 @@ dependencies = [
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ark-circom?rev=35ce5a9#35ce5a909ee09ae8c3101e69cc57785a21ed7f64"
-dependencies = [
- "ark-bn254 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-groth16 0.3.0",
- "ark-poly 0.3.0",
- "ark-relations 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "byteorder",
- "cfg-if",
- "color-eyre 0.6.2",
- "criterion 0.3.6",
- "ethers-core 2.0.4",
- "fnv",
- "hex",
- "num",
- "num-bigint",
- "num-traits",
- "thiserror",
- "wasmer",
-]
-
-[[package]]
-name = "ark-circom"
-version = "0.1.0"
 source = "git+https://github.com/gakonst/ark-circom?rev=a93c8b0#a93c8b03d4376e197ceb36aa410a8903c283dab7"
 dependencies = [
  "ark-bn254 0.3.0",
@@ -182,7 +155,7 @@ dependencies = [
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ark-circom#f97ac2b2458fd14489bc70375bb45688f5ef26a8"
+source = "git+https://github.com/vacp2p/ark-circom?rev=f8a23cf#f8a23cfeaadbc8036194642a64ee142e0d7998dd"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-crypto-primitives 0.4.0",
@@ -197,6 +170,34 @@ dependencies = [
  "cfg-if",
  "color-eyre 0.6.2",
  "criterion 0.3.6",
+ "ethers-core 2.0.8",
+ "fnv",
+ "hex",
+ "num",
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "wasmer",
+]
+
+[[package]]
+name = "ark-circom"
+version = "0.1.0"
+source = "git+https://github.com/vacp2p/ark-circom#aa6785c48e0e23cff413f7255b738db3f23a3913"
+dependencies = [
+ "ark-bn254 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-groth16 0.3.0",
+ "ark-poly 0.3.0",
+ "ark-relations 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "byteorder",
+ "cfg-if",
+ "color-eyre 0.5.11",
+ "criterion 0.3.6",
+ "ethers-core 1.0.0",
  "fnv",
  "hex",
  "num",
@@ -583,6 +584,12 @@ dependencies = [
  "object 0.30.3",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -1200,6 +1207,18 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
@@ -1300,6 +1319,16 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
@@ -1355,16 +1384,28 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
- "der",
+ "der 0.7.5",
  "digest 0.10.6",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.4",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -1375,19 +1416,38 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.6",
+ "ff 0.12.1",
+ "generic-array",
+ "group 0.12.1",
+ "rand_core",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.2",
  "digest 0.10.6",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core",
- "sec1",
+ "sec1 0.7.2",
  "subtle",
  "zeroize",
 ]
@@ -1504,18 +1564,43 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
+version = "1.0.0"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f829bd68#f829bd68761f58f46d1075f3bb5d238161e5441c"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "chrono",
+ "elliptic-curve 0.12.3",
+ "ethabi",
+ "generic-array",
+ "hex",
+ "k256 0.11.6",
+ "open-fastrlp",
+ "rand",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "serde_json",
+ "strum 0.24.1",
+ "thiserror",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ethers-core"
 version = "2.0.4"
 source = "git+https://github.com/gakonst/ethers-rs#34f6a8c5d4c26ce3dc85aa5c34ac02b3930b18f2"
 dependencies = [
  "arrayvec",
  "bytes",
  "chrono",
- "elliptic-curve",
+ "elliptic-curve 0.13.4",
  "ethabi",
  "generic-array",
  "getrandom",
  "hex",
- "k256",
+ "k256 0.13.1",
  "num_enum",
  "open-fastrlp",
  "rand",
@@ -1532,16 +1617,17 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs?rev=030bf43#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
 dependencies = [
  "arrayvec",
  "bytes",
  "chrono",
- "elliptic-curve",
+ "elliptic-curve 0.13.4",
  "ethabi",
  "generic-array",
  "hex",
- "k256",
+ "k256 0.13.1",
  "num_enum",
  "open-fastrlp",
  "rand",
@@ -1578,6 +1664,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1685,11 +1781,22 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -1926,13 +2033,26 @@ dependencies = [
 
 [[package]]
 name = "k256"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "k256"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.7",
+ "elliptic-curve 0.13.4",
  "once_cell",
  "sha2",
 ]
@@ -2082,7 +2202,7 @@ name = "multiplier"
 version = "0.1.0"
 dependencies = [
  "ark-bn254 0.3.0",
- "ark-circom 0.1.0 (git+https://github.com/gakonst/ark-circom?rev=35ce5a9)",
+ "ark-circom 0.1.0 (git+https://github.com/vacp2p/ark-circom?rev=f8a23cf)",
  "ark-groth16 0.3.0",
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
@@ -2374,12 +2494,22 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.5",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -2653,6 +2783,17 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -2695,7 +2836,7 @@ name = "rln"
 version = "0.1.0"
 dependencies = [
  "ark-bn254 0.4.0",
- "ark-circom 0.1.0 (git+https://github.com/gakonst/ark-circom)",
+ "ark-circom 0.1.0 (git+https://github.com/vacp2p/ark-circom)",
  "ark-ec 0.4.1",
  "ark-ff 0.4.1",
  "ark-groth16 0.4.0",
@@ -2908,14 +3049,28 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.5",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -2954,7 +3109,7 @@ name = "semaphore-wrapper"
 version = "0.1.0"
 dependencies = [
  "ark-bn254 0.3.0",
- "ark-circom 0.1.0 (git+https://github.com/gakonst/ark-circom?rev=35ce5a9)",
+ "ark-circom 0.1.0 (git+https://github.com/vacp2p/ark-circom?rev=f8a23cf)",
  "ark-ec 0.3.0",
  "ark-groth16 0.3.0",
  "ark-relations 0.3.0",
@@ -3091,6 +3246,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core",
+]
+
+[[package]]
+name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
@@ -3135,12 +3300,22 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/vacp2p/ark-circom?rev=f8a23cf#f8a23cfeaadbc8036194642a64ee142e0d7998dd"
+source = "git+https://github.com/vacp2p/ark-circom?rev=f8a23cf"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-crypto-primitives 0.4.0",

--- a/multiplier/Cargo.toml
+++ b/multiplier/Cargo.toml
@@ -22,7 +22,7 @@ ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", rev = "765817f",
 # ark-poly = { version = "^0.3.0", default-features = false, features = ["parallel"] }
 ark-serialize = { version = "0.3.0", default-features = false }
 
-ark-circom = { git = "https://github.com/gakonst/ark-circom", features = ["circom-2"], rev = "35ce5a9" }
+ark-circom = { git = "https://github.com/vacp2p/ark-circom", features = ["circom-2"], rev = "f8a23cf" }
 
 # error handling
 color-eyre = "0.6.1"

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -21,7 +21,7 @@ ark-bn254 = { version = "=0.4.0" }
 ark-groth16 = { version = "=0.4.0", features = ["parallel"], default-features = false }
 ark-relations = { version = "=0.4.0", default-features = false, features = [ "std" ] }
 ark-serialize = { version = "=0.4.1", default-features = false }
-ark-circom = { version = "=0.1.0", git = "https://github.com/gakonst/ark-circom", default-features = false, features = ["circom-2"] }
+ark-circom = { version = "=0.1.0", git = "https://github.com/vacp2p/ark-circom", default-features = false, features = ["circom-2"] }
 
 # WASM
 wasmer = { version = "2.3.0", default-features = false }

--- a/semaphore/Cargo.toml
+++ b/semaphore/Cargo.toml
@@ -12,7 +12,7 @@ dylib = [ "wasmer/dylib", "wasmer-engine-dylib", "wasmer-compiler-cranelift" ]
 
 [dependencies]
 ark-bn254 = { version = "0.3.0" }
-ark-circom = { git = "https://github.com/gakonst/ark-circom", features=["circom-2"], rev = "35ce5a9" }
+ark-circom = { git = "https://github.com/vacp2p/ark-circom", features=["circom-2"], rev = "f8a23cf" }
 ark-ec = { version = "0.3.0", default-features = false, features = ["parallel"] }
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", rev = "765817f", features = ["parallel"] }
 ark-relations = { version = "0.3.0", default-features = false }


### PR DESCRIPTION
Uses our fork of ark-circom to use the crates.io version of ethers-core
