### PR TITLE
chore(utils): bump pmtree rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "pmtree"
 version = "1.0.0"
-source = "git+https://github.com/vacp2p/pmtree?rev=46a39a3#46a39a373ffdb6da14fd122b008437e63f1f7e2b"
+source = "git+https://github.com/vacp2p/pmtree?rev=be7c964#be7c96472f5c97b348297ab23c77f228fba0914f"
 dependencies = [
  "rayon",
 ]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 ark-ff = { version = "=0.4.1", default-features = false, features = ["asm"] }
 num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"] }
 color-eyre = "=0.6.2"
-pmtree = { git = "https://github.com/vacp2p/pmtree", rev = "46a39a3", optional = true}
+pmtree = { git = "https://github.com/vacp2p/pmtree", rev = "be7c964", optional = true}
 sled = "=0.34.7"
 serde = "1.0.44"
 


### PR DESCRIPTION
Bumps pmtree to avoid unwrapping on values that don't exist at the time of db load
