### PR TITLE
chore: accept tree_config in new_with_params

### DIFF
--- a/rln-wasm/src/lib.rs
+++ b/rln-wasm/src/lib.rs
@@ -250,11 +250,7 @@ pub fn wasm_set_metadata(ctx: *mut RLNWrapper, input: Uint8Array) -> Result<(), 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[wasm_bindgen(js_name = getMetadata)]
 pub fn wasm_get_metadata(ctx: *mut RLNWrapper) -> Result<Uint8Array, String> {
-    call_with_output_and_error_msg!(
-        ctx,
-        get_metadata,
-        "could not get metadata".to_string()
-    )
+    call_with_output_and_error_msg!(ctx, get_metadata, "could not get metadata".to_string())
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -186,6 +186,7 @@ pub extern "C" fn new_with_params(
     circom_buffer: *const Buffer,
     zkey_buffer: *const Buffer,
     vk_buffer: *const Buffer,
+    tree_config: *const Buffer,
     ctx: *mut *mut RLN,
 ) -> bool {
     if let Ok(rln) = RLN::new_with_params(
@@ -193,6 +194,7 @@ pub extern "C" fn new_with_params(
         circom_buffer.process().to_vec(),
         zkey_buffer.process().to_vec(),
         vk_buffer.process().to_vec(),
+        tree_config.process(),
     ) {
         unsafe { *ctx = Box::into_raw(Box::new(rln)) };
         true

--- a/rln/tests/ffi.rs
+++ b/rln/tests/ffi.rs
@@ -617,11 +617,14 @@ mod test {
 
         // Creating a RLN instance passing the raw data
         let mut rln_pointer_raw_bytes = MaybeUninit::<*mut RLN>::uninit();
+        let tree_config = "".to_string();
+        let tree_config_buffer = &Buffer::from(tree_config.as_bytes());
         let success = new_with_params(
             tree_height,
             circom_data,
             zkey_data,
             vk_data,
+            tree_config_buffer,
             rln_pointer_raw_bytes.as_mut_ptr(),
         );
         assert!(success, "RLN object creation failed");


### PR DESCRIPTION
go-waku embeds the zkey, vk and circuit in the binary, so it's not necessary to rely on external files when deploying go-waku service node. It uses `new_with_params` to be able to pass these parameters. 
However, this function does not allow passing the merkle tree configuration. 
This PR adds a new parameter `tree_config`  which would allow passing this configuration. 

In a future PR, rln-wasm should be updated to receive a JSON (not a string containing a json) in the `wasm_new` function