### PR TITLE
chore: use pmtree instead of vacp2p_pmtree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pmtree"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e054322ee96d2ccd86cd47b87797166682e45f5d67571c48eaa864668d26f510"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,15 +3514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 
 [[package]]
-name = "vacp2p_pmtree"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee78790de52d6774ea318eb747a488fd5d96055bfe75ec2e7f605b15e21c664"
-dependencies = [
- "rayon",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,8 +4269,8 @@ dependencies = [
  "hex-literal",
  "num-bigint",
  "num-traits",
+ "pmtree",
  "serde",
  "sled",
  "tiny-keccak",
- "vacp2p_pmtree",
 ]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 ark-ff = { version = "=0.4.1", default-features = false, features = ["asm"] }
 num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"] }
 color-eyre = "=0.6.2"
-pmtree = { package = "vacp2p_pmtree", version = "=1.0.0", optional = true}
+pmtree = { package = "pmtree", version = "=2.0.0", optional = true}
 sled = "=0.34.7"
 serde = "=1.0.163"
 


### PR DESCRIPTION
Now that the changes we require are upstream, using pmtree's crate
