### PR TITLE
chore(rln): expose seq_atomic_operation api

### DIFF
--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -296,6 +296,22 @@ pub extern "C" fn atomic_operation(
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
+pub extern "C" fn seq_atomic_operation(
+    ctx: *mut RLN,
+    leaves_buffer: *const Buffer,
+    indices_buffer: *const Buffer,
+) -> bool {
+    call!(
+        ctx,
+        atomic_operation,
+        ctx.process().leaves_set(),
+        leaves_buffer,
+        indices_buffer
+    )
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
 pub extern "C" fn get_root(ctx: *const RLN, output_buffer: *mut Buffer) -> bool {
     call_with_output_arg!(ctx, get_root, output_buffer)
 }

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -406,6 +406,10 @@ impl RLN<'_> {
         Ok(())
     }
 
+    pub fn leaves_set(&mut self) -> usize {
+        self.tree.leaves_set()
+    }
+
     /// Sets a leaf value at the next available never-set leaf index.
     ///
     /// This function updates the internal Merkle tree `next_index` value indicating the next available index corresponding to a never-set leaf as `next_index = next_index + 1`.


### PR DESCRIPTION
Exposes a `seq_atomic_operation` api that uses the `next_index` under the hood to sequentially write to the tree
