### PR TITLE
`message_id` range check

### DIFF
--- a/rln-cli/src/state.rs
+++ b/rln-cli/src/state.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use rln::public::RLN;
 use std::fs::File;
 
-use crate::config::{InnerConfig, Config};
+use crate::config::{Config, InnerConfig};
 
 #[derive(Default)]
 pub(crate) struct State<'a> {

--- a/rln-wasm/tests/rln-wasm.rs
+++ b/rln-wasm/tests/rln-wasm.rs
@@ -122,7 +122,6 @@ mod tests {
         // Creating an instance of RLN
         let rln_instance = wasm_new(tree_height, zkey, vk).unwrap();
 
-
         let test_metadata = Uint8Array::new(&JsValue::from_str("test"));
         // Inserting random metadata
         wasm_set_metadata(rln_instance, test_metadata.clone()).unwrap();

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -649,7 +649,9 @@ pub fn inputs_for_witness_calculation(
         .for_each(|v| identity_path_index.push(BigInt::from(*v)));
 
     if rln_witness.message_id > rln_witness.user_message_limit {
-        return Err(color_eyre::Report::msg("message_id is not within user_message_limit"))
+        return Err(color_eyre::Report::msg(
+            "message_id is not within user_message_limit",
+        ));
     }
 
     Ok([

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -233,7 +233,7 @@ pub fn proof_inputs_to_rln_witness(
 pub fn rln_witness_from_json(input_json_str: &str) -> Result<RLNWitnessInput> {
     let input_json: serde_json::Value =
         serde_json::from_str(input_json_str).expect("JSON was not well-formatted");
-    
+
     let user_message_limit = str_to_fr(&input_json["user_message_limit"].to_string(), 10)?;
 
     let message_id = str_to_fr(&input_json["message_id"].to_string(), 10)?;
@@ -680,7 +680,6 @@ pub fn inputs_for_witness_calculation(
         .iter()
         .for_each(|v| identity_path_index.push(BigInt::from(*v)));
 
-
     Ok([
         (
             "identity_secret",
@@ -804,7 +803,7 @@ pub fn verify_proof(
 ///
 /// Returns a JSON object containing the inputs necessary to calculate
 /// the witness with CIRCOM on javascript
-/// 
+///
 /// # Errors
 ///
 /// Returns an error if `rln_witness.message_id` is not within `rln_witness.user_message_limit`.
@@ -837,10 +836,7 @@ pub fn get_json_inputs(rln_witness: &RLNWitnessInput) -> Result<serde_json::Valu
     Ok(inputs)
 }
 
-pub fn message_id_range_check(
-    message_id: &Fr,
-    user_message_limit: &Fr,
-) -> Result<()> {
+pub fn message_id_range_check(message_id: &Fr, user_message_limit: &Fr) -> Result<()> {
     if message_id > user_message_limit {
         return Err(color_eyre::Report::msg(
             "message_id is not within user_message_limit",

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -92,6 +92,11 @@ pub fn deserialize_identity_tuple(serialized: Vec<u8>) -> (Fr, Fr, Fr, Fr) {
     )
 }
 
+/// Serializes witness
+///
+/// # Errors
+///
+/// Returns an error if `rln_witness.message_id` is not within `rln_witness.user_message_limit`.
 pub fn serialize_witness(rln_witness: &RLNWitnessInput) -> Result<Vec<u8>> {
     message_id_range_check(&rln_witness.message_id, &rln_witness.user_message_limit)?;
 
@@ -109,6 +114,11 @@ pub fn serialize_witness(rln_witness: &RLNWitnessInput) -> Result<Vec<u8>> {
     Ok(serialized)
 }
 
+/// Deserializes witness
+///
+/// # Errors
+///
+/// Returns an error if `message_id` is not within `user_message_limit`.
 pub fn deserialize_witness(serialized: &[u8]) -> Result<(RLNWitnessInput, usize)> {
     let mut all_read: usize = 0;
 
@@ -215,6 +225,11 @@ pub fn proof_inputs_to_rln_witness(
     ))
 }
 
+/// Returns `RLNWitnessInput` given a file with JSON serialized values.
+///
+/// # Errors
+///
+/// Returns an error if `message_id` is not within `user_message_limit`.
 pub fn rln_witness_from_json(input_json_str: &str) -> Result<RLNWitnessInput> {
     let input_json: serde_json::Value =
         serde_json::from_str(input_json_str).expect("JSON was not well-formatted");
@@ -262,6 +277,11 @@ pub fn rln_witness_from_json(input_json_str: &str) -> Result<RLNWitnessInput> {
     })
 }
 
+/// Creates `RLNWitnessInput` from it's fields.
+///
+/// # Errors
+///
+/// Returns an error if `message_id` is not within `user_message_limit`.
 pub fn rln_witness_from_values(
     identity_secret: Fr,
     merkle_proof: &MerkleProof,
@@ -272,7 +292,7 @@ pub fn rln_witness_from_values(
     message_id: Fr,
 ) -> Result<RLNWitnessInput> {
     message_id_range_check(&message_id, &user_message_limit)?;
-    
+
     let path_elements = merkle_proof.get_path_elements();
     let identity_path_index = merkle_proof.get_path_index();
 
@@ -784,6 +804,10 @@ pub fn verify_proof(
 ///
 /// Returns a JSON object containing the inputs necessary to calculate
 /// the witness with CIRCOM on javascript
+/// 
+/// # Errors
+///
+/// Returns an error if `rln_witness.message_id` is not within `rln_witness.user_message_limit`.
 pub fn get_json_inputs(rln_witness: &RLNWitnessInput) -> Result<serde_json::Value> {
     message_id_range_check(&rln_witness.message_id, &rln_witness.user_message_limit)?;
 

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -626,6 +626,11 @@ pub fn generate_proof_with_witness(
     Ok(proof)
 }
 
+/// Formats inputs for witness calculation
+///
+/// # Errors
+///
+/// Returns an error if `rln_witness.message_id` is not within `rln_witness.user_message_limit`.
 pub fn inputs_for_witness_calculation(
     rln_witness: &RLNWitnessInput,
 ) -> Result<[(&str, Vec<BigInt>); 8]> {
@@ -642,6 +647,10 @@ pub fn inputs_for_witness_calculation(
         .identity_path_index
         .iter()
         .for_each(|v| identity_path_index.push(BigInt::from(*v)));
+
+    if rln_witness.message_id > rln_witness.user_message_limit {
+        return Err(color_eyre::Report::msg("message_id is not within user_message_limit"))
+    }
 
     Ok([
         (

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -727,7 +727,7 @@ impl RLN<'_> {
         let mut witness_byte: Vec<u8> = Vec::new();
         input_data.read_to_end(&mut witness_byte)?;
         let (rln_witness, _) = proof_inputs_to_rln_witness(&mut self.tree, &witness_byte)?;
-        let proof_values = proof_values_from_witness(&rln_witness);
+        let proof_values = proof_values_from_witness(&rln_witness)?;
 
         let proof = generate_proof(self.witness_calculator, &self.proving_key, &rln_witness)?;
 
@@ -752,7 +752,7 @@ impl RLN<'_> {
         mut output_data: W,
     ) -> Result<()> {
         let (rln_witness, _) = deserialize_witness(&rln_witness_vec[..])?;
-        let proof_values = proof_values_from_witness(&rln_witness);
+        let proof_values = proof_values_from_witness(&rln_witness)?;
 
         let proof = generate_proof_with_witness(calculated_witness, &self.proving_key).unwrap();
 


### PR DESCRIPTION
- Adds a range check before the proof generation to ensure the provided `messageId` is within the `userMessageLimit`
- Changed corresponding types to `Result`, as now they can emit errors
- Added function level documenation
