### PR TITLE
chore(rln): expose leaves_set api

### DIFF
--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -263,6 +263,12 @@ pub extern "C" fn get_leaf(ctx: *mut RLN, index: usize, output_buffer: *mut Buff
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
+pub extern "C" fn leaves_set(ctx: *mut RLN) -> usize {
+    ctx.process().leaves_set()
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
 pub extern "C" fn set_next_leaf(ctx: *mut RLN, input_buffer: *const Buffer) -> bool {
     call!(ctx, set_next_leaf, input_buffer)
 }

--- a/rln/tests/ffi.rs
+++ b/rln/tests/ffi.rs
@@ -143,6 +143,8 @@ mod test {
         assert!(success, "RLN object creation failed");
         let rln_pointer = unsafe { &mut *rln_pointer.assume_init() };
 
+        assert_eq!(rln_pointer.leaves_set(), 0);
+
         // We generate a vector of random leaves
         let mut leaves: Vec<Fr> = Vec::new();
         let mut rng = thread_rng();
@@ -159,6 +161,7 @@ mod test {
         let input_buffer = &Buffer::from(leaves_ser.as_ref());
         let success = init_tree_with_leaves(rln_pointer, input_buffer);
         assert!(success, "init tree with leaves call failed");
+        assert_eq!(rln_pointer.leaves_set(), no_of_leaves);
 
         // We get the root of the tree obtained adding leaves in batch
         let mut output_buffer = MaybeUninit::<Buffer>::uninit();


### PR DESCRIPTION
Exposes the `leaves_set` api to allow consuming applications to have more metadata about the tree
