### PR TITLE
fix(rln): if only a single insertion, dont use batch_insert

### DIFF
--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -178,6 +178,13 @@ impl ZerokitMerkleTree for PmTree {
         start: usize,
         values: I,
     ) -> Result<()> {
+        let values = values.into_iter().collect::<Vec<_>>();
+        if values.len() == 1 {
+            return self
+                .tree
+                .set(start, values[0])
+                .map_err(|e| Report::msg(e.to_string()));
+        }
         self.tree
             .set_range(start, values)
             .map_err(|e| Report::msg(e.to_string()))


### PR DESCRIPTION
the `batch_insert` api is useful for multiple insertions while maintaining atomicity, but for single insertions, ruins performance - single insertions are atomic by 
nature so this pr circumvents it.
