### PR TITLE
Expose generate proof with witness ffi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - v0.3.5
     paths-ignore:
       - '**.md'
       - '!.github/workflows/*.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 on:
   push:
     branches:
-      - v0.3.5
-      - add-witness
+      - master
     paths-ignore:
       - '**.md'
       - '!.github/workflows/*.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - v0.3.5
+      - add-witness
     paths-ignore:
       - '**.md'
       - '!.github/workflows/*.yml'

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -363,6 +363,21 @@ pub extern "C" fn generate_rln_proof(
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
+pub extern "C" fn generate_rln_proof_with_witness(
+    ctx: *mut RLN,
+    input_buffer: *const Buffer,
+    output_buffer: *mut Buffer,
+) -> bool {
+    call_with_output_arg!(
+        ctx,
+        generate_rln_proof_with_witness,
+        output_buffer,
+        input_buffer
+    )
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
 pub extern "C" fn verify_rln_proof(
     ctx: *const RLN,
     proof_buffer: *const Buffer,

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -720,9 +720,9 @@ impl RLN<'_> {
         mut output_data: W,
     ) -> Result<()> {
         // We read input RLN witness and we serialize_compressed it
-        let mut witness_byte: Vec<u8> = Vec::new();
-        input_data.read_to_end(&mut witness_byte)?;
-        let (rln_witness, _) = proof_inputs_to_rln_witness(&mut self.tree, &witness_byte)?;
+        let mut input_byte: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut input_byte)?;
+        let (rln_witness, _) = proof_inputs_to_rln_witness(&mut self.tree, &input_byte)?;
         let proof_values = proof_values_from_witness(&rln_witness);
 
         let proof = generate_proof(self.witness_calculator, &self.proving_key, &rln_witness)?;
@@ -735,22 +735,22 @@ impl RLN<'_> {
         Ok(())
     }
 
-    // TODO: this function seems to use redundant witness (as bigint and serialized) and should be refactored
     // Generate RLN Proof using a witness calculated from outside zerokit
     //
     // output_data is  [ proof<128> | root<32> | epoch<32> | share_x<32> | share_y<32> | nullifier<32> | rln_identifier<32> ]
     // we skip it from documentation for now
     #[doc(hidden)]
-    pub fn generate_rln_proof_with_witness<W: Write>(
+    pub fn generate_rln_proof_with_witness<R: Read, W: Write>(
         &mut self,
-        calculated_witness: Vec<BigInt>,
-        rln_witness_vec: Vec<u8>,
+        mut input_data: R,
         mut output_data: W,
     ) -> Result<()> {
-        let (rln_witness, _) = deserialize_witness(&rln_witness_vec[..])?;
+        let mut witness_byte: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut witness_byte)?;
+        let (rln_witness, _) = deserialize_witness(&witness_byte)?;
         let proof_values = proof_values_from_witness(&rln_witness);
 
-        let proof = generate_proof_with_witness(calculated_witness, &self.proving_key).unwrap();
+        let proof = generate_proof(self.witness_calculator, &self.proving_key, &rln_witness)?;
 
         // Note: we export a serialization of ark-groth16::Proof not semaphore::Proof
         // This proof is compressed, i.e. 128 bytes long
@@ -1800,13 +1800,10 @@ mod test {
             .collect();
 
         // Generating the proof
+        let mut input_buffer = Cursor::new(serialized_witness);
         let mut output_buffer = Cursor::new(Vec::<u8>::new());
-        rln.generate_rln_proof_with_witness(
-            calculated_witness_vec,
-            serialized_witness,
-            &mut output_buffer,
-        )
-        .unwrap();
+        rln.generate_rln_proof_with_witness(&mut input_buffer, &mut output_buffer)
+            .unwrap();
 
         // output_data is [ proof<128> | share_y<32> | nullifier<32> | root<32> | epoch<32> | share_x<32> | rln_identifier<32> ]
         let mut proof_data = output_buffer.into_inner();


### PR DESCRIPTION
* Expose generate proof with witness ffi. This aims to allow other programming languages using the ffi to provide its own witness.
* Based on v0.3.4 so that its compatible with RLN v1. Ignore diff since the PR can't be based in a tag.