### PR TITLE
chore(rln): return empty metadata if it doesnt exist

### DIFF
--- a/rln/src/circuit.rs
+++ b/rln/src/circuit.rs
@@ -77,7 +77,7 @@ pub fn zkey_from_folder(
 }
 
 // Loads the verification key from a bytes vector
-pub fn vk_from_raw(vk_data: &Vec<u8>, zkey_data: &Vec<u8>) -> Result<VerifyingKey<Curve>> {
+pub fn vk_from_raw(vk_data: &[u8], zkey_data: &Vec<u8>) -> Result<VerifyingKey<Curve>> {
     let verifying_key: VerifyingKey<Curve>;
 
     if !vk_data.is_empty() {

--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -246,7 +246,8 @@ impl ZerokitMerkleTree for PmTree {
         let data = self.tree.db.get(METADATA_KEY)?;
 
         if data.is_none() {
-            return Err(Report::msg("metadata does not exist"));
+            // send empty Metadata
+            return Ok(Vec::new());
         }
         Ok(data.unwrap())
     }

--- a/rln/src/public_api_tests.rs
+++ b/rln/src/public_api_tests.rs
@@ -977,7 +977,7 @@ fn test_get_leaf() {
 }
 
 #[test]
-fn test_metadata() {
+fn test_valid_metadata() {
     let tree_height = TEST_TREE_HEIGHT;
 
     let input_buffer =
@@ -992,4 +992,19 @@ fn test_metadata() {
     let received_metadata = buffer.into_inner();
 
     assert_eq!(arbitrary_metadata, received_metadata);
+}
+
+#[test]
+fn test_empty_metadata() {
+    let tree_height = TEST_TREE_HEIGHT;
+
+    let input_buffer =
+        Cursor::new(json!({ "resources_folder": TEST_RESOURCES_FOLDER }).to_string());
+    let rln = RLN::new(tree_height, input_buffer).unwrap();
+
+    let mut buffer = Cursor::new(Vec::<u8>::new());
+    rln.get_metadata(&mut buffer).unwrap();
+    let received_metadata = buffer.into_inner();
+
+    assert_eq!(received_metadata.len(), 0);
 }


### PR DESCRIPTION
Previously, we returned an error if the metadata field was empty in the db. Now we return an empty vec so that clients can handle the error appropriately.
See: https://github.com/waku-org/nwaku/issues/2471
