### PR TITLE
chore(rln): add QoL traits to the Hasher associated type in MerkleTree trait

### DIFF
--- a/utils/src/merkle_tree/merkle_tree.rs
+++ b/utils/src/merkle_tree/merkle_tree.rs
@@ -21,7 +21,7 @@ use color_eyre::Result;
 /// and the hash function used to initialize a Merkle Tree implementation
 pub trait Hasher {
     /// Type of the leaf and tree node
-    type Fr: Clone + Copy + Eq;
+    type Fr: Clone + Copy + Eq + Default + std::fmt::Debug + std::fmt::Display + FromStr;
 
     /// Returns the default tree leaf
     fn default_leaf() -> Self::Fr;


### PR DESCRIPTION
Few QoL traits to assist debugging.
