### PR TITLE
fix(rln-wasm): dont run benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["rln", "rln-cli", "rln-wasm", "utils"]
+default-members = ["rln", "rln-cli", "utils"]
 resolver = "2"
 
 # Compilation profile for any non-workspace member.

--- a/rln-wasm/Cargo.toml
+++ b/rln-wasm/Cargo.toml
@@ -3,6 +3,9 @@ name = "rln-wasm"
 version = "0.0.13"
 edition = "2021"
 license = "MIT or Apache2"
+autobenches = false
+autotests = false
+autobins = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -30,4 +33,3 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
 wasm-bindgen-futures = "0.4.33"
-

--- a/rln-wasm/Makefile.toml
+++ b/rln-wasm/Makefile.toml
@@ -29,3 +29,7 @@ args = ["login"]
 [tasks.publish]
 command = "wasm-pack"
 args = ["publish", "--access", "public", "--target", "web"]
+
+[tasks.bench]
+command = "echo"
+args = ["'No benchmarks available for this project'"]


### PR DESCRIPTION
- **fix(rln-wasm): dont run benchmarks**

This PR excludes rln-wasm from default-members of the workspace and thereby allows `cargo bench` and `cargo make bench` to be ran from the root of the project.

thanks for the report @seemenkina
