### PR TITLE
chore(rln): tests and benchmarks review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "color-eyre",
  "criterion 0.4.0",
  "hex-literal",
+ "lazy_static 1.4.0",
  "num-bigint",
  "num-traits",
  "pmtree",

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -87,3 +87,7 @@ harness = false
 [[bench]]
 name = "circuit_loading_benchmark"
 harness = false
+
+[[bench]]
+name = "poseidon_tree_benchmark"
+harness = false

--- a/rln/benches/poseidon_tree_benchmark.rs
+++ b/rln/benches/poseidon_tree_benchmark.rs
@@ -1,0 +1,73 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rln::{
+    circuit::{Fr, TEST_TREE_HEIGHT},
+    hashers::PoseidonHash,
+};
+use utils::{FullMerkleTree, OptimalMerkleTree, ZerokitMerkleTree};
+
+pub fn get_leaves(n: u32) -> Vec<Fr> {
+    (0..n).map(|s| Fr::from(s)).collect()
+}
+
+pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
+    c.bench_function("OptMTree::full_height_gen", |b| {
+        b.iter(|| {
+            OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
+        })
+    });
+
+    let mut group = c.benchmark_group("Set");
+    for &n in [1u32, 10, 100].iter() {
+        let leaves = get_leaves(n);
+
+        let mut tree = OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
+        group.bench_function(BenchmarkId::new("OptMTree::set", n), |b| {
+            b.iter(|| {
+                for (i, l) in leaves.iter().enumerate() {
+                    let _ = tree.set(i, *l);
+                }
+            })
+        });
+
+        let mut tree_r = OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
+        group.bench_function(BenchmarkId::new("OptMTree::set_range", n), |b| {
+            b.iter(|| tree_r.set_range(0, leaves.iter().cloned()))
+        });
+    }
+    group.finish();
+}
+
+pub fn full_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
+    c.bench_function("FullMTree::full_height_gen", |b| {
+        b.iter(|| {
+            FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
+        })
+    });
+
+    let mut group = c.benchmark_group("Set");
+    for &n in [1u32, 10, 100].iter() {
+        let leaves = get_leaves(n);
+
+        let mut tree = FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
+        group.bench_function(BenchmarkId::new("FullMTree::set", n), |b| {
+            b.iter(|| {
+                for (i, l) in leaves.iter().enumerate() {
+                    let _ = tree.set(i, *l);
+                }
+            })
+        });
+
+        let mut tree_r = FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
+        group.bench_function(BenchmarkId::new("FullMTree::set_range", n), |b| {
+            b.iter(|| tree_r.set_range(0, leaves.iter().cloned()))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    optimal_merkle_tree_poseidon_benchmark,
+    full_merkle_tree_poseidon_benchmark
+);
+criterion_main!(benches);

--- a/rln/benches/poseidon_tree_benchmark.rs
+++ b/rln/benches/poseidon_tree_benchmark.rs
@@ -10,7 +10,7 @@ pub fn get_leaves(n: u32) -> Vec<Fr> {
 }
 
 pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
-    c.bench_function("OptMTree::full_height_gen", |b| {
+    c.bench_function("OptimalMerkleTree::full_height_gen", |b| {
         b.iter(|| {
             OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
         })
@@ -21,7 +21,7 @@ pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
         let leaves = get_leaves(n);
 
         let mut tree = OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
-        group.bench_function(BenchmarkId::new("OptMTree::set", n), |b| {
+        group.bench_function(BenchmarkId::new("OptimalMerkleTree::set", n), |b| {
             b.iter(|| {
                 for (i, l) in leaves.iter().enumerate() {
                     let _ = tree.set(i, *l);
@@ -30,7 +30,7 @@ pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
         });
 
         let mut tree_r = OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
-        group.bench_function(BenchmarkId::new("OptMTree::set_range", n), |b| {
+        group.bench_function(BenchmarkId::new("OptimalMerkleTree::set_range", n), |b| {
             b.iter(|| tree_r.set_range(0, leaves.iter().cloned()))
         });
     }
@@ -38,7 +38,7 @@ pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
 }
 
 pub fn full_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
-    c.bench_function("FullMTree::full_height_gen", |b| {
+    c.bench_function("FullMerkleTree::full_height_gen", |b| {
         b.iter(|| {
             FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
         })
@@ -49,7 +49,7 @@ pub fn full_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
         let leaves = get_leaves(n);
 
         let mut tree = FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
-        group.bench_function(BenchmarkId::new("FullMTree::set", n), |b| {
+        group.bench_function(BenchmarkId::new("FullMerkleTree::set", n), |b| {
             b.iter(|| {
                 for (i, l) in leaves.iter().enumerate() {
                     let _ = tree.set(i, *l);
@@ -58,7 +58,7 @@ pub fn full_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
         });
 
         let mut tree_r = FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
-        group.bench_function(BenchmarkId::new("FullMTree::set_range", n), |b| {
+        group.bench_function(BenchmarkId::new("FullMerkleTree::set_range", n), |b| {
             b.iter(|| tree_r.set_range(0, leaves.iter().cloned()))
         });
     }

--- a/rln/benches/poseidon_tree_benchmark.rs
+++ b/rln/benches/poseidon_tree_benchmark.rs
@@ -10,7 +10,7 @@ pub fn get_leaves(n: u32) -> Vec<Fr> {
 }
 
 pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
-    c.bench_function("OptimalMerkleTree::full_height_gen", |b| {
+    c.bench_function("OptimalMerkleTree::<Poseidon>::full_height_gen", |b| {
         b.iter(|| {
             OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
         })
@@ -21,23 +21,27 @@ pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
         let leaves = get_leaves(n);
 
         let mut tree = OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
-        group.bench_function(BenchmarkId::new("OptimalMerkleTree::set", n), |b| {
-            b.iter(|| {
-                for (i, l) in leaves.iter().enumerate() {
-                    let _ = tree.set(i, *l);
-                }
-            })
-        });
+        group.bench_function(
+            BenchmarkId::new("OptimalMerkleTree::<Poseidon>::set", n),
+            |b| {
+                b.iter(|| {
+                    for (i, l) in leaves.iter().enumerate() {
+                        let _ = tree.set(i, *l);
+                    }
+                })
+            },
+        );
 
-        group.bench_function(BenchmarkId::new("OptimalMerkleTree::set_range", n), |b| {
-            b.iter(|| tree.set_range(0, leaves.iter().cloned()))
-        });
+        group.bench_function(
+            BenchmarkId::new("OptimalMerkleTree::<Poseidon>::set_range", n),
+            |b| b.iter(|| tree.set_range(0, leaves.iter().cloned())),
+        );
     }
     group.finish();
 }
 
 pub fn full_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
-    c.bench_function("FullMerkleTree::full_height_gen", |b| {
+    c.bench_function("FullMerkleTree::<Poseidon>::full_height_gen", |b| {
         b.iter(|| {
             FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
         })
@@ -48,17 +52,21 @@ pub fn full_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
         let leaves = get_leaves(n);
 
         let mut tree = FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
-        group.bench_function(BenchmarkId::new("FullMerkleTree::set", n), |b| {
-            b.iter(|| {
-                for (i, l) in leaves.iter().enumerate() {
-                    let _ = tree.set(i, *l);
-                }
-            })
-        });
+        group.bench_function(
+            BenchmarkId::new("FullMerkleTree::<Poseidon>::set", n),
+            |b| {
+                b.iter(|| {
+                    for (i, l) in leaves.iter().enumerate() {
+                        let _ = tree.set(i, *l);
+                    }
+                })
+            },
+        );
 
-        group.bench_function(BenchmarkId::new("FullMerkleTree::set_range", n), |b| {
-            b.iter(|| tree.set_range(0, leaves.iter().cloned()))
-        });
+        group.bench_function(
+            BenchmarkId::new("FullMerkleTree::<Poseidon>::set_range", n),
+            |b| b.iter(|| tree.set_range(0, leaves.iter().cloned())),
+        );
     }
     group.finish();
 }

--- a/rln/benches/poseidon_tree_benchmark.rs
+++ b/rln/benches/poseidon_tree_benchmark.rs
@@ -29,9 +29,8 @@ pub fn optimal_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
             })
         });
 
-        let mut tree_r = OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
         group.bench_function(BenchmarkId::new("OptimalMerkleTree::set_range", n), |b| {
-            b.iter(|| tree_r.set_range(0, leaves.iter().cloned()))
+            b.iter(|| tree.set_range(0, leaves.iter().cloned()))
         });
     }
     group.finish();
@@ -57,9 +56,8 @@ pub fn full_merkle_tree_poseidon_benchmark(c: &mut Criterion) {
             })
         });
 
-        let mut tree_r = FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
         group.bench_function(BenchmarkId::new("FullMerkleTree::set_range", n), |b| {
-            b.iter(|| tree_r.set_range(0, leaves.iter().cloned()))
+            b.iter(|| tree.set_range(0, leaves.iter().cloned()))
         });
     }
     group.finish();

--- a/rln/tests/ffi.rs
+++ b/rln/tests/ffi.rs
@@ -398,14 +398,6 @@ mod test {
         );
     }
 
-    fn fread(fpath: &str) -> Vec<u8> {
-        let mut file = File::open(&fpath).expect("no file found");
-        let metadata = std::fs::metadata(&fpath).expect("unable to read metadata");
-        let mut buffer = vec![0; metadata.len() as usize];
-        file.read_exact(&mut buffer).expect("buffer overflow");
-        buffer
-    }
-
     #[test]
     // Creating a RLN with raw data should generate same results as using a path to resources
     fn test_rln_raw_ffi() {
@@ -416,15 +408,34 @@ mod test {
         let root_rln_folder = get_tree_root(rln_pointer);
 
         // Reading the raw data from the files required for instantiating a RLN instance using raw data
-        let circom_data = &Buffer::from(fread("./resources/tree_height_20/rln.wasm").as_ref());
-        let vk_data =
-            &Buffer::from(fread("./resources/tree_height_20/verification_key.json").as_ref());
+        let circom_path = "./resources/tree_height_20/rln.wasm";
+        let mut circom_file = File::open(&circom_path).expect("no file found");
+        let metadata = std::fs::metadata(&circom_path).expect("unable to read metadata");
+        let mut circom_buffer = vec![0; metadata.len() as usize];
+        circom_file
+            .read_exact(&mut circom_buffer)
+            .expect("buffer overflow");
 
         #[cfg(feature = "arkzkey")]
         let zkey_path = "./resources/tree_height_20/rln_final.arkzkey";
         #[cfg(not(feature = "arkzkey"))]
         let zkey_path = "./resources/tree_height_20/rln_final.zkey";
-        let zkey_data = &Buffer::from(fread(zkey_path).as_ref());
+        let mut zkey_file = File::open(&zkey_path).expect("no file found");
+        let metadata = std::fs::metadata(&zkey_path).expect("unable to read metadata");
+        let mut zkey_buffer = vec![0; metadata.len() as usize];
+        zkey_file
+            .read_exact(&mut zkey_buffer)
+            .expect("buffer overflow");
+
+        let vk_path = "./resources/tree_height_20/verification_key.json";
+        let mut vk_file = File::open(&vk_path).expect("no file found");
+        let metadata = std::fs::metadata(&vk_path).expect("unable to read metadata");
+        let mut vk_buffer = vec![0; metadata.len() as usize];
+        vk_file.read_exact(&mut vk_buffer).expect("buffer overflow");
+
+        let circom_data = &Buffer::from(&circom_buffer[..]);
+        let zkey_data = &Buffer::from(&zkey_buffer[..]);
+        let vk_data = &Buffer::from(&vk_buffer[..]);
 
         // Creating a RLN instance passing the raw data
         let mut rln_pointer_raw_bytes = MaybeUninit::<*mut RLN>::uninit();

--- a/rln/tests/poseidon_tree.rs
+++ b/rln/tests/poseidon_tree.rs
@@ -9,15 +9,13 @@ mod test {
     use utils::{FullMerkleTree, OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree};
 
     #[test]
-    /// The test is checked correctness for `FullMerkleTree` and `OptimalMerkleTree`
+    /// The test is checked correctness for `FullMerkleTree` and `OptimalMerkleTree` with Poseidon hash
     fn test_zerokit_merkle_implementations() {
-        let tree_height = TEST_TREE_HEIGHT;
         let sample_size = 100;
-
         let leaves: Vec<Fr> = (0..sample_size).map(|s| Fr::from(s)).collect();
 
-        let mut tree_full = FullMerkleTree::<PoseidonHash>::default(tree_height).unwrap();
-        let mut tree_opt = OptimalMerkleTree::<PoseidonHash>::default(tree_height).unwrap();
+        let mut tree_full = FullMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
+        let mut tree_opt = OptimalMerkleTree::<PoseidonHash>::default(TEST_TREE_HEIGHT).unwrap();
 
         for i in 0..sample_size.try_into().unwrap() {
             tree_full.set(i, leaves[i]).unwrap();

--- a/rln/tests/poseidon_tree.rs
+++ b/rln/tests/poseidon_tree.rs
@@ -9,43 +9,22 @@ mod test {
     use utils::{FullMerkleTree, OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree};
 
     #[test]
-    /// A basic performance comparison between the two supported Merkle Tree implementations
-    fn test_zerokit_merkle_implementations_performances() {
-        use std::time::{Duration, Instant};
-
-        let tree_height = 20;
+    /// The test is checked correctness for `FullMerkleTree` and `OptimalMerkleTree`
+    fn test_zerokit_merkle_implementations() {
+        let tree_height = TEST_TREE_HEIGHT;
         let sample_size = 100;
 
         let leaves: Vec<Fr> = (0..sample_size).map(|s| Fr::from(s)).collect();
-
-        let mut gen_time_full: u128 = 0;
-        let mut upd_time_full: u128 = 0;
-        let mut gen_time_opt: u128 = 0;
-        let mut upd_time_opt: u128 = 0;
-
-        for _ in 0..sample_size.try_into().unwrap() {
-            let now = Instant::now();
-            FullMerkleTree::<PoseidonHash>::default(tree_height).unwrap();
-            gen_time_full += now.elapsed().as_nanos();
-
-            let now = Instant::now();
-            OptimalMerkleTree::<PoseidonHash>::default(tree_height).unwrap();
-            gen_time_opt += now.elapsed().as_nanos();
-        }
 
         let mut tree_full = FullMerkleTree::<PoseidonHash>::default(tree_height).unwrap();
         let mut tree_opt = OptimalMerkleTree::<PoseidonHash>::default(tree_height).unwrap();
 
         for i in 0..sample_size.try_into().unwrap() {
-            let now = Instant::now();
             tree_full.set(i, leaves[i]).unwrap();
-            upd_time_full += now.elapsed().as_nanos();
             let proof = tree_full.proof(i).expect("index should be set");
             assert_eq!(proof.leaf_index(), i);
 
-            let now = Instant::now();
             tree_opt.set(i, leaves[i]).unwrap();
-            upd_time_opt += now.elapsed().as_nanos();
             let proof = tree_opt.proof(i).expect("index should be set");
             assert_eq!(proof.leaf_index(), i);
         }
@@ -55,26 +34,5 @@ mod test {
         let tree_opt_root = tree_opt.root();
 
         assert_eq!(tree_full_root, tree_opt_root);
-
-        println!(" Average tree generation time:");
-        println!(
-            "   - Full Merkle Tree:  {:?}",
-            Duration::from_nanos((gen_time_full / sample_size).try_into().unwrap())
-        );
-        println!(
-            "   - Optimal Merkle Tree: {:?}",
-            Duration::from_nanos((gen_time_opt / sample_size).try_into().unwrap())
-        );
-
-        println!(" Average update_next execution time:");
-        println!(
-            "   - Full Merkle Tree: {:?}",
-            Duration::from_nanos((upd_time_full / sample_size).try_into().unwrap())
-        );
-
-        println!(
-            "   - Optimal Merkle Tree: {:?}",
-            Duration::from_nanos((upd_time_opt / sample_size).try_into().unwrap())
-        );
     }
 }

--- a/rln/tests/protocol.rs
+++ b/rln/tests/protocol.rs
@@ -71,7 +71,6 @@ mod test {
     #[test]
     // We test Merkle tree generation, proofs and verification
     fn test_merkle_proof() {
-        let tree_height = TEST_TREE_HEIGHT;
         let leaf_index = 3;
 
         // generate identity
@@ -82,7 +81,7 @@ mod test {
         // generate merkle tree
         let default_leaf = Fr::from(0);
         let mut tree = PoseidonTree::new(
-            tree_height,
+            TEST_TREE_HEIGHT,
             default_leaf,
             ConfigOf::<PoseidonTree>::default(),
         )
@@ -92,141 +91,49 @@ mod test {
         // We check correct computation of the root
         let root = tree.root();
 
-        if TEST_TREE_HEIGHT == 20 {
-            assert_eq!(
-                root,
-                BigInt([
-                    4939322235247991215,
-                    5110804094006647505,
-                    4427606543677101242,
-                    910933464535675827
-                ])
-                .into()
-            );
-        }
+        assert_eq!(
+            root,
+            BigInt([
+                4939322235247991215,
+                5110804094006647505,
+                4427606543677101242,
+                910933464535675827
+            ])
+            .into()
+        );
 
         let merkle_proof = tree.proof(leaf_index).expect("proof should exist");
         let path_elements = merkle_proof.get_path_elements();
         let identity_path_index = merkle_proof.get_path_index();
 
         // We check correct computation of the path and indexes
-        // These values refers to TEST_TREE_HEIGHT == 16
-        let mut expected_path_elements = vec![
-            str_to_fr(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x1069673dcdb12263df301a6ff584a7ec261a44cb9dc68df067a4774460b1f1e1",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x18f43331537ee2af2e3d758d50f72106467c6eea50371dd528d57eb2b856d238",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x07f9d837cb17b0d36320ffe93ba52345f1b728571a568265caac97559dbc952a",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2b94cf5e8746b3f5c9631f4c5df32907a699c58c94b2ad4d7b5cec1639183f55",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2dee93c5a666459646ea7d22cca9e1bcfed71e6951b953611d11dda32ea09d78",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x078295e5a22b84e982cf601eb639597b8b0515a88cb5ac7fa8a4aabe3c87349d",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2fa5e5f18f6027a6501bec864564472a616b2e274a41211a444cbe3a99f3cc61",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x0e884376d0d8fd21ecb780389e941f66e45e7acce3e228ab3e2156a614fcd747",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x1b7201da72494f1e28717ad1a52eb469f95892f957713533de6175e5da190af2",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x1f8d8822725e36385200c0b201249819a6e6e1e4650808b5bebc6bface7d7636",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2c5d82f66c914bafb9701589ba8cfcfb6162b0a12acf88a8d0879a0471b5f85a",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x14c54148a0940bb820957f5adf3fa1134ef5c4aaa113f4646458f270e0bfbfd0",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x190d33b12f986f961e10c0ee44d8b9af11be25588cad89d416118e4bf4ebe80c",
-                16,
-            )
-            .unwrap(),
-        ];
+        let expected_path_elements: Vec<Fr> = [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864",
+            "0x1069673dcdb12263df301a6ff584a7ec261a44cb9dc68df067a4774460b1f1e1",
+            "0x18f43331537ee2af2e3d758d50f72106467c6eea50371dd528d57eb2b856d238",
+            "0x07f9d837cb17b0d36320ffe93ba52345f1b728571a568265caac97559dbc952a",
+            "0x2b94cf5e8746b3f5c9631f4c5df32907a699c58c94b2ad4d7b5cec1639183f55",
+            "0x2dee93c5a666459646ea7d22cca9e1bcfed71e6951b953611d11dda32ea09d78",
+            "0x078295e5a22b84e982cf601eb639597b8b0515a88cb5ac7fa8a4aabe3c87349d",
+            "0x2fa5e5f18f6027a6501bec864564472a616b2e274a41211a444cbe3a99f3cc61",
+            "0x0e884376d0d8fd21ecb780389e941f66e45e7acce3e228ab3e2156a614fcd747",
+            "0x1b7201da72494f1e28717ad1a52eb469f95892f957713533de6175e5da190af2",
+            "0x1f8d8822725e36385200c0b201249819a6e6e1e4650808b5bebc6bface7d7636",
+            "0x2c5d82f66c914bafb9701589ba8cfcfb6162b0a12acf88a8d0879a0471b5f85a",
+            "0x14c54148a0940bb820957f5adf3fa1134ef5c4aaa113f4646458f270e0bfbfd0",
+            "0x190d33b12f986f961e10c0ee44d8b9af11be25588cad89d416118e4bf4ebe80c",
+            "0x22f98aa9ce704152ac17354914ad73ed1167ae6596af510aa5b3649325e06c92",
+            "0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323",
+            "0x2e8186e558698ec1c67af9c14d463ffc470043c9c2988b954d75dd643f36b992",
+            "0x0f57c5571e9a4eab49e2c8cf050dae948aef6ead647392273546249d1c1ff10f",
+            "0x1830ee67b5fb554ad5f63d4388800e1cfe78e310697d46e43c9ce36134f72cca",
+        ]
+        .map(|e| str_to_fr(e, 16).unwrap())
+        .to_vec();
 
-        let mut expected_identity_path_index: Vec<u8> =
-            vec![1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        // We add the remaining elements for the case TEST_TREE_HEIGHT = 20
-        if TEST_TREE_HEIGHT == 20 {
-            expected_path_elements.append(&mut vec![
-                str_to_fr(
-                    "0x22f98aa9ce704152ac17354914ad73ed1167ae6596af510aa5b3649325e06c92",
-                    16,
-                )
-                .unwrap(),
-                str_to_fr(
-                    "0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323",
-                    16,
-                )
-                .unwrap(),
-                str_to_fr(
-                    "0x2e8186e558698ec1c67af9c14d463ffc470043c9c2988b954d75dd643f36b992",
-                    16,
-                )
-                .unwrap(),
-                str_to_fr(
-                    "0x0f57c5571e9a4eab49e2c8cf050dae948aef6ead647392273546249d1c1ff10f",
-                    16,
-                )
-                .unwrap(),
-            ]);
-            expected_identity_path_index.append(&mut vec![0, 0, 0, 0]);
-        }
-
-        if TEST_TREE_HEIGHT == 20 {
-            expected_path_elements.append(&mut vec![str_to_fr(
-                "0x1830ee67b5fb554ad5f63d4388800e1cfe78e310697d46e43c9ce36134f72cca",
-                16,
-            )
-            .unwrap()]);
-            expected_identity_path_index.append(&mut vec![0]);
-        }
+        let expected_identity_path_index: Vec<u8> =
+            vec![1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
         assert_eq!(path_elements, expected_path_elements);
         assert_eq!(identity_path_index, expected_identity_path_index);
@@ -260,7 +167,6 @@ mod test {
     #[test]
     // We test a RLN proof generation and verification
     fn test_end_to_end() {
-        let tree_height = TEST_TREE_HEIGHT;
         let leaf_index = 3;
 
         // Generate identity pair
@@ -271,7 +177,7 @@ mod test {
         //// generate merkle tree
         let default_leaf = Fr::from(0);
         let mut tree = PoseidonTree::new(
-            tree_height,
+            TEST_TREE_HEIGHT,
             default_leaf,
             ConfigOf::<PoseidonTree>::default(),
         )

--- a/rln/tests/public.rs
+++ b/rln/tests/public.rs
@@ -14,13 +14,12 @@ mod test {
     #[test]
     // This test is similar to the one in lib, but uses only public API
     fn test_merkle_proof() {
-        let tree_height = TEST_TREE_HEIGHT;
         let leaf_index = 3;
         let user_message_limit = 1;
 
         let input_buffer =
             Cursor::new(json!({ "resources_folder": TEST_RESOURCES_FOLDER }).to_string());
-        let mut rln = RLN::new(tree_height, input_buffer).unwrap();
+        let mut rln = RLN::new(TEST_TREE_HEIGHT, input_buffer).unwrap();
 
         // generate identity
         let identity_secret_hash = hash_to_field(b"test-merkle-proof");
@@ -36,17 +35,15 @@ mod test {
         rln.get_root(&mut buffer).unwrap();
         let (root, _) = bytes_le_to_fr(&buffer.into_inner());
 
-        if TEST_TREE_HEIGHT == 20 {
-            assert_eq!(
-                root,
-                Fr::from(BigInt([
-                    17110646155607829651,
-                    5040045984242729823,
-                    6965416728592533086,
-                    2328960363755461975
-                ]))
-            );
-        }
+        assert_eq!(
+            root,
+            Fr::from(BigInt([
+                17110646155607829651,
+                5040045984242729823,
+                6965416728592533086,
+                2328960363755461975
+            ]))
+        );
 
         // We check correct computation of merkle proof
         let mut buffer = Cursor::new(Vec::<u8>::new());
@@ -57,122 +54,33 @@ mod test {
         let (identity_path_index, _) = bytes_le_to_vec_u8(&buffer_inner[read..].to_vec()).unwrap();
 
         // We check correct computation of the path and indexes
-        let mut expected_path_elements = vec![
-            str_to_fr(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x1069673dcdb12263df301a6ff584a7ec261a44cb9dc68df067a4774460b1f1e1",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x18f43331537ee2af2e3d758d50f72106467c6eea50371dd528d57eb2b856d238",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x07f9d837cb17b0d36320ffe93ba52345f1b728571a568265caac97559dbc952a",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2b94cf5e8746b3f5c9631f4c5df32907a699c58c94b2ad4d7b5cec1639183f55",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2dee93c5a666459646ea7d22cca9e1bcfed71e6951b953611d11dda32ea09d78",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x078295e5a22b84e982cf601eb639597b8b0515a88cb5ac7fa8a4aabe3c87349d",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2fa5e5f18f6027a6501bec864564472a616b2e274a41211a444cbe3a99f3cc61",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x0e884376d0d8fd21ecb780389e941f66e45e7acce3e228ab3e2156a614fcd747",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x1b7201da72494f1e28717ad1a52eb469f95892f957713533de6175e5da190af2",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x1f8d8822725e36385200c0b201249819a6e6e1e4650808b5bebc6bface7d7636",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x2c5d82f66c914bafb9701589ba8cfcfb6162b0a12acf88a8d0879a0471b5f85a",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x14c54148a0940bb820957f5adf3fa1134ef5c4aaa113f4646458f270e0bfbfd0",
-                16,
-            )
-            .unwrap(),
-            str_to_fr(
-                "0x190d33b12f986f961e10c0ee44d8b9af11be25588cad89d416118e4bf4ebe80c",
-                16,
-            )
-            .unwrap(),
-        ];
+        let expected_path_elements: Vec<Fr> = [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864",
+            "0x1069673dcdb12263df301a6ff584a7ec261a44cb9dc68df067a4774460b1f1e1",
+            "0x18f43331537ee2af2e3d758d50f72106467c6eea50371dd528d57eb2b856d238",
+            "0x07f9d837cb17b0d36320ffe93ba52345f1b728571a568265caac97559dbc952a",
+            "0x2b94cf5e8746b3f5c9631f4c5df32907a699c58c94b2ad4d7b5cec1639183f55",
+            "0x2dee93c5a666459646ea7d22cca9e1bcfed71e6951b953611d11dda32ea09d78",
+            "0x078295e5a22b84e982cf601eb639597b8b0515a88cb5ac7fa8a4aabe3c87349d",
+            "0x2fa5e5f18f6027a6501bec864564472a616b2e274a41211a444cbe3a99f3cc61",
+            "0x0e884376d0d8fd21ecb780389e941f66e45e7acce3e228ab3e2156a614fcd747",
+            "0x1b7201da72494f1e28717ad1a52eb469f95892f957713533de6175e5da190af2",
+            "0x1f8d8822725e36385200c0b201249819a6e6e1e4650808b5bebc6bface7d7636",
+            "0x2c5d82f66c914bafb9701589ba8cfcfb6162b0a12acf88a8d0879a0471b5f85a",
+            "0x14c54148a0940bb820957f5adf3fa1134ef5c4aaa113f4646458f270e0bfbfd0",
+            "0x190d33b12f986f961e10c0ee44d8b9af11be25588cad89d416118e4bf4ebe80c",
+            "0x22f98aa9ce704152ac17354914ad73ed1167ae6596af510aa5b3649325e06c92",
+            "0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323",
+            "0x2e8186e558698ec1c67af9c14d463ffc470043c9c2988b954d75dd643f36b992",
+            "0x0f57c5571e9a4eab49e2c8cf050dae948aef6ead647392273546249d1c1ff10f",
+            "0x1830ee67b5fb554ad5f63d4388800e1cfe78e310697d46e43c9ce36134f72cca",
+        ]
+        .map(|e| str_to_fr(e, 16).unwrap())
+        .to_vec();
 
-        let mut expected_identity_path_index: Vec<u8> =
-            vec![1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
-        // We add the remaining elements for the case TEST_TREE_HEIGHT = 20
-        if TEST_TREE_HEIGHT == 20 {
-            expected_path_elements.append(&mut vec![
-                str_to_fr(
-                    "0x22f98aa9ce704152ac17354914ad73ed1167ae6596af510aa5b3649325e06c92",
-                    16,
-                )
-                .unwrap(),
-                str_to_fr(
-                    "0x2a7c7c9b6ce5880b9f6f228d72bf6a575a526f29c66ecceef8b753d38bba7323",
-                    16,
-                )
-                .unwrap(),
-                str_to_fr(
-                    "0x2e8186e558698ec1c67af9c14d463ffc470043c9c2988b954d75dd643f36b992",
-                    16,
-                )
-                .unwrap(),
-                str_to_fr(
-                    "0x0f57c5571e9a4eab49e2c8cf050dae948aef6ead647392273546249d1c1ff10f",
-                    16,
-                )
-                .unwrap(),
-            ]);
-            expected_identity_path_index.append(&mut vec![0, 0, 0, 0]);
-        }
-
-        if TEST_TREE_HEIGHT == 20 {
-            expected_path_elements.append(&mut vec![str_to_fr(
-                "0x1830ee67b5fb554ad5f63d4388800e1cfe78e310697d46e43c9ce36134f72cca",
-                16,
-            )
-            .unwrap()]);
-            expected_identity_path_index.append(&mut vec![0]);
-        }
+        let expected_identity_path_index: Vec<u8> =
+            vec![1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
         assert_eq!(path_elements, expected_path_elements);
         assert_eq!(identity_path_index, expected_identity_path_index);

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -18,6 +18,7 @@ color-eyre = "=0.6.2"
 pmtree = { package = "pmtree", version = "=2.0.0", optional = true}
 sled = "=0.34.7"
 serde = "=1.0.163"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 ark-bn254 = "=0.4.0"

--- a/utils/benches/merkle_tree_benchmark.rs
+++ b/utils/benches/merkle_tree_benchmark.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use hex_literal::hex;
+use lazy_static::lazy_static;
 use std::{fmt::Display, str::FromStr};
 use tiny_keccak::{Hasher as _, Keccak};
 use zerokit_utils::{
@@ -45,22 +46,24 @@ impl FromStr for TestFr {
     }
 }
 
-pub fn optimal_merkle_tree_benchmark(c: &mut Criterion) {
-    let mut tree =
-        OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
-            .unwrap();
-
-    let leaves = [
+lazy_static! {
+    static ref LEAVES: [TestFr; 4] = [
         hex!("0000000000000000000000000000000000000000000000000000000000000001"),
         hex!("0000000000000000000000000000000000000000000000000000000000000002"),
         hex!("0000000000000000000000000000000000000000000000000000000000000003"),
         hex!("0000000000000000000000000000000000000000000000000000000000000004"),
     ]
-    .map(|x| TestFr(x));
+    .map(TestFr);
+}
+
+pub fn optimal_merkle_tree_benchmark(c: &mut Criterion) {
+    let mut tree =
+        OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
+            .unwrap();
 
     c.bench_function("OptimalMerkleTree::set", |b| {
         b.iter(|| {
-            tree.set(0, leaves[0]).unwrap();
+            tree.set(0, LEAVES[0]).unwrap();
         })
     });
 
@@ -72,7 +75,7 @@ pub fn optimal_merkle_tree_benchmark(c: &mut Criterion) {
 
     c.bench_function("OptimalMerkleTree::override_range", |b| {
         b.iter(|| {
-            tree.override_range(0, leaves, [0, 1, 2, 3]).unwrap();
+            tree.override_range(0, *LEAVES, [0, 1, 2, 3]).unwrap();
         })
     });
 
@@ -93,17 +96,9 @@ pub fn full_merkle_tree_benchmark(c: &mut Criterion) {
     let mut tree =
         FullMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), FullMerkleConfig::default()).unwrap();
 
-    let leaves = [
-        hex!("0000000000000000000000000000000000000000000000000000000000000001"),
-        hex!("0000000000000000000000000000000000000000000000000000000000000002"),
-        hex!("0000000000000000000000000000000000000000000000000000000000000003"),
-        hex!("0000000000000000000000000000000000000000000000000000000000000004"),
-    ]
-    .map(|x| TestFr(x));
-
     c.bench_function("FullMerkleTree::set", |b| {
         b.iter(|| {
-            tree.set(0, leaves[0]).unwrap();
+            tree.set(0, LEAVES[0]).unwrap();
         })
     });
 
@@ -115,7 +110,7 @@ pub fn full_merkle_tree_benchmark(c: &mut Criterion) {
 
     c.bench_function("FullMerkleTree::override_range", |b| {
         b.iter(|| {
-            tree.override_range(0, leaves, [0, 1, 2, 3]).unwrap();
+            tree.override_range(0, *LEAVES, [0, 1, 2, 3]).unwrap();
         })
     });
 

--- a/utils/tests/merkle_tree.rs
+++ b/utils/tests/merkle_tree.rs
@@ -170,8 +170,8 @@ pub mod test {
         .unwrap();
 
         // ensure that the leaves are set correctly
-        for (i, &new_leave) in new_leaves.iter().enumerate() {
-            assert_eq!(tree.get_leaf(i), new_leave);
+        for (i, &new_leaf) in new_leaves.iter().enumerate() {
+            assert_eq!(tree.get_leaf(i), new_leaf);
         }
     }
 }

--- a/utils/tests/merkle_tree.rs
+++ b/utils/tests/merkle_tree.rs
@@ -57,6 +57,15 @@ pub mod test {
         .map(TestFr);
     }
 
+    fn default_full_merkle_tree() -> FullMerkleTree<Keccak256> {
+        FullMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), FullMerkleConfig::default()).unwrap()
+    }
+
+    fn default_optimal_merkle_tree() -> OptimalMerkleTree<Keccak256> {
+        OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
+            .unwrap()
+    }
+
     #[test]
     fn test_root() {
         let default_tree_root = TestFr(hex!(
@@ -71,18 +80,14 @@ pub mod test {
         ]
         .map(TestFr);
 
-        let mut tree =
-            FullMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), FullMerkleConfig::default())
-                .unwrap();
+        let mut tree = default_full_merkle_tree();
         assert_eq!(tree.root(), default_tree_root);
         for i in 0..LEAVES.len() {
             tree.set(i, LEAVES[i]).unwrap();
             assert_eq!(tree.root(), roots[i]);
         }
 
-        let mut tree =
-            OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
-                .unwrap();
+        let mut tree = default_optimal_merkle_tree();
         assert_eq!(tree.root(), default_tree_root);
         for i in 0..LEAVES.len() {
             tree.set(i, LEAVES[i]).unwrap();
@@ -93,9 +98,7 @@ pub mod test {
     #[test]
     fn test_proof() {
         // We thest the FullMerkleTree implementation
-        let mut tree =
-            FullMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), FullMerkleConfig::default())
-                .unwrap();
+        let mut tree = default_full_merkle_tree();
         for i in 0..LEAVES.len() {
             // We set the leaves
             tree.set(i, LEAVES[i]).unwrap();
@@ -119,9 +122,7 @@ pub mod test {
         }
 
         // We test the OptimalMerkleTree implementation
-        let mut tree =
-            OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
-                .unwrap();
+        let mut tree = default_optimal_merkle_tree();
         for i in 0..LEAVES.len() {
             // We set the leaves
             tree.set(i, LEAVES[i]).unwrap();
@@ -147,9 +148,7 @@ pub mod test {
 
     #[test]
     fn test_override_range() {
-        let mut tree =
-            OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
-                .unwrap();
+        let mut tree = default_optimal_merkle_tree();
 
         // We set the leaves
         tree.set_range(0, LEAVES.iter().cloned()).unwrap();

--- a/utils/tests/merkle_tree.rs
+++ b/utils/tests/merkle_tree.rs
@@ -1,9 +1,9 @@
 // Tests adapted from https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/merkle_tree.rs
 #[cfg(test)]
 pub mod test {
-    use std::{fmt::Display, str::FromStr};
-
     use hex_literal::hex;
+    use lazy_static::lazy_static;
+    use std::{fmt::Display, str::FromStr};
     use tiny_keccak::{Hasher as _, Keccak};
     use zerokit_utils::{
         FullMerkleConfig, FullMerkleTree, Hasher, OptimalMerkleConfig, OptimalMerkleTree,
@@ -47,16 +47,18 @@ pub mod test {
         }
     }
 
-    #[test]
-    fn test_root() {
-        let leaves = [
+    lazy_static! {
+        static ref LEAVES: [TestFr; 4] = [
             hex!("0000000000000000000000000000000000000000000000000000000000000001"),
             hex!("0000000000000000000000000000000000000000000000000000000000000002"),
             hex!("0000000000000000000000000000000000000000000000000000000000000003"),
             hex!("0000000000000000000000000000000000000000000000000000000000000004"),
         ]
-        .map(|x| TestFr(x));
+        .map(TestFr);
+    }
 
+    #[test]
+    fn test_root() {
         let default_tree_root = TestFr(hex!(
             "b4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30"
         ));
@@ -67,14 +69,14 @@ pub mod test {
             hex!("222ff5e0b5877792c2bc1670e2ccd0c2c97cd7bb1672a57d598db05092d3d72c"),
             hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36"),
         ]
-        .map(|x| TestFr(x));
+        .map(TestFr);
 
         let mut tree =
             FullMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), FullMerkleConfig::default())
                 .unwrap();
         assert_eq!(tree.root(), default_tree_root);
-        for i in 0..leaves.len() {
-            tree.set(i, leaves[i]).unwrap();
+        for i in 0..LEAVES.len() {
+            tree.set(i, LEAVES[i]).unwrap();
             assert_eq!(tree.root(), roots[i]);
         }
 
@@ -82,29 +84,21 @@ pub mod test {
             OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
                 .unwrap();
         assert_eq!(tree.root(), default_tree_root);
-        for i in 0..leaves.len() {
-            tree.set(i, leaves[i]).unwrap();
+        for i in 0..LEAVES.len() {
+            tree.set(i, LEAVES[i]).unwrap();
             assert_eq!(tree.root(), roots[i]);
         }
     }
 
     #[test]
     fn test_proof() {
-        let leaves = [
-            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
-            hex!("0000000000000000000000000000000000000000000000000000000000000002"),
-            hex!("0000000000000000000000000000000000000000000000000000000000000003"),
-            hex!("0000000000000000000000000000000000000000000000000000000000000004"),
-        ]
-        .map(|x| TestFr(x));
-
         // We thest the FullMerkleTree implementation
         let mut tree =
             FullMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), FullMerkleConfig::default())
                 .unwrap();
-        for i in 0..leaves.len() {
+        for i in 0..LEAVES.len() {
             // We set the leaves
-            tree.set(i, leaves[i]).unwrap();
+            tree.set(i, LEAVES[i]).unwrap();
 
             // We compute a merkle proof
             let proof = tree.proof(i).expect("index should be set");
@@ -113,14 +107,14 @@ pub mod test {
             assert_eq!(proof.leaf_index(), i);
 
             // We verify the proof
-            assert!(tree.verify(&leaves[i], &proof).unwrap());
+            assert!(tree.verify(&LEAVES[i], &proof).unwrap());
 
             // We ensure that the Merkle proof and the leaf generate the same root as the tree
-            assert_eq!(proof.compute_root_from(&leaves[i]), tree.root());
+            assert_eq!(proof.compute_root_from(&LEAVES[i]), tree.root());
 
             // We check that the proof is not valid for another leaf
             assert!(!tree
-                .verify(&leaves[(i + 1) % leaves.len()], &proof)
+                .verify(&LEAVES[(i + 1) % LEAVES.len()], &proof)
                 .unwrap());
         }
 
@@ -128,9 +122,9 @@ pub mod test {
         let mut tree =
             OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
                 .unwrap();
-        for i in 0..leaves.len() {
+        for i in 0..LEAVES.len() {
             // We set the leaves
-            tree.set(i, leaves[i]).unwrap();
+            tree.set(i, LEAVES[i]).unwrap();
 
             // We compute a merkle proof
             let proof = tree.proof(i).expect("index should be set");
@@ -139,40 +133,32 @@ pub mod test {
             assert_eq!(proof.leaf_index(), i);
 
             // We verify the proof
-            assert!(tree.verify(&leaves[i], &proof).unwrap());
+            assert!(tree.verify(&LEAVES[i], &proof).unwrap());
 
             // We ensure that the Merkle proof and the leaf generate the same root as the tree
-            assert_eq!(proof.compute_root_from(&leaves[i]), tree.root());
+            assert_eq!(proof.compute_root_from(&LEAVES[i]), tree.root());
 
             // We check that the proof is not valid for another leaf
             assert!(!tree
-                .verify(&leaves[(i + 1) % leaves.len()], &proof)
+                .verify(&LEAVES[(i + 1) % LEAVES.len()], &proof)
                 .unwrap());
         }
     }
 
     #[test]
     fn test_override_range() {
-        let initial_leaves = [
-            hex!("0000000000000000000000000000000000000000000000000000000000000001"),
-            hex!("0000000000000000000000000000000000000000000000000000000000000002"),
-            hex!("0000000000000000000000000000000000000000000000000000000000000003"),
-            hex!("0000000000000000000000000000000000000000000000000000000000000004"),
-        ]
-        .map(|x| TestFr(x));
-
         let mut tree =
             OptimalMerkleTree::<Keccak256>::new(2, TestFr([0; 32]), OptimalMerkleConfig::default())
                 .unwrap();
 
         // We set the leaves
-        tree.set_range(0, initial_leaves.iter().cloned()).unwrap();
+        tree.set_range(0, LEAVES.iter().cloned()).unwrap();
 
         let new_leaves = [
             hex!("0000000000000000000000000000000000000000000000000000000000000005"),
             hex!("0000000000000000000000000000000000000000000000000000000000000006"),
         ]
-        .map(|x| TestFr(x));
+        .map(TestFr);
 
         let to_delete_indices: [usize; 2] = [0, 1];
 
@@ -185,8 +171,8 @@ pub mod test {
         .unwrap();
 
         // ensure that the leaves are set correctly
-        for i in 0..new_leaves.len() {
-            assert_eq!(tree.get_leaf(i), new_leaves[i]);
+        for (i, &new_leave) in new_leaves.iter().enumerate() {
+            assert_eq!(tree.get_leaf(i), new_leave);
         }
     }
 }

--- a/utils/tests/poseidon_constants.rs
+++ b/utils/tests/poseidon_constants.rs
@@ -25,16 +25,10 @@ mod test {
         input_clean = input_clean.trim().to_string();
 
         if radix == 10 {
-            BigUint::from_str_radix(&input_clean, radix)
-                .unwrap()
-                .try_into()
-                .unwrap()
+            BigUint::from_str_radix(&input_clean, radix).unwrap().into()
         } else {
             input_clean = input_clean.replace("0x", "");
-            BigUint::from_str_radix(&input_clean, radix)
-                .unwrap()
-                .try_into()
-                .unwrap()
+            BigUint::from_str_radix(&input_clean, radix).unwrap().into()
         }
     }
     // The following constants were taken from https://github.com/arnaucube/poseidon-rs/blob/233027d6075a637c29ad84a8a44f5653b81f0410/src/constants.rs
@@ -3500,21 +3494,21 @@ mod test {
     fn load_constants() -> (Vec<Vec<Fr>>, Vec<Vec<Vec<Fr>>>) {
         let (c_str, m_str) = constants();
         let mut c: Vec<Vec<Fr>> = Vec::new();
-        for i in 0..c_str.len() {
-            let mut cci: Vec<Fr> = Vec::new();
-            for j in 0..c_str[i].len() {
-                let b: Fr = str_to_fr(c_str[i][j], 10);
-                cci.push(b);
+        for c_i in c_str {
+            let mut ci: Vec<Fr> = Vec::new();
+            for c_i_j in c_i {
+                let b: Fr = str_to_fr(c_i_j, 10);
+                ci.push(b);
             }
-            c.push(cci);
+            c.push(ci);
         }
         let mut m: Vec<Vec<Vec<Fr>>> = Vec::new();
-        for i in 0..m_str.len() {
+        for m_i in m_str {
             let mut mi: Vec<Vec<Fr>> = Vec::new();
-            for j in 0..m_str[i].len() {
+            for m_i_j in m_i {
                 let mut mij: Vec<Fr> = Vec::new();
-                for k in 0..m_str[i][j].len() {
-                    let b: Fr = str_to_fr(m_str[i][j][k], 10);
+                for m_i_j_k in m_i_j {
+                    let b: Fr = str_to_fr(m_i_j_k, 10);
                     mij.push(b);
                 }
                 mi.push(mij);
@@ -3542,7 +3536,7 @@ mod test {
                 assert_eq!(loaded_m[i], poseidon_parameters[i].m);
             }
         } else {
-            assert!(false);
+            unreachable!();
         }
     }
 }


### PR DESCRIPTION
Part of #237 

This PR includes:

- create benchmark from this test https://github.com/vacp2p/zerokit/blob/0521c7349e7aa36e25b43e4663def226451a7147/rln/tests/poseidon_tree.rs#L13

- add additional measurements for `FullMerkleTree` and `OptimalMerkleTree`  using `set_range` 

- extract common logic in tests/ffi.rs 
- refactor tests and benches