### PR TITLE
feat: expose custom witness ffi

### DIFF
--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -363,6 +363,21 @@ pub extern "C" fn generate_rln_proof(
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
+pub extern "C" fn generate_rln_proof_with_witness(
+    ctx: *mut RLN,
+    input_buffer: *const Buffer,
+    output_buffer: *mut Buffer,
+) -> bool {
+    call_with_output_arg!(
+        ctx,
+        generate_rln_proof_with_witness,
+        output_buffer,
+        input_buffer
+    )
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
 pub extern "C" fn verify_rln_proof(
     ctx: *const RLN,
     proof_buffer: *const Buffer,

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -820,7 +820,7 @@ impl RLN<'_> {
     //
     // output_data is [ proof<128> | root<32> | external_nullifier<32> | x<32> | y<32> | nullifier<32>]
     // we skip it from documentation for now
-    #[doc(hidden)]
+    #[cfg(target_arch = "wasm32")]
     pub fn generate_rln_proof_with_witness<W: Write>(
         &mut self,
         calculated_witness: Vec<BigInt>,

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -840,7 +840,7 @@ impl RLN<'_> {
 
     // Generate RLN Proof using a witness calculated from outside zerokit
     //
-    // output_data is  [ proof<128> | root<32> | epoch<32> | share_x<32> | share_y<32> | nullifier<32> | rln_identifier<32> ]
+    // output_data is  [ proof<128> | root<32> | external_nullifier<32> | x<32> | y<32> | nullifier<32>]
     // we skip it from documentation for now
     #[cfg(not(target_arch = "wasm32"))]
     pub fn generate_rln_proof_with_witness<R: Read, W: Write>(

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -23,9 +23,9 @@ cfg_if! {
         use serde_json::{json, Value};
         use utils::{Hasher};
         use std::str::FromStr;
-        use num_bigint::BigInt;
     } else {
         use std::marker::*;
+        use num_bigint::BigInt;
     }
 }
 

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -11,7 +11,6 @@ use ark_relations::r1cs::ConstraintMatrices;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, Write};
 use cfg_if::cfg_if;
 use color_eyre::{Report, Result};
-use num_bigint::BigInt;
 use std::io::Cursor;
 use utils::{ZerokitMerkleProof, ZerokitMerkleTree};
 
@@ -24,6 +23,7 @@ cfg_if! {
         use serde_json::{json, Value};
         use utils::{Hasher};
         use std::str::FromStr;
+        use num_bigint::BigInt;
     } else {
         use std::marker::*;
     }
@@ -831,6 +831,30 @@ impl RLN<'_> {
         let proof_values = proof_values_from_witness(&rln_witness)?;
 
         let proof = generate_proof_with_witness(calculated_witness, &self.proving_key).unwrap();
+
+        // Note: we export a serialization of ark-groth16::Proof not semaphore::Proof
+        // This proof is compressed, i.e. 128 bytes long
+        proof.serialize_compressed(&mut output_data)?;
+        output_data.write_all(&serialize_proof_values(&proof_values))?;
+        Ok(())
+    }
+
+    // Generate RLN Proof using a witness calculated from outside zerokit
+    //
+    // output_data is  [ proof<128> | root<32> | epoch<32> | share_x<32> | share_y<32> | nullifier<32> | rln_identifier<32> ]
+    // we skip it from documentation for now
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn generate_rln_proof_with_witness<R: Read, W: Write>(
+        &mut self,
+        mut input_data: R,
+        mut output_data: W,
+    ) -> Result<()> {
+        let mut witness_byte: Vec<u8> = Vec::new();
+        input_data.read_to_end(&mut witness_byte)?;
+        let (rln_witness, _) = deserialize_witness(&witness_byte)?;
+        let proof_values = proof_values_from_witness(&rln_witness)?;
+
+        let proof = generate_proof(self.witness_calculator, &self.proving_key, &rln_witness)?;
 
         // Note: we export a serialization of ark-groth16::Proof not semaphore::Proof
         // This proof is compressed, i.e. 128 bytes long

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -819,7 +819,6 @@ impl RLN<'_> {
     // Generate RLN Proof using a witness calculated from outside zerokit
     //
     // output_data is [ proof<128> | root<32> | external_nullifier<32> | x<32> | y<32> | nullifier<32>]
-    // we skip it from documentation for now
     #[cfg(target_arch = "wasm32")]
     pub fn generate_rln_proof_with_witness<W: Write>(
         &mut self,

--- a/rln/src/public_api_tests.rs
+++ b/rln/src/public_api_tests.rs
@@ -665,13 +665,10 @@ fn test_rln_with_witness() {
         .collect();
 
     // Generating the proof
+    let mut input_buffer = Cursor::new(serialized_witness);
     let mut output_buffer = Cursor::new(Vec::<u8>::new());
-    rln.generate_rln_proof_with_witness(
-        calculated_witness_vec,
-        serialized_witness,
-        &mut output_buffer,
-    )
-    .unwrap();
+    rln.generate_rln_proof_with_witness(&mut input_buffer, &mut output_buffer)
+        .unwrap();
 
     // output_data is  [ proof<128> | root<32> | external_nullifier<32> | x<32> | y<32> | nullifier<32> ]
     let mut proof_data = output_buffer.into_inner();


### PR DESCRIPTION
* Exposes `generate_rln_proof_with_witness` FFI, which allows to generate proofs with a custom witness.
* Similar as https://github.com/vacp2p/zerokit/pull/227/, which targeted RLN v1 but now targeting RLN v2.