### PR TITLE
chore(rln): add verifying key deser benchmark

### DIFF
--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -89,5 +89,9 @@ name = "circuit_loading_benchmark"
 harness = false
 
 [[bench]]
+name = "circuit_deser_benchmark"
+harness = false
+
+[[bench]]
 name = "poseidon_tree_benchmark"
 harness = false

--- a/rln/benches/circuit_deser_benchmark.rs
+++ b/rln/benches/circuit_deser_benchmark.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use rln::circuit::{to_verifying_key, RESOURCES_DIR, VK_FILENAME};
+use serde_json::Value;
+use std::path::Path;
+
+// Here we benchmark how long the deserialization of the
+// verifying_key takes, only testing the json => verifying_key conversion,
+// and skipping conversion from bytes => string => serde_json::Value
+pub fn vk_deserialize_benchmark(c: &mut Criterion) {
+    let vk = RESOURCES_DIR.get_file(Path::new(VK_FILENAME)).unwrap();
+    let vk = vk.contents_utf8().unwrap();
+    let json: Value = serde_json::from_str(vk).unwrap();
+
+    c.bench_function("circuit::to_verifying_key", |b| {
+        b.iter(|| {
+            let _ = to_verifying_key(&json);
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(10));
+    targets = vk_deserialize_benchmark
+}
+criterion_main!(benches);

--- a/rln/benches/circuit_loading_benchmark.rs
+++ b/rln/benches/circuit_loading_benchmark.rs
@@ -10,5 +10,9 @@ pub fn key_load_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, key_load_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(250));
+    targets = key_load_benchmark
+}
 criterion_main!(benches);

--- a/rln/src/circuit.rs
+++ b/rln/src/circuit.rs
@@ -35,13 +35,13 @@ cfg_if! {
 }
 
 const ZKEY_FILENAME: &str = "tree_height_20/rln_final.zkey";
-const VK_FILENAME: &str = "tree_height_20/verification_key.json";
+pub const VK_FILENAME: &str = "tree_height_20/verification_key.json";
 const WASM_FILENAME: &str = "tree_height_20/rln.wasm";
 
 pub const TEST_TREE_HEIGHT: usize = 20;
 
 #[cfg(not(target_arch = "wasm32"))]
-static RESOURCES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources");
+pub static RESOURCES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources");
 
 // The following types define the pairing friendly elliptic curve, the underlying finite fields and groups default to this module
 // Note that proofs are serialized assuming Fr to be 4x8 = 32 bytes in size. Hence, changing to a curve with different encoding will make proof verification to fail
@@ -248,20 +248,20 @@ fn json_to_g2(json: &Value, key: &str) -> Result<G2Affine> {
 }
 
 // Converts JSON to a VerifyingKey
-fn to_verifying_key(json: serde_json::Value) -> Result<VerifyingKey<Curve>> {
+pub fn to_verifying_key(json: &serde_json::Value) -> Result<VerifyingKey<Curve>> {
     Ok(VerifyingKey {
-        alpha_g1: json_to_g1(&json, "vk_alpha_1")?,
-        beta_g2: json_to_g2(&json, "vk_beta_2")?,
-        gamma_g2: json_to_g2(&json, "vk_gamma_2")?,
-        delta_g2: json_to_g2(&json, "vk_delta_2")?,
-        gamma_abc_g1: json_to_g1_vec(&json, "IC")?,
+        alpha_g1: json_to_g1(json, "vk_alpha_1")?,
+        beta_g2: json_to_g2(json, "vk_beta_2")?,
+        gamma_g2: json_to_g2(json, "vk_gamma_2")?,
+        delta_g2: json_to_g2(json, "vk_delta_2")?,
+        gamma_abc_g1: json_to_g1_vec(json, "IC")?,
     })
 }
 
 // Computes the verification key from its JSON serialization
 fn vk_from_json(vk: &str) -> Result<VerifyingKey<Curve>> {
     let json: Value = serde_json::from_str(vk)?;
-    to_verifying_key(json)
+    to_verifying_key(&json)
 }
 
 // Computes the verification key from a bytes vector containing its JSON serialization
@@ -269,7 +269,7 @@ fn vk_from_vector(vk: &[u8]) -> Result<VerifyingKey<Curve>> {
     let json = String::from_utf8(vk.to_vec())?;
     let json: Value = serde_json::from_str(&json)?;
 
-    to_verifying_key(json)
+    to_verifying_key(&json)
 }
 
 // Checks verification key to be correct with respect to proving key


### PR DESCRIPTION
Benchmarking deserialization of verifying key. Need to merge this before https://github.com/vacp2p/zerokit/pull/257 to check if performance gains are being made.
