### PR TITLE
chore(rln): refactor resource initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,6 @@ jobs:
     timeout-minutes: 60
 
     name: benchmark - ${{ matrix.platform }} - ${{ matrix.crate }}
-    env:
-      RUST_BACKTRACE: 1
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
     timeout-minutes: 60
 
     name: benchmark - ${{ matrix.platform }} - ${{ matrix.crate }}
+    env:
+      RUST_BACKTRACE: 1
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,25 +1461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,7 +2284,6 @@ dependencies = [
  "cfg-if",
  "color-eyre",
  "criterion 0.4.0",
- "include_dir",
  "num-bigint",
  "num-traits",
  "once_cell",

--- a/rln-cli/src/state.rs
+++ b/rln-cli/src/state.rs
@@ -5,12 +5,12 @@ use std::fs::File;
 use crate::config::{Config, InnerConfig};
 
 #[derive(Default)]
-pub(crate) struct State<'a> {
-    pub rln: Option<RLN<'a>>,
+pub(crate) struct State {
+    pub rln: Option<RLN>,
 }
 
-impl<'a> State<'a> {
-    pub(crate) fn load_state() -> Result<State<'a>> {
+impl State {
+    pub(crate) fn load_state() -> Result<State> {
         let config = Config::load_config()?;
         let rln = if let Some(InnerConfig { file, tree_height }) = config.inner {
             let resources = File::open(&file)?;

--- a/rln-wasm/src/lib.rs
+++ b/rln-wasm/src/lib.rs
@@ -19,7 +19,7 @@ pub fn init_panic_hook() {
 pub struct RLNWrapper {
     // The purpose of this wrapper is to hold a RLN instance with the 'static lifetime
     // because wasm_bindgen does not allow returning elements with lifetimes
-    instance: RLN<'static>,
+    instance: RLN,
 }
 
 // Macro to call methods with arbitrary amount of arguments,

--- a/rln-wasm/src/lib.rs
+++ b/rln-wasm/src/lib.rs
@@ -150,8 +150,8 @@ impl<T> ProcessArg for Vec<T> {
     }
 }
 
-impl<'a> ProcessArg for *const RLN<'a> {
-    type ReturnType = &'a RLN<'a>;
+impl ProcessArg for *const RLN {
+    type ReturnType = &'static RLN;
     fn process(self) -> Self::ReturnType {
         unsafe { &*self }
     }

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -58,8 +58,6 @@ utils = { package = "zerokit_utils", version = "=0.5.0", path = "../utils/", def
 serde_json = "=1.0.96"
 serde = { version = "=1.0.163", features = ["derive"] }
 
-include_dir = "=0.7.3"
-
 [dev-dependencies]
 sled = "=0.34.7"
 criterion = { version = "=0.4.0", features = ["html_reports"] }

--- a/rln/benches/circuit_deser_benchmark.rs
+++ b/rln/benches/circuit_deser_benchmark.rs
@@ -7,7 +7,7 @@ use rln::circuit::{vk_from_ark_serialized, VK_BYTES};
 pub fn vk_deserialize_benchmark(c: &mut Criterion) {
     let vk = VK_BYTES;
 
-    c.bench_function("circuit::to_verifying_key", |b| {
+    c.bench_function("vk::vk_from_ark_serialized", |b| {
         b.iter(|| {
             let _ = vk_from_ark_serialized(vk);
         })

--- a/rln/benches/circuit_deser_benchmark.rs
+++ b/rln/benches/circuit_deser_benchmark.rs
@@ -1,17 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rln::circuit::{vk_from_ark_serialized, RESOURCES_DIR, VK_FILENAME};
-use std::path::Path;
+use rln::circuit::{vk_from_ark_serialized, VK_BYTES};
 
 // Here we benchmark how long the deserialization of the
 // verifying_key takes, only testing the json => verifying_key conversion,
 // and skipping conversion from bytes => string => serde_json::Value
 pub fn vk_deserialize_benchmark(c: &mut Criterion) {
-    let vk = RESOURCES_DIR.get_file(Path::new(VK_FILENAME)).unwrap();
-    let vk = vk.contents();
+    let vk = VK_BYTES;
 
     c.bench_function("circuit::to_verifying_key", |b| {
         b.iter(|| {
-            let _ = vk_from_ark_serialized(&vk);
+            let _ = vk_from_ark_serialized(vk);
         })
     });
 }

--- a/rln/benches/circuit_loading_benchmark.rs
+++ b/rln/benches/circuit_loading_benchmark.rs
@@ -12,7 +12,7 @@ pub fn key_load_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().measurement_time(std::time::Duration::from_secs(250));
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(10));
     targets = key_load_benchmark
 }
 criterion_main!(benches);

--- a/rln/benches/circuit_loading_benchmark.rs
+++ b/rln/benches/circuit_loading_benchmark.rs
@@ -1,11 +1,14 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use rln::circuit::{zkey_from_raw, ZKEY_BYTES};
 
 // Depending on the key type (enabled by the `--features arkzkey` flag)
 // the upload speed from the `rln_final.zkey` or `rln_final.arkzkey` file is calculated
 pub fn key_load_benchmark(c: &mut Criterion) {
+    let zkey = ZKEY_BYTES.to_vec();
+
     c.bench_function("zkey::upload_from_folder", |b| {
         b.iter(|| {
-            let _ = rln::circuit::zkey_from_folder();
+            let _ = zkey_from_raw(&zkey);
         })
     });
 }

--- a/rln/benches/circuit_loading_benchmark.rs
+++ b/rln/benches/circuit_loading_benchmark.rs
@@ -12,7 +12,7 @@ pub fn key_load_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().measurement_time(std::time::Duration::from_secs(350));
+    config = Criterion::default().without_plots().measurement_time(std::time::Duration::from_secs(10));
     targets = key_load_benchmark
 }
 criterion_main!(benches);

--- a/rln/benches/circuit_loading_benchmark.rs
+++ b/rln/benches/circuit_loading_benchmark.rs
@@ -12,7 +12,7 @@ pub fn key_load_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().measurement_time(std::time::Duration::from_secs(250));
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(350));
     targets = key_load_benchmark
 }
 criterion_main!(benches);

--- a/rln/benches/circuit_loading_benchmark.rs
+++ b/rln/benches/circuit_loading_benchmark.rs
@@ -6,7 +6,7 @@ use rln::circuit::{zkey_from_raw, ZKEY_BYTES};
 pub fn key_load_benchmark(c: &mut Criterion) {
     let zkey = ZKEY_BYTES.to_vec();
 
-    c.bench_function("zkey::upload_from_folder", |b| {
+    c.bench_function("zkey::zkey_from_raw", |b| {
         b.iter(|| {
             let _ = zkey_from_raw(&zkey);
         })
@@ -15,7 +15,7 @@ pub fn key_load_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().without_plots().measurement_time(std::time::Duration::from_secs(10));
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(250));
     targets = key_load_benchmark
 }
 criterion_main!(benches);

--- a/rln/benches/circuit_loading_benchmark.rs
+++ b/rln/benches/circuit_loading_benchmark.rs
@@ -12,7 +12,7 @@ pub fn key_load_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().measurement_time(std::time::Duration::from_secs(10));
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(250));
     targets = key_load_benchmark
 }
 criterion_main!(benches);

--- a/rln/src/circuit.rs
+++ b/rln/src/circuit.rs
@@ -33,6 +33,7 @@ const ZKEY_BYTES: &[u8] = include_bytes!("../resources/tree_height_20/rln_final.
 pub const VK_BYTES: &[u8] = include_bytes!("../resources/tree_height_20/verification_key.arkvkey");
 const WASM_BYTES: &[u8] = include_bytes!("../resources/tree_height_20/rln.wasm");
 
+#[cfg(not(target_arch = "wasm32"))]
 static ZKEY: Lazy<(ProvingKey<Curve>, ConstraintMatrices<Fr>)> = Lazy::new(|| {
     cfg_if! {
         if #[cfg(feature = "arkzkey")] {
@@ -44,6 +45,7 @@ static ZKEY: Lazy<(ProvingKey<Curve>, ConstraintMatrices<Fr>)> = Lazy::new(|| {
     }
 });
 
+#[cfg(not(target_arch = "wasm32"))]
 static VK: Lazy<VerifyingKey<Curve>> =
     Lazy::new(|| vk_from_ark_serialized(VK_BYTES).expect("Failed to read vk"));
 

--- a/rln/src/ffi.rs
+++ b/rln/src/ffi.rs
@@ -143,15 +143,15 @@ impl ProcessArg for *const Buffer {
     }
 }
 
-impl<'a> ProcessArg for *const RLN<'a> {
-    type ReturnType = &'a RLN<'a>;
+impl ProcessArg for *const RLN {
+    type ReturnType = &'static RLN;
     fn process(self) -> Self::ReturnType {
         unsafe { &*self }
     }
 }
 
-impl<'a> ProcessArg for *mut RLN<'a> {
-    type ReturnType = &'a mut RLN<'a>;
+impl ProcessArg for *mut RLN {
+    type ReturnType = &'static mut RLN;
     fn process(self) -> Self::ReturnType {
         unsafe { &mut *self }
     }

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -79,9 +79,9 @@ impl RLN<'_> {
         let tree_config = rln_config["tree_config"].to_string();
 
         let witness_calculator = circom_from_folder()?;
-        let proving_key = zkey_from_folder()?;
+        let proving_key = zkey_from_folder();
 
-        let verification_key = vk_from_folder()?;
+        let verification_key = vk_from_folder();
 
         let tree_config: <PoseidonTree as ZerokitMerkleTree>::Config = if tree_config.is_empty() {
             <PoseidonTree as ZerokitMerkleTree>::Config::default()
@@ -98,8 +98,8 @@ impl RLN<'_> {
 
         Ok(RLN {
             witness_calculator,
-            proving_key,
-            verification_key,
+            proving_key: proving_key.to_owned(),
+            verification_key: verification_key.to_owned(),
             tree,
             #[cfg(target_arch = "wasm32")]
             _marker: PhantomData,

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -186,11 +186,7 @@ impl RLN {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub fn new_with_params(
-        tree_height: usize,
-        zkey_vec: Vec<u8>,
-        vk_vec: Vec<u8>,
-    ) -> Result<RLN<'static>> {
+    pub fn new_with_params(tree_height: usize, zkey_vec: Vec<u8>, vk_vec: Vec<u8>) -> Result<RLN> {
         #[cfg(not(target_arch = "wasm32"))]
         let witness_calculator = circom_from_raw(circom_vec)?;
 

--- a/rln/tests/ffi.rs
+++ b/rln/tests/ffi.rs
@@ -16,7 +16,7 @@ mod test {
 
     const NO_OF_LEAVES: usize = 256;
 
-    fn create_rln_instance() -> &'static mut RLN<'static> {
+    fn create_rln_instance() -> &'static mut RLN {
         let mut rln_pointer = MaybeUninit::<*mut RLN>::uninit();
         let input_config = json!({}).to_string();
         let input_buffer = &Buffer::from(input_config.as_bytes());

--- a/rln/tests/protocol.rs
+++ b/rln/tests/protocol.rs
@@ -129,7 +129,7 @@ mod test {
         // We generate all relevant keys
         let proving_key = zkey_from_folder();
         let verification_key = vk_from_folder();
-        let builder = circom_from_folder().unwrap();
+        let builder = circom_from_folder();
 
         // We compute witness from the json input
         let rln_witness = get_test_witness();
@@ -158,7 +158,7 @@ mod test {
         // We generate all relevant keys
         let proving_key = zkey_from_folder();
         let verification_key = vk_from_folder();
-        let builder = circom_from_folder().unwrap();
+        let builder = circom_from_folder();
 
         // Let's generate a zkSNARK proof
         let proof = generate_proof(builder, &proving_key, &rln_witness_deser).unwrap();

--- a/rln/tests/protocol.rs
+++ b/rln/tests/protocol.rs
@@ -127,8 +127,8 @@ mod test {
     // We test a RLN proof generation and verification
     fn test_witness_from_json() {
         // We generate all relevant keys
-        let proving_key = zkey_from_folder().unwrap();
-        let verification_key = vk_from_folder().unwrap();
+        let proving_key = zkey_from_folder();
+        let verification_key = vk_from_folder();
         let builder = circom_from_folder().unwrap();
 
         // We compute witness from the json input
@@ -156,8 +156,8 @@ mod test {
         assert_eq!(rln_witness_deser, rln_witness);
 
         // We generate all relevant keys
-        let proving_key = zkey_from_folder().unwrap();
-        let verification_key = vk_from_folder().unwrap();
+        let proving_key = zkey_from_folder();
+        let verification_key = vk_from_folder();
         let builder = circom_from_folder().unwrap();
 
         // Let's generate a zkSNARK proof


### PR DESCRIPTION
Refactored the RLN module to use static resources instead of dynamically loaded resources, removing lifetime dependencies. Additionally, updated several RLN object methods and tests for compatibility with these changes.