### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,7 @@ dependencies = [
 
 [[package]]
 name = "rln"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-bn254",
  "ark-circom",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "zerokit_utils"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-bn254",
  "ark-ff",

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rln"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "APIs to manage, compute and verify zkSNARK proofs and RLN primitives"
@@ -52,7 +52,7 @@ lazy_static = "=1.4.0"
 rand = "=0.8.5"
 rand_chacha = "=0.3.1"
 tiny-keccak = { version = "=2.0.2", features = ["keccak"] }
-utils = { package = "zerokit_utils", version = "=0.5.0", path = "../utils/", default-features = false }
+utils = { package = "zerokit_utils", version = "=0.5.1", path = "../utils/", default-features = false }
 
 
 # serialization

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerokit_utils"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Various utilities for Zerokit"


### PR DESCRIPTION
We initially crafted a github release v0.5.1 to test downstream, but since it works as intended, we bump packages and release to crates.io.
