### PR TITLE
chore(rln-wasm): Make rln-wasm stateless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasmer",
  "web-sys",
+ "zerokit_utils",
 ]
 
 [[package]]

--- a/rln-wasm/Cargo.toml
+++ b/rln-wasm/Cargo.toml
@@ -11,7 +11,10 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-rln = { path = "../rln", default-features = false, features = ["wasm"] }
+rln = { path = "../rln", default-features = false, features = [
+    "wasm",
+    "stateless",
+] }
 num-bigint = { version = "0.4", default-features = false, features = [
     "rand",
     "serde",
@@ -29,6 +32,7 @@ serde_json = "1.0.85"
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
+zerokit_utils = { version = "0.5.1", path = "../utils" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/rln-wasm/src/lib.rs
+++ b/rln-wasm/src/lib.rs
@@ -182,86 +182,13 @@ impl<'a> ProcessArg for &'a [u8] {
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[wasm_bindgen(js_name = newRLN)]
 pub fn wasm_new(
-    tree_height: usize,
     zkey: Uint8Array,
     vk: Uint8Array,
 ) -> Result<*mut RLNWrapper, String> {
-    let instance = RLN::new_with_params(tree_height, zkey.to_vec(), vk.to_vec())
+    let instance = RLN::new_with_params(zkey.to_vec(), vk.to_vec())
         .map_err(|err| format!("{:#?}", err))?;
     let wrapper = RLNWrapper { instance };
     Ok(Box::into_raw(Box::new(wrapper)))
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = getSerializedRLNWitness)]
-pub fn wasm_get_serialized_rln_witness(
-    ctx: *mut RLNWrapper,
-    input: Uint8Array,
-) -> Result<Uint8Array, String> {
-    let rln_witness = call!(ctx, get_serialized_rln_witness, &input.to_vec()[..])
-        .map_err(|err| format!("{:#?}", err))?;
-    Ok(Uint8Array::from(&rln_witness[..]))
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = insertMember)]
-pub fn wasm_set_next_leaf(ctx: *mut RLNWrapper, input: Uint8Array) -> Result<(), String> {
-    call_with_error_msg!(
-        ctx,
-        set_next_leaf,
-        "could not insert member into merkle tree".to_string(),
-        &input.to_vec()[..]
-    )
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = setLeavesFrom)]
-pub fn wasm_set_leaves_from(
-    ctx: *mut RLNWrapper,
-    index: usize,
-    input: Uint8Array,
-) -> Result<(), String> {
-    call_with_error_msg!(
-        ctx,
-        set_leaves_from,
-        "could not set multiple leaves".to_string(),
-        index,
-        &*input.to_vec()
-    )
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = deleteLeaf)]
-pub fn wasm_delete_leaf(ctx: *mut RLNWrapper, index: usize) -> Result<(), String> {
-    call_with_error_msg!(ctx, delete_leaf, "could not delete leaf".to_string(), index)
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = setMetadata)]
-pub fn wasm_set_metadata(ctx: *mut RLNWrapper, input: Uint8Array) -> Result<(), String> {
-    call_with_error_msg!(
-        ctx,
-        set_metadata,
-        "could not set metadata".to_string(),
-        &*input.to_vec()
-    )
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = getMetadata)]
-pub fn wasm_get_metadata(ctx: *mut RLNWrapper) -> Result<Uint8Array, String> {
-    call_with_output_and_error_msg!(ctx, get_metadata, "could not get metadata".to_string())
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = initTreeWithLeaves)]
-pub fn wasm_init_tree_with_leaves(ctx: *mut RLNWrapper, input: Uint8Array) -> Result<(), String> {
-    call_with_error_msg!(
-        ctx,
-        init_tree_with_leaves,
-        "could not init merkle tree".to_string(),
-        &*input.to_vec()
-    )
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -363,17 +290,6 @@ pub fn wasm_recover_id_secret(
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = verifyRLNProof)]
-pub fn wasm_verify_rln_proof(ctx: *const RLNWrapper, proof: Uint8Array) -> Result<bool, String> {
-    call_bool_method_with_error_msg!(
-        ctx,
-        verify_rln_proof,
-        "error while verifying rln proof".to_string(),
-        &proof.to_vec()[..]
-    )
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[wasm_bindgen(js_name = verifyWithRoots)]
 pub fn wasm_verify_with_roots(
     ctx: *const RLNWrapper,
@@ -387,12 +303,6 @@ pub fn wasm_verify_with_roots(
         &proof.to_vec()[..],
         &roots.to_vec()[..]
     )
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[wasm_bindgen(js_name = getRoot)]
-pub fn wasm_get_root(ctx: *const RLNWrapper) -> Result<Uint8Array, String> {
-    call_with_output_and_error_msg!(ctx, get_root, "could not obtain root")
 }
 
 #[wasm_bindgen(js_name = hash)]

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -19,6 +19,7 @@ cfg_if! {
         use std::sync::Mutex;
         use crate::circuit::{circom_from_folder, vk_from_folder, circom_from_raw, zkey_from_folder, TEST_TREE_HEIGHT};
         use ark_circom::WitnessCalculator;
+        use crate::poseidon_tree::PoseidonTree;
         use serde_json::{json, Value};
         use utils::{Hasher};
         use std::sync::Arc;

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -211,26 +211,6 @@ impl RLN {
         })
     }
 
-    #[cfg(all(target_arch = "wasm32", not(feature = "stateless")))]
-    pub fn new_with_params(tree_height: usize, zkey_vec: Vec<u8>, vk_vec: Vec<u8>) -> Result<RLN> {
-        // TODO: check this lines while update rln-wasm
-        #[cfg(not(target_arch = "wasm32"))]
-        let witness_calculator = circom_from_raw(circom_vec)?;
-
-        let proving_key = zkey_from_raw(&zkey_vec)?;
-        let verification_key = vk_from_raw(&vk_vec, &zkey_vec)?;
-
-        // We compute a default empty tree
-        let tree = PoseidonTree::default(tree_height)?;
-
-        Ok(RLN {
-            proving_key,
-            verification_key,
-            tree,
-            _marker: PhantomData,
-        })
-    }
-
     /// Creates a new stateless RLN object by passing circuit resources as byte vectors.
     ///
     /// Input parameters are
@@ -275,39 +255,8 @@ impl RLN {
         })
     }
 
-    /// Creates a new stateless RLN object by passing circuit resources as byte vectors.
-    ///
-    /// Input parameters are
-    /// - `zkey_vec`: a byte vector containing to the proving key (`rln_final.zkey`)  or (`rln_final.arkzkey`) as binary file
-    /// - `vk_vec`: a byte vector containing to the verification key (`verification_key.arkvkey`) as binary file
-    ///
-    /// Example:
-    /// ```
-    /// use std::fs::File;
-    /// use std::io::Read;
-    ///
-    /// let resources_folder = "./resources/tree_height_20/";
-    ///
-    /// let mut resources: Vec<Vec<u8>> = Vec::new();
-    /// for filename in ["rln_final.zkey", "verification_key.arkvkey"] {
-    ///     let fullpath = format!("{resources_folder}{filename}");
-    ///     let mut file = File::open(&fullpath).expect("no file found");
-    ///     let metadata = std::fs::metadata(&fullpath).expect("unable to read metadata");
-    ///     let mut buffer = vec![0; metadata.len() as usize];
-    ///     file.read_exact(&mut buffer).expect("buffer overflow");
-    ///     resources.push(buffer);
-    /// }
-    ///
-    /// let mut rln = RLN::new_with_params(
-    ///     resources[0].clone(),
-    ///     resources[1].clone(),
-    /// );
-    /// ```
     #[cfg(all(target_arch = "wasm32", feature = "stateless"))]
     pub fn new_with_params(zkey_vec: Vec<u8>, vk_vec: Vec<u8>) -> Result<RLN> {
-        #[cfg(not(target_arch = "wasm32"))]
-        let witness_calculator = circom_from_raw(circom_vec)?;
-
         let proving_key = zkey_from_raw(&zkey_vec)?;
         let verification_key = vk_from_raw(&vk_vec, &zkey_vec)?;
 


### PR DESCRIPTION
Regarding Release v0.6.0 in issue #263 
Deprecate tree and correspond function from rln-wasm