### PR TITLE
chore(build): improve WABT installation across platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,14 @@ ifeq ($(shell uname),Darwin)
 # commented due to https://github.com/orgs/Homebrew/discussions/4612
 # @brew update
 	@brew install cmake ninja
+	@git -C "wabt" pull || git clone --recursive https://github.com/WebAssembly/wabt.git "wabt"
+	@cd wabt && mkdir -p build && make
 else ifeq ($(shell uname),Linux)
 	@sudo apt-get update
 	@sudo apt-get install -y cmake ninja-build
-endif
 	@git -C "wabt" pull || git clone --recursive https://github.com/WebAssembly/wabt.git "wabt"
 	@cd wabt && mkdir -p build && cd build && cmake .. -GNinja && ninja && sudo ninja install
+endif
 	@which wasm-pack || cargo install wasm-pack
 	# nvm already checks if it's installed, and no-ops if it is
 	@curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash


### PR DESCRIPTION
Modify Makefile to handle WABT installation consistently for macOS and Linux, ensuring proper setup and build of the WebAssembly Binary Toolkit (WABT).