### PR TITLE
ci: fixed problem with nightly build after updating dependencies 

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.75.0
+          toolchain: 1.80.0
           override: true
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.80.0
+          toolchain: 1.81.0
           override: true
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -12,7 +12,7 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
+          # - i686-unknown-linux-gnu
         include:
           - feature: stateless
             cargo_args: --exclude rln-cli
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: stable
           override: true
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -33,7 +33,7 @@ jobs:
         run: make installdeps
       - name: cross build
         run: |
-          cross build --release --target ${{ matrix.target }} --features ${{ matrix.feature }}
+          cross build --release --target ${{ matrix.target }} --features ${{ matrix.feature }} --workspace ${{ matrix.cargo_args }}
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/
@@ -72,7 +72,7 @@ jobs:
         run: make installdeps
       - name: cross build
         run: |
-          cross build --release --target ${{ matrix.target }} --features ${{ matrix.feature }}
+          cross build --release --target ${{ matrix.target }} --features ${{ matrix.feature }} --workspace ${{ matrix.cargo_args }}
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.82.0
+          toolchain: 1.75.0
           override: true
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.82.0
           override: true
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Return the exception settings for run-cli. Also remove the build for the x32 architecture, because the new version of ark-circom depends on wasmer-wasix, which cannot be built on the x32 architecture.

See this issue for more details: https://github.com/vacp2p/zerokit/issues/282