### PR TITLE
fix: pin ark-circom version and solve local building problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ark-circom.git#7f80002b525c0ebc96b18fb1edcd731e4e4dd679"
+source = "git+https://github.com/gakonst/ark-circom.git?rev=7f80002#7f80002b525c0ebc96b18fb1edcd731e4e4dd679"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/rln-cli/Makefile.toml
+++ b/rln-cli/Makefile.toml
@@ -1,0 +1,8 @@
+[tasks.build]
+command = "cargo"
+args = ["build", "--release"]
+
+[tasks.test]
+command = "cargo"
+args = ["test", "--release"]
+

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -31,7 +31,7 @@ ark-relations = { version = "=0.4.0", default-features = false, features = [
 ark-serialize = { version = "=0.4.2", default-features = false }
 # v0.5.0 use all other ark 0.5.0 versions and they are not compatible with current code.
 # master branch contains commit with compatible version
-ark-circom = { git = "https://github.com/gakonst/ark-circom.git" }
+ark-circom = { git = "https://github.com/gakonst/ark-circom.git", rev = "7f80002" }
 
 # error handling
 color-eyre = "0.6.2"


### PR DESCRIPTION
ark-circom update their branch to new dependency version and we can't support it right now. So I fix on previous commit

also during the local testing I find out that cargo make doesn't work correctly with new rln-cli examples (it calls "cargo" "build" "--all-features") and it's wrong behaviour 