### PR TITLE
fix(rln): review and refine utility functions in rln

### DIFF
--- a/rln-cli/src/examples/relay.rs
+++ b/rln-cli/src/examples/relay.rs
@@ -8,9 +8,9 @@ use color_eyre::{eyre::eyre, Result};
 use rln::{
     circuit::{Fr, TEST_TREE_HEIGHT},
     hashers::{hash_to_field, poseidon_hash},
-    protocol::{deserialize_field_element, keygen, prepare_verify_input},
+    protocol::{keygen, prepare_prove_input, prepare_verify_input},
     public::RLN,
-    utils::{bytes_le_to_fr, fr_to_bytes_le, generate_input_buffer, normalize_usize},
+    utils::{bytes_le_to_fr, fr_to_bytes_le, generate_input_buffer},
 };
 
 const MESSAGE_LIMIT: u32 = 1;
@@ -118,26 +118,14 @@ impl RLNSystem {
             None => return Err(eyre!("user index {user_index} not found")),
         };
 
-        let mut input_buffer = Cursor::new(Vec::new());
-        self.rln.get_leaf(user_index, &mut input_buffer)?;
-        let stored_rate_commitment = deserialize_field_element(input_buffer.into_inner());
-
-        let expected_rate_commitment =
-            poseidon_hash(&[identity.id_commitment, Fr::from(MESSAGE_LIMIT)]);
-
-        if stored_rate_commitment != expected_rate_commitment {
-            return Err(eyre!("user mismatch in merkle tree"));
-        }
-
-        let mut serialized = Vec::new();
-        serialized.append(&mut fr_to_bytes_le(&identity.identity_secret_hash));
-        serialized.append(&mut normalize_usize(user_index));
-        serialized.append(&mut fr_to_bytes_le(&Fr::from(MESSAGE_LIMIT)));
-        serialized.append(&mut fr_to_bytes_le(&Fr::from(message_id)));
-        serialized.append(&mut fr_to_bytes_le(&external_nullifier));
-        serialized.append(&mut normalize_usize(signal.len()));
-        serialized.append(&mut signal.as_bytes().to_vec());
-
+        let serialized = prepare_prove_input(
+            identity.identity_secret_hash,
+            user_index,
+            Fr::from(MESSAGE_LIMIT),
+            Fr::from(message_id),
+            external_nullifier,
+            signal.as_bytes(),
+        );
         let mut input_buffer = Cursor::new(serialized);
         let mut output_buffer = Cursor::new(Vec::new());
         self.rln

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -105,7 +105,8 @@ pub fn serialize_witness(rln_witness: &RLNWitnessInput) -> Result<Vec<u8>> {
     message_id_range_check(&rln_witness.message_id, &rln_witness.user_message_limit)?;
 
     let mut serialized: Vec<u8> = Vec::with_capacity(
-        160 + 32 * rln_witness.path_elements.len() + rln_witness.identity_path_index.len(),
+        fr_byte_size() * (5 + rln_witness.path_elements.len())
+            + rln_witness.identity_path_index.len(),
     );
 
     serialized.extend_from_slice(&fr_to_bytes_le(&rln_witness.identity_secret));
@@ -311,7 +312,7 @@ pub fn proof_values_from_witness(rln_witness: &RLNWitnessInput) -> Result<RLNPro
 
 /// input_data is [ root<32> | external_nullifier<32> | x<32> | y<32> | nullifier<32> ]
 pub fn serialize_proof_values(rln_proof_values: &RLNProofValues) -> Vec<u8> {
-    let mut serialized = Vec::with_capacity(160);
+    let mut serialized = Vec::with_capacity(fr_byte_size() * 5);
 
     serialized.extend_from_slice(&fr_to_bytes_le(&rln_proof_values.root));
     serialized.extend_from_slice(&fr_to_bytes_le(&rln_proof_values.external_nullifier));
@@ -363,7 +364,7 @@ pub fn prepare_prove_input(
     external_nullifier: Fr,
     signal: &[u8],
 ) -> Vec<u8> {
-    let mut serialized = Vec::with_capacity(144 + signal.len());
+    let mut serialized = Vec::with_capacity(fr_byte_size() * 4 + 16 + signal.len());
 
     serialized.extend_from_slice(&fr_to_bytes_le(&identity_secret));
     serialized.extend_from_slice(&normalize_usize(id_index));

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -108,13 +108,13 @@ pub fn serialize_witness(rln_witness: &RLNWitnessInput) -> Result<Vec<u8>> {
         160 + 32 * rln_witness.path_elements.len() + rln_witness.identity_path_index.len(),
     );
 
-    serialized.extend_from_slice(&mut fr_to_bytes_le(&rln_witness.identity_secret));
-    serialized.extend_from_slice(&mut fr_to_bytes_le(&rln_witness.user_message_limit));
-    serialized.extend_from_slice(&mut fr_to_bytes_le(&rln_witness.message_id));
-    serialized.extend_from_slice(&mut vec_fr_to_bytes_le(&rln_witness.path_elements)?);
-    serialized.extend_from_slice(&mut vec_u8_to_bytes_le(&rln_witness.identity_path_index)?);
-    serialized.extend_from_slice(&mut fr_to_bytes_le(&rln_witness.x));
-    serialized.extend_from_slice(&mut fr_to_bytes_le(&rln_witness.external_nullifier));
+    serialized.extend_from_slice(&fr_to_bytes_le(&rln_witness.identity_secret));
+    serialized.extend_from_slice(&fr_to_bytes_le(&rln_witness.user_message_limit));
+    serialized.extend_from_slice(&fr_to_bytes_le(&rln_witness.message_id));
+    serialized.extend_from_slice(&vec_fr_to_bytes_le(&rln_witness.path_elements)?);
+    serialized.extend_from_slice(&vec_u8_to_bytes_le(&rln_witness.identity_path_index)?);
+    serialized.extend_from_slice(&fr_to_bytes_le(&rln_witness.x));
+    serialized.extend_from_slice(&fr_to_bytes_le(&rln_witness.external_nullifier));
 
     Ok(serialized)
 }

--- a/rln/src/protocol.rs
+++ b/rln/src/protocol.rs
@@ -353,6 +353,8 @@ pub fn deserialize_proof_values(serialized: &[u8]) -> (RLNProofValues, usize) {
 pub fn prepare_prove_input(
     identity_secret: Fr,
     id_index: usize,
+    user_message_limit: Fr,
+    message_id: Fr,
     external_nullifier: Fr,
     signal: &[u8],
 ) -> Vec<u8> {
@@ -360,6 +362,8 @@ pub fn prepare_prove_input(
 
     serialized.append(&mut fr_to_bytes_le(&identity_secret));
     serialized.append(&mut normalize_usize(id_index));
+    serialized.append(&mut fr_to_bytes_le(&user_message_limit));
+    serialized.append(&mut fr_to_bytes_le(&message_id));
     serialized.append(&mut fr_to_bytes_le(&external_nullifier));
     serialized.append(&mut normalize_usize(signal.len()));
     serialized.append(&mut signal.to_vec());
@@ -367,7 +371,6 @@ pub fn prepare_prove_input(
     serialized
 }
 
-#[allow(clippy::redundant_clone)]
 pub fn prepare_verify_input(proof_data: Vec<u8>, signal: &[u8]) -> Vec<u8> {
     let mut serialized: Vec<u8> = Vec::new();
 

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -783,26 +783,25 @@ impl RLN {
     /// let mut buffer = Cursor::new(fr_to_bytes_le(&rate_commitment));
     /// rln.set_leaf(identity_index, &mut buffer).unwrap();
     ///
-    /// // We generate a random signal
-    /// let mut rng = rand::thread_rng();
-    /// let signal: [u8; 32] = rng.gen();
-    ///
     /// // We generate a random epoch
     /// let epoch = hash_to_field(b"test-epoch");
     /// // We generate a random rln_identifier
     /// let rln_identifier = hash_to_field(b"test-rln-identifier");
-    /// let external_nullifier = poseidon_hash(&[epoch, rln_identifier]);
+    /// // We generate a external nullifier
+    /// let external_nullifier = utils_poseidon_hash(&[epoch, rln_identifier]);
+    /// // We choose a message_id satisfy 0 <= message_id < MESSAGE_LIMIT
+    /// let message_id = Fr::from(1);
     ///
     /// // We prepare input for generate_rln_proof API
     /// // input_data is [ identity_secret<32> | id_index<8> | user_message_limit<32> | message_id<32> | external_nullifier<32> | signal_len<8> | signal<var> ]
-    /// let mut serialized: Vec<u8> = Vec::new();
-    /// serialized.append(&mut fr_to_bytes_le(&identity_secret_hash));
-    /// serialized.append(&mut normalize_usize(identity_index));
-    /// serialized.append(&mut fr_to_bytes_le(&user_message_limit));
-    /// serialized.append(&mut fr_to_bytes_le(&Fr::from(1))); // message_id
-    /// serialized.append(&mut fr_to_bytes_le(&external_nullifier));
-    /// serialized.append(&mut normalize_usize(signal_len).resize(8,0));
-    /// serialized.append(&mut signal.to_vec());
+    /// let prove_input = prepare_prove_input(
+    ///     identity_secret_hash,
+    ///     identity_index,
+    ///     user_message_limit,
+    ///     message_id,
+    ///     external_nullifier,
+    ///     &signal,
+    /// );
     ///
     /// let mut input_buffer = Cursor::new(serialized);
     /// let mut output_buffer = Cursor::new(Vec::<u8>::new());
@@ -877,10 +876,9 @@ impl RLN {
     /// // We prepare input for verify_rln_proof API
     /// // input_data is  `[ proof<128> | root<32> | external_nullifier<32> | x<32> | y<32> | nullifier<32> | signal_len<8> | signal<var>]`
     /// // that is [ proof_data || signal_len<8> | signal<var> ]
-    /// proof_data.append(&mut normalize_usize(signal_len));
-    /// proof_data.append(&mut signal.to_vec());
+    /// let verify_input = prepare_verify_input(proof_data, &signal);
     ///
-    /// let mut input_buffer = Cursor::new(proof_data);
+    /// let mut input_buffer = Cursor::new(verify_input);
     /// let verified = rln.verify_rln_proof(&mut input_buffer).unwrap();
     ///
     /// assert!(verified);
@@ -956,7 +954,7 @@ impl RLN {
     /// roots_serialized.append(&mut fr_to_bytes_le(&root));
     /// roots_buffer = Cursor::new(roots_serialized.clone());
     /// let verified = rln
-    ///     .verify_with_roots(&mut input_buffer.clone(), &mut roots_buffer)
+    ///     .verify_with_roots(&mut input_buffer, &mut roots_buffer)
     ///     .unwrap();
     ///
     /// assert!(verified);

--- a/rln/src/utils.rs
+++ b/rln/src/utils.rs
@@ -58,6 +58,9 @@ pub fn fr_to_bytes_le(input: &Fr) -> Vec<u8> {
 
 #[inline(always)]
 pub fn vec_fr_to_bytes_le(input: &[Fr]) -> Result<Vec<u8>> {
+    // Calculate capacity for Vec:
+    // - 8 bytes for normalized vector length (usize)
+    // - each Fr element requires fr_byte_size() bytes (typically 32 bytes)
     let mut bytes = Vec::with_capacity(8 + input.len() * fr_byte_size());
 
     // We store the vector length
@@ -73,6 +76,9 @@ pub fn vec_fr_to_bytes_le(input: &[Fr]) -> Result<Vec<u8>> {
 
 #[inline(always)]
 pub fn vec_u8_to_bytes_le(input: &[u8]) -> Result<Vec<u8>> {
+    // Calculate capacity for Vec:
+    // - 8 bytes for normalized vector length (usize)
+    // - variable length input data
     let mut bytes = Vec::with_capacity(8 + input.len());
 
     // We store the vector length

--- a/rln/src/utils.rs
+++ b/rln/src/utils.rs
@@ -45,31 +45,12 @@ pub fn bytes_le_to_fr(input: &[u8]) -> (Fr, usize) {
     )
 }
 
-pub fn bytes_be_to_fr(input: &[u8]) -> (Fr, usize) {
-    let el_size = fr_byte_size();
-    (
-        Fr::from(BigUint::from_bytes_be(&input[0..el_size])),
-        el_size,
-    )
-}
-
 pub fn fr_to_bytes_le(input: &Fr) -> Vec<u8> {
     let input_biguint: BigUint = (*input).into();
     let mut res = input_biguint.to_bytes_le();
     //BigUint conversion ignores most significant zero bytes. We restore them otherwise serialization will fail (length % 8 != 0)
     while res.len() != fr_byte_size() {
         res.push(0);
-    }
-    res
-}
-
-pub fn fr_to_bytes_be(input: &Fr) -> Vec<u8> {
-    let input_biguint: BigUint = (*input).into();
-    let mut res = input_biguint.to_bytes_be();
-    // BigUint conversion ignores most significant zero bytes. We restore them otherwise serialization might fail
-    // Fr elements are stored using 64 bits nimbs
-    while res.len() != fr_byte_size() {
-        res.insert(0, 0);
     }
     res
 }
@@ -85,31 +66,10 @@ pub fn vec_fr_to_bytes_le(input: &[Fr]) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-pub fn vec_fr_to_bytes_be(input: &[Fr]) -> Result<Vec<u8>> {
-    let mut bytes: Vec<u8> = Vec::new();
-    //We store the vector length
-    bytes.extend(u64::try_from(input.len())?.to_be_bytes().to_vec());
-
-    // We store each element
-    input.iter().for_each(|el| bytes.extend(fr_to_bytes_be(el)));
-
-    Ok(bytes)
-}
-
 pub fn vec_u8_to_bytes_le(input: &[u8]) -> Result<Vec<u8>> {
     let mut bytes: Vec<u8> = Vec::new();
     //We store the vector length
     bytes.extend(u64::try_from(input.len())?.to_le_bytes().to_vec());
-
-    bytes.extend(input);
-
-    Ok(bytes)
-}
-
-pub fn vec_u8_to_bytes_be(input: Vec<u8>) -> Result<Vec<u8>> {
-    let mut bytes: Vec<u8> = Vec::new();
-    //We store the vector length
-    bytes.extend(u64::try_from(input.len())?.to_be_bytes().to_vec());
 
     bytes.extend(input);
 
@@ -128,19 +88,6 @@ pub fn bytes_le_to_vec_u8(input: &[u8]) -> Result<(Vec<u8>, usize)> {
     Ok((res, read))
 }
 
-pub fn bytes_be_to_vec_u8(input: &[u8]) -> Result<(Vec<u8>, usize)> {
-    let mut read: usize = 0;
-
-    let len = usize::try_from(u64::from_be_bytes(input[0..8].try_into()?))?;
-    read += 8;
-
-    let res = input[8..8 + len].to_vec();
-
-    read += res.len();
-
-    Ok((res, read))
-}
-
 pub fn bytes_le_to_vec_fr(input: &[u8]) -> Result<(Vec<Fr>, usize)> {
     let mut read: usize = 0;
     let mut res: Vec<Fr> = Vec::new();
@@ -151,23 +98,6 @@ pub fn bytes_le_to_vec_fr(input: &[u8]) -> Result<(Vec<Fr>, usize)> {
     let el_size = fr_byte_size();
     for i in 0..len {
         let (curr_el, _) = bytes_le_to_fr(&input[8 + el_size * i..8 + el_size * (i + 1)]);
-        res.push(curr_el);
-        read += el_size;
-    }
-
-    Ok((res, read))
-}
-
-pub fn bytes_be_to_vec_fr(input: &[u8]) -> Result<(Vec<Fr>, usize)> {
-    let mut read: usize = 0;
-    let mut res: Vec<Fr> = Vec::new();
-
-    let len = usize::try_from(u64::from_be_bytes(input[0..8].try_into()?))?;
-    read += 8;
-
-    let el_size = fr_byte_size();
-    for i in 0..len {
-        let (curr_el, _) = bytes_be_to_fr(&input[8 + el_size * i..8 + el_size * (i + 1)]);
         res.push(curr_el);
         read += el_size;
     }
@@ -198,137 +128,3 @@ pub fn bytes_le_to_vec_usize(input: &[u8]) -> Result<Vec<usize>> {
 pub fn generate_input_buffer() -> Cursor<String> {
     Cursor::new(json!({}).to_string())
 }
-
-/* Old conversion utilities between different libraries data types
-
-// Conversion Utilities between poseidon-rs Field and arkworks Fr (in order to call directly poseidon-rs' poseidon_hash)
-
-use ff::{PrimeField as _, PrimeFieldRepr as _};
-use poseidon_rs::Fr as PosFr;
-
-pub fn fr_to_posfr(value: Fr) -> PosFr {
-    let mut bytes = [0_u8; 32];
-    let byte_vec = value.into_repr().to_bytes_be();
-    bytes.copy_from_slice(&byte_vec[..]);
-    let mut repr = <PosFr as ff::PrimeField>::Repr::default();
-    repr.read_be(&bytes[..])
-        .expect("read from correctly sized slice always succeeds");
-    PosFr::from_repr(repr).expect("value is always in range")
-}
-
-pub fn posfr_to_fr(value: PosFr) -> Fr {
-    let mut bytes = [0u8; 32];
-    value
-        .into_repr()
-        .write_be(&mut bytes[..])
-        .expect("write to correctly sized slice always succeeds");
-    Fr::from_be_bytes_mod_order(&bytes)
-}
-
-
-// Conversion Utilities between semaphore-rs Field and arkworks Fr
-
-use semaphore::Field;
-
-pub fn to_fr(el: &Field) -> Fr {
-    Fr::try_from(*el).unwrap()
-}
-
-pub fn to_field(el: &Fr) -> Field {
-    (*el).try_into().unwrap()
-}
-
-pub fn vec_to_fr(v: &[Field]) -> Vec<Fr> {
-    v.iter().map(|el| to_fr(el)).collect()
-}
-
-pub fn vec_to_field(v: &[Fr]) -> Vec<Field> {
-    v.iter().map(|el| to_field(el)).collect()
-}
-
-pub fn vec_fr_to_field(input: &[Fr]) -> Vec<Field> {
-    input.iter().map(|el| to_field(el)).collect()
-}
-
-pub fn vec_field_to_fr(input: &[Field]) -> Vec<Fr> {
-    input.iter().map(|el| to_fr(el)).collect()
-}
-
-pub fn str_to_field(input: String, radix: i32) -> Field {
-    assert!((radix == 10) || (radix == 16));
-
-    // We remove any quote present and we trim
-    let single_quote: char = '\"';
-    let input_clean = input.replace(single_quote, "");
-    let input_clean = input_clean.trim();
-
-    if radix == 10 {
-        Field::from_str(&format!(
-            "{:01$x}",
-            BigUint::from_str(input_clean).unwrap(),
-            64
-        ))
-        .unwrap()
-    } else {
-        let input_clean = input_clean.replace("0x", "");
-        Field::from_str(&format!("{:0>64}", &input_clean)).unwrap()
-    }
-}
-
-pub fn bytes_le_to_field(input: &[u8]) -> (Field, usize) {
-    let (fr_el, read) = bytes_le_to_fr(input);
-    (to_field(&fr_el), read)
-}
-
-pub fn bytes_be_to_field(input: &[u8]) -> (Field, usize) {
-    let (fr_el, read) = bytes_be_to_fr(input);
-    (to_field(&fr_el), read)
-}
-
-
-pub fn field_to_bytes_le(input: &Field) -> Vec<u8> {
-    fr_to_bytes_le(&to_fr(input))
-}
-
-pub fn field_to_bytes_be(input: &Field) -> Vec<u8> {
-    fr_to_bytes_be(&to_fr(input))
-}
-
-
-pub fn vec_field_to_bytes_le(input: &[Field]) -> Vec<u8> {
-    vec_fr_to_bytes_le(&vec_field_to_fr(input))
-}
-
-pub fn vec_field_to_bytes_be(input: &[Field]) -> Vec<u8> {
-    vec_fr_to_bytes_be(&vec_field_to_fr(input))
-}
-
-
-pub fn bytes_le_to_vec_field(input: &[u8]) -> (Vec<Field>, usize) {
-    let (vec_fr, read) = bytes_le_to_vec_fr(input);
-    (vec_fr_to_field(&vec_fr), read)
-}
-
-pub fn bytes_be_to_vec_field(input: &[u8]) -> (Vec<Field>, usize) {
-    let (vec_fr, read) = bytes_be_to_vec_fr(input);
-    (vec_fr_to_field(&vec_fr), read)
-}
-
-// Arithmetic over Field elements (wrapped over arkworks algebra crate)
-
-pub fn add(a: &Field, b: &Field) -> Field {
-    to_field(&(to_fr(a) + to_fr(b)))
-}
-
-pub fn mul(a: &Field, b: &Field) -> Field {
-    to_field(&(to_fr(a) * to_fr(b)))
-}
-
-pub fn div(a: &Field, b: &Field) -> Field {
-    to_field(&(to_fr(a) / to_fr(b)))
-}
-
-pub fn inv(a: &Field) -> Field {
-    to_field(&(Fr::from(1) / to_fr(a)))
-}
-*/


### PR DESCRIPTION
Review and refine utility functions to resolve #279:
- Update utility functions to the current version.
- Remove unused and commented-out code.
- Optimize some utility functions by using extend_from_slice() and pre-allocate size for Vec<u8>.