### PR TITLE
Add rust overlay and update shell dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ installdeps: .pre-build
 ifeq ($(shell uname),Darwin)
 	@brew install cmake ninja binaryen
 else ifeq ($(shell uname),Linux)
-	@sudo apt-get install -y cmake ninja-build binaryen
+	@if [ -f /etc/os-release ] && grep -q "ID=nixos" /etc/os-release; then \
+		echo "Detected NixOS, skipping apt-get installation."; \
+	else \
+		sudo apt-get install -y cmake ninja-build binaryen; \
+	fi
 endif
 	@which wasm-pack > /dev/null && wasm-pack --version | grep -q "0.13.1" || cargo install wasm-pack --version=0.13.1
 	@which wasm-bindgen > /dev/null && wasm-bindgen --version | grep -q "0.2.100" || cargo install wasm-bindgen-cli --version=0.2.100

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Zerokit currently focuses on RLN (Rate-Limiting Nullifier) implementation using 
 make installdeps
 ```
 
+#### Use Nix to install dependencies
+
+```bash
+nix develop
+```
+
 ### Build and Test All Crates
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745289264,
+        "narHash": "sha256-7nt+UJ7qaIUe2J7BdnEEph9n2eKEwxUwKS/QIr091uA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3b7171858c20d5293360042936058fb0c4cb93a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
   inputs = {
     # Version 24.11
     nixpkgs.url = "github:NixOS/nixpkgs?rev=f44bd8ca21e026135061a0a57dcf3d0775b67a49";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs }: 
+  outputs = { self, nixpkgs, rust-overlay }: 
     let
       stableSystems = [
         "x86_64-linux" "aarch64-linux"
@@ -15,7 +19,8 @@
         "i686-windows"
       ];
       forAllSystems = nixpkgs.lib.genAttrs stableSystems;
-      pkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+      overlays = [ (import rust-overlay) ];
+      pkgsFor = forAllSystems (system: import nixpkgs { inherit system overlays; });
     in rec
     {
       packages = forAllSystems (system: let
@@ -29,9 +34,21 @@
         pkgs = pkgsFor.${system};
       in {
         default = pkgs.mkShell {
-          inputsFrom = [
-            packages.${system}.default
+          buildInputs = with pkgs; [
+            git
+            cmake
+            cargo-make
+            binaryen
+            ninja
+            gnuplot
+            rustup
+            xz
+            rust-bin.stable.latest.default
           ];
+          # Shared library liblzma.so.5 used by wasm-pack
+          shellHook = ''
+            export LD_LIBRARY_PATH="${pkgs.xz.out}/lib:$LD_LIBRARY_PATH"
+          '';
         };
       });
     };


### PR DESCRIPTION
It was requested to use newer version of Rust, so I added the https://github.com/oxalica/rust-overlay to have the most recent rust toolchain. Some of the dependencies needed to compile everything (`make all`) within shell weren't there so I had to add them. Also, within the Makefile the installation of `wasm-pack` using script downloaded from the internet was replaced with installation using cargo - same result but more safe.