### PR TITLE
Benchmark current internal impl of poseidon + external available impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "light-poseidon"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3d87542063daaccbfecd78b60f988079b6ec4e089249658b9455075c78d42"
+dependencies = [
+ "ark-bn254",
+ "ark-ff 0.5.0",
+ "num-bigint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -1706,7 +1718,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sled",
- "thiserror",
+ "thiserror 2.0.12",
  "tiny-keccak",
  "zerokit_utils",
 ]
@@ -2010,11 +2022,31 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2537,6 +2569,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "lazy_static",
+ "light-poseidon",
  "num-bigint",
  "num-traits",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,13 +1576,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1782,7 +1781,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.0",
+ "rand 0.9.1",
  "rlp",
  "ruint-macro",
  "serde",
@@ -2572,6 +2571,10 @@ dependencies = [
  "light-poseidon",
  "num-bigint",
  "num-traits",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "rln",
  "serde",
  "sled",
  "tiny-keccak",

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 		[ -s "$$NVM_DIR/nvm.sh" ] && \. "$$NVM_DIR/nvm.sh" && \
 		nvm install 22.14.0 && \
 		nvm use 22.14.0'
-	@curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+	@cargo install wasm-pack
 	@echo "\033[1;32m>>> Now run this command to activate Node.js 22.14.0: \033[1;33msource $$HOME/.nvm/nvm.sh && nvm use 22.14.0\033[0m"
 
 build: .pre-build

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745289264,
+        "narHash": "sha256-7nt+UJ7qaIUe2J7BdnEEph9n2eKEwxUwKS/QIr091uA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3b7171858c20d5293360042936058fb0c4cb93a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
             git
             cmake
             rustup
+            cargo-make
+            gnuplot
             xz
             wasm-pack
             rust-bin.stable.latest.default

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -32,6 +32,10 @@ num-traits = "0.2.19"
 hex-literal = "1.0.0"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 criterion = { version = "0.4.0", features = ["html_reports"] }
+rand = "0.9.1"
+rand_chacha = "0.9.0"
+rand_core = "0.9.3"
+rln = { path = "../rln", default-features = false }
 
 [features]
 default = []

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -24,6 +24,7 @@ sled = "0.34.7"
 serde = "1.0"
 lazy_static = "1.5.0"
 hex = "0.4"
+light-poseidon = "0.3.0"
 
 [dev-dependencies]
 ark-bn254 = { version = "0.5.0", features = ["std"] }

--- a/utils/benches/poseidon_benchmark.rs
+++ b/utils/benches/poseidon_benchmark.rs
@@ -2,6 +2,7 @@ use ark_bn254::Fr;
 use criterion::{
     black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
 };
+use light_poseidon::PoseidonParameters as LPoseidonParameters;
 use zerokit_utils::Poseidon;
 
 const ROUND_PARAMS: [(usize, usize, usize, usize); 8] = [

--- a/utils/benches/poseidon_benchmark.rs
+++ b/utils/benches/poseidon_benchmark.rs
@@ -56,7 +56,7 @@ pub fn poseidon_benchmark(c: &mut Criterion) {
                             full_rounds: *n_rounds_full,
                             partial_rounds: *n_rounds_partial,
                             width: *t,
-                            alpha: 1,
+                            alpha: 5,
                         };
                         let vals = make_values(size);
                         let light_hasher = light_poseidon::Poseidon::<Fr>::new(l_params);

--- a/utils/benches/poseidon_benchmark.rs
+++ b/utils/benches/poseidon_benchmark.rs
@@ -43,7 +43,7 @@ pub fn poseidon_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(*size as u64));
 
         group.bench_with_input(
-            BenchmarkId::new("Array hash ift", size),
+            BenchmarkId::new("Array hash light", size),
             size,
             |b, &size| {
                 b.iter_batched(
@@ -73,7 +73,7 @@ pub fn poseidon_benchmark(c: &mut Criterion) {
             },
         );
         group.bench_with_input(
-            BenchmarkId::new("Array hash light", size),
+            BenchmarkId::new("Array hash ift", size),
             size,
             |b, &size| {
                 b.iter_batched(

--- a/utils/tests/poseidon_constants.rs
+++ b/utils/tests/poseidon_constants.rs
@@ -3533,8 +3533,8 @@ mod test {
             let poseidon_hasher = Poseidon::<Fr>::from(&ROUND_PARAMS);
             let poseidon_parameters = poseidon_hasher.get_parameters();
             for i in 0..poseidon_parameters.len() {
-                assert_eq!(loaded_c[i], poseidon_parameters[i].c);
-                assert_eq!(loaded_m[i], poseidon_parameters[i].m);
+                assert_eq!(loaded_c[i], poseidon_parameters[i].ark_consts);
+                assert_eq!(loaded_m[i], poseidon_parameters[i].mds);
             }
         } else {
             unreachable!();


### PR DESCRIPTION
NOTE: While this is in draft phase, I'll be working using the changes made in the add-rust-overlay branch

We currently use an internal implementation of the Poseidon hashing algorithm. 

There are other implementations of Poseidon, and we need empirical data to make future decisions.

Initial plan 
- familiarise myself with existing benchmarks
- add/refine to the benchmarks
- bring in [light_poseidon](https://docs.rs/light-poseidon/latest/light_poseidon/) (and other promising impls)
- deploy the hasher thunder-dome, and get some answers.

<details>
<summary>Notes taken</summary>

light_poseidon parameters:

```rust
/// Parameters for the Poseidon hash algorithm.
pub struct PoseidonParameters<F: PrimeField> {
    /// Round constants.
    pub ark: Vec<F>,
    /// MDS matrix.
    pub mds: Vec<Vec<F>>,
    /// Number of full rounds (where S-box is applied to all elements of the
    /// state).
    pub full_rounds: usize,
    /// Number of partial rounds (where S-box is applied only to the first
    /// element of the state).
    pub partial_rounds: usize,
    /// Number of prime fields in the state.
    pub width: usize,
    /// Exponential used in S-box to power elements of the state.
    pub alpha: u64,
}
```

our corresponding struct:

```rust
#[derive(Debug, Clone, PartialEq, Eq)]
pub struct RoundParameters<F: PrimeField> {
    /// input-length + 1
    pub rate: usize,
    pub n_rounds_full: usize,
    pub n_rounds_partial: usize,
    pub skip_matrices: usize,
    pub ark_consts: Vec<F>,
    pub mds: Vec<Vec<F>>,
}
```

...but for our impl, you must provide an array of tuples to create what is a vector of parameters, e.g.:

```rust
// rate, full rounds, partial rounds, skip matrix
const ROUND_PARAMS: [(usize, usize, usize, usize); 8] = [
    (2, 8, 56, 0),
    (3, 8, 57, 0),
    (4, 8, 56, 0),
    (5, 8, 60, 0),
    (6, 8, 60, 0),
    (7, 8, 63, 0),
    (8, 8, 64, 0),
    (9, 8, 63, 0),
];
```

...which for this e.g. provides:

```
r   f  p   s  clen mlen
(2, 8, 56, 0, 128, 2)
(3, 8, 57, 0, 195, 3)
(4, 8, 56, 0, 256, 4)
(5, 8, 60, 0, 340, 5)
(6, 8, 60, 0, 408, 6)
(7, 8, 63, 0, 497, 7)
(8, 8, 64, 0, 576, 8)
(9, 8, 63, 0, 639, 9)
```

looking at the implementation, this collection of parameters gets selected at runtime:
```rust
    pub fn hash(&self, inp: &[F]) -> Result<F, String> {
        // Note that the rate becomes input length + 1; hence for length N we pick parameters with T = N + 1
        let rate = inp.len() + 1;

        // We seek the index (Poseidon's round_params is an ordered vector) for the parameters corresponding to `rate`
        let param_index = self.round_params.iter().position(|el| el.rate == rate);
```

...and the chosen param_index is the entry in the collection of generated parameters.

As for difference in params: we have the skip matrix field, they have the alpha field.

The light-poseidon ecosystem generates `5` for the `alpha` field when generating for `bn254_x5`. I need to investigate this parameter.

Our benchmarks do not use skip matrices.

</details>

Initial results:

![image](https://github.com/user-attachments/assets/453451ed-4269-4320-8e56-29336b5c7e85)