### PR TITLE
nix: add RLN targets for different platforms

### DIFF
--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://vac.dev"
 repository = "https://github.com/vacp2p/zerokit"
 
 [lib]
-crate-type = ["rlib", "staticlib"]
+crate-type = ["rlib", "staticlib", "cdylib"]
 bench = false
 
 # This flag disable cargo doctests, i.e. testing example code-snippets in documentation


### PR DESCRIPTION
Wanted to be able to build `wakucanary` without having to build `zerokit` manually.
Also adds the `release` flag which can be set to `false` for a debug build.

Depends on:
- https://github.com/vacp2p/zerokit/pull/312