### PR TITLE
feat: resolve overlap between stateless and merkletree feature flags

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -121,7 +121,7 @@ jobs:
           if [[ ${{ matrix.feature }} == *parallel* ]]; then
             env RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals" \
             rustup run nightly wasm-pack build --release --target web --scope waku \
-            --features {{ matrix.feature }} -Z build-std=panic_abort,std
+            --features ${{ matrix.feature }} -Z build-std=panic_abort,std
 
             wasm-bindgen --target web --split-linked-modules --out-dir ./pkg \
             ./target/wasm32-unknown-unknown/release/rln_wasm.wasm

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -35,8 +35,12 @@ jobs:
       - name: Cross build
         run: |
           FEATURES="${{ matrix.feature }}"
-
-          cross build --release --target ${{ matrix.target }} --features $FEATURES --workspace --exclude rln-cli
+          if [[ "$FEATURES" == *"stateless"* ]]; then
+            NO_DEFAULT="--no-default-features"
+          else
+            NO_DEFAULT=""
+          fi
+          cross build --release --target ${{ matrix.target }} $NO_DEFAULT --features $FEATURES --workspace --exclude rln-cli
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/
@@ -77,8 +81,12 @@ jobs:
       - name: Cross build
         run: |
           FEATURES="${{ matrix.feature }}"
-
-          cross build --release --target ${{ matrix.target }} --features $FEATURES --workspace --exclude rln-cli
+          if [[ "$FEATURES" == *"stateless"* ]]; then
+            NO_DEFAULT="--no-default-features"
+          else
+            NO_DEFAULT=""
+          fi
+          cross build --release --target ${{ matrix.target }} $NO_DEFAULT --features $FEATURES --workspace --exclude rln-cli
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -118,7 +118,7 @@ jobs:
           sudo apt-get install -y binaryen
       - name: Build wasm package
         run: |
-          if [[ "{{ matrix.feature }}" == *"parallel"* ]]; then
+          if [[ ${{ matrix.feature }} == *parallel* ]]; then
             env RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals" \
             rustup run nightly wasm-pack build --release --target web --scope waku \
             --features {{ matrix.feature }} -Z build-std=panic_abort,std

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -34,7 +34,7 @@ jobs:
         run: make installdeps
       - name: Cross build
         run: |
-          cross build --release --target ${{ matrix.target }} --no-default-features --features $FEATURES --workspace --exclude rln-cli
+          cross build --release --target ${{ matrix.target }} --no-default-features --features ${{ matrix.feature }} --workspace --exclude rln-cli
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/
@@ -74,7 +74,7 @@ jobs:
         run: make installdeps
       - name: Cross build
         run: |
-          cross build --release --target ${{ matrix.target }} --no-default-features --features $FEATURES --workspace --exclude rln-cli
+          cross build --release --target ${{ matrix.target }} --no-default-features --features ${{ matrix.feature }} --workspace --exclude rln-cli
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/
@@ -118,12 +118,10 @@ jobs:
           sudo apt-get install -y binaryen
       - name: Build wasm package
         run: |
-          FEATURES="${{ matrix.feature }}"
-
-          if [[ "$FEATURES" == *"parallel"* ]]; then
+          if [[ "{{ matrix.feature }}" == *"parallel"* ]]; then
             env RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals" \
             rustup run nightly wasm-pack build --release --target web --scope waku \
-            --features $FEATURES -Z build-std=panic_abort,std
+            --features {{ matrix.feature }} -Z build-std=panic_abort,std
 
             wasm-bindgen --target web --split-linked-modules --out-dir ./pkg \
             ./target/wasm32-unknown-unknown/release/rln_wasm.wasm
@@ -136,7 +134,7 @@ jobs:
             -exec sed -i.bak 's|await initWbg(module, memory);|await initWbg({ module, memory });|g' {} \; \
             -exec rm -f {}.bak \;
           else
-            wasm-pack build --release --target web --scope waku --features $FEATURES
+            wasm-pack build --release --target web --scope waku --features {{ matrix.feature }}
           fi
 
           sed -i.bak 's/rln-wasm/zerokit-rln-wasm/g' pkg/package.json && rm pkg/package.json.bak

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -134,7 +134,7 @@ jobs:
             -exec sed -i.bak 's|await initWbg(module, memory);|await initWbg({ module, memory });|g' {} \; \
             -exec rm -f {}.bak \;
           else
-            wasm-pack build --release --target web --scope waku --features {{ matrix.feature }}
+            wasm-pack build --release --target web --scope waku --features ${{ matrix.feature }}
           fi
 
           sed -i.bak 's/rln-wasm/zerokit-rln-wasm/g' pkg/package.json && rm pkg/package.json.bak

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -34,13 +34,7 @@ jobs:
         run: make installdeps
       - name: Cross build
         run: |
-          FEATURES="${{ matrix.feature }}"
-          if [[ "$FEATURES" == *"stateless"* ]]; then
-            NO_DEFAULT="--no-default-features"
-          else
-            NO_DEFAULT=""
-          fi
-          cross build --release --target ${{ matrix.target }} $NO_DEFAULT --features $FEATURES --workspace --exclude rln-cli
+          cross build --release --target ${{ matrix.target }} --no-default-features --features $FEATURES --workspace --exclude rln-cli
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/
@@ -80,13 +74,7 @@ jobs:
         run: make installdeps
       - name: Cross build
         run: |
-          FEATURES="${{ matrix.feature }}"
-          if [[ "$FEATURES" == *"stateless"* ]]; then
-            NO_DEFAULT="--no-default-features"
-          else
-            NO_DEFAULT=""
-          fi
-          cross build --release --target ${{ matrix.target }} $NO_DEFAULT --features $FEATURES --workspace --exclude rln-cli
+          cross build --release --target ${{ matrix.target }} --no-default-features --features $FEATURES --workspace --exclude rln-cli
           mkdir release
           cp target/${{ matrix.target }}/release/librln* release/
           tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/

--- a/rln-cli/Cargo.toml
+++ b/rln-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/examples/stateless.rs"
 required-features = ["stateless"]
 
 [dependencies]
-rln = { path = "../rln", version = "0.8.0", default-features = true }
+rln = { path = "../rln", version = "0.8.0", default-features = false }
 zerokit_utils = { path = "../utils", version = "0.6.0", default-features = false }
 clap = { version = "4.5.41", features = ["cargo", "derive", "env"] }
 color-eyre = "0.6.5"
@@ -21,5 +21,5 @@ serde_json = "1.0.141"
 serde = { version = "1.0", features = ["derive"] }
 
 [features]
-default = []
-stateless = ["rln/stateless"]
+default = ["rln/pmtree-ft", "rln/parallel"]
+stateless = ["rln/stateless", "rln/parallel"]

--- a/rln-cli/README.md
+++ b/rln-cli/README.md
@@ -50,7 +50,7 @@ This example function similarly to the [Relay Example](#relay-example) but uses 
 You can run the example using the following command:
 
 ```bash
-cargo run --example stateless --features stateless
+cargo run --example stateless --no-default-features --features stateless
 ```
 
 ## CLI Commands

--- a/rln-cli/src/examples/relay.rs
+++ b/rln-cli/src/examples/relay.rs
@@ -7,13 +7,12 @@ use std::{
 
 use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Report, Result};
-use rln::utils::IdSecret;
 use rln::{
     circuit::Fr,
     hashers::{hash_to_field, poseidon_hash},
     protocol::{keygen, prepare_prove_input, prepare_verify_input},
     public::RLN,
-    utils::{fr_to_bytes_le, generate_input_buffer},
+    utils::{fr_to_bytes_le, generate_input_buffer, IdSecret},
 };
 
 const MESSAGE_LIMIT: u32 = 1;

--- a/rln-cli/src/examples/stateless.rs
+++ b/rln-cli/src/examples/stateless.rs
@@ -132,7 +132,8 @@ impl RLNSystem {
 
         let rln_witness = rln_witness_from_values(
             identity.identity_secret_hash.clone(),
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x,
             external_nullifier,
             Fr::from(MESSAGE_LIMIT),

--- a/rln-cli/src/examples/stateless.rs
+++ b/rln-cli/src/examples/stateless.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "stateless")]
+
 use std::{
     collections::HashMap,
     io::{stdin, stdout, Cursor, Write},
@@ -6,16 +7,14 @@ use std::{
 
 use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Result};
-use rln::utils::IdSecret;
 use rln::{
     circuit::{Fr, TEST_TREE_HEIGHT},
-    hashers::{hash_to_field, poseidon_hash},
-    poseidon_tree::PoseidonTree,
+    hashers::{hash_to_field, poseidon_hash, PoseidonHash},
     protocol::{keygen, prepare_verify_input, rln_witness_from_values, serialize_witness},
     public::RLN,
-    utils::fr_to_bytes_le,
+    utils::{fr_to_bytes_le, IdSecret},
 };
-use zerokit_utils::ZerokitMerkleTree;
+use zerokit_utils::{OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree};
 
 const MESSAGE_LIMIT: u32 = 1;
 
@@ -62,7 +61,7 @@ impl Identity {
 
 struct RLNSystem {
     rln: RLN,
-    tree: PoseidonTree,
+    tree: OptimalMerkleTree<PoseidonHash>,
     used_nullifiers: HashMap<[u8; 32], Vec<u8>>,
     local_identities: HashMap<usize, Identity>,
 }
@@ -71,11 +70,12 @@ impl RLNSystem {
     fn new() -> Result<Self> {
         let rln = RLN::new()?;
         let default_leaf = Fr::from(0);
-        let tree = PoseidonTree::new(
+        let tree: OptimalMerkleTree<PoseidonHash> = OptimalMerkleTree::new(
             TEST_TREE_HEIGHT,
             default_leaf,
-            ConfigOf::<PoseidonTree>::default(),
-        )?;
+            ConfigOf::<OptimalMerkleTree<PoseidonHash>>::default(),
+        )
+        .unwrap();
 
         Ok(RLNSystem {
             rln,

--- a/rln-wasm/Cargo.toml
+++ b/rln-wasm/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 rln = { path = "../rln", version = "0.8.0", default-features = false, features = [
     "stateless",
-    "fullmerkletree",
 ] }
 zerokit_utils = { path = "../utils", version = "0.6.0", default-features = false }
 num-bigint = { version = "0.4.6", default-features = false }

--- a/rln-wasm/tests/browser.rs
+++ b/rln-wasm/tests/browser.rs
@@ -4,8 +4,7 @@
 mod tests {
     use js_sys::{BigInt as JsBigInt, Date, Object, Uint8Array};
     use rln::circuit::{Fr, TEST_TREE_HEIGHT};
-    use rln::hashers::{hash_to_field, poseidon_hash};
-    use rln::poseidon_tree::PoseidonTree;
+    use rln::hashers::{hash_to_field, poseidon_hash, PoseidonHash};
     use rln::protocol::{prepare_verify_input, rln_witness_from_values, serialize_witness};
     use rln::utils::{bytes_le_to_fr, fr_to_bytes_le, IdSecret};
     use rln_wasm::{
@@ -14,7 +13,9 @@ mod tests {
     };
     use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
     use wasm_bindgen_test::{console_log, wasm_bindgen_test, wasm_bindgen_test_configure};
-    use zerokit_utils::merkle_tree::merkle_tree::ZerokitMerkleTree;
+    use zerokit_utils::{
+        OptimalMerkleProof, OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree,
+    };
 
     #[cfg(feature = "parallel")]
     use {rln_wasm::init_thread_pool, wasm_bindgen_futures::JsFuture, web_sys::window};
@@ -64,7 +65,7 @@ mod tests {
 
     const WITNESS_CALCULATOR_JS: &str = include_str!("../resources/witness_calculator_browser.js");
 
-    const ARKZKEY_BYTES: &[u8] =
+    const ZKEY_BYTES: &[u8] =
         include_bytes!("../../rln/resources/tree_height_20/rln_final.arkzkey");
 
     const CIRCOM_BYTES: &[u8] = include_bytes!("../../rln/resources/tree_height_20/rln.wasm");
@@ -95,7 +96,7 @@ mod tests {
         let mut results = String::from("\nbenchmarks:\n");
         let iterations = 10;
 
-        let zkey = readFile(&ARKZKEY_BYTES).expect("Failed to read zkey file");
+        let zkey = readFile(&ZKEY_BYTES).expect("Failed to read zkey file");
 
         // Benchmark wasm_new
         let start_wasm_new = Date::now();
@@ -106,7 +107,8 @@ mod tests {
 
         // Create RLN instance for other benchmarks
         let rln_instance = wasm_new(zkey).expect("Failed to create RLN instance");
-        let mut tree = PoseidonTree::default(TEST_TREE_HEIGHT).expect("Failed to create tree");
+        let mut tree: OptimalMerkleTree<PoseidonHash> =
+            OptimalMerkleTree::default(TEST_TREE_HEIGHT).expect("Failed to create tree");
 
         // Benchmark wasm_key_gen
         let start_wasm_key_gen = Date::now();
@@ -137,13 +139,14 @@ mod tests {
         let signal: [u8; 32] = [0; 32];
         let x = hash_to_field(&signal);
 
-        let merkle_proof = tree
+        let merkle_proof: OptimalMerkleProof<PoseidonHash> = tree
             .proof(identity_index)
             .expect("Failed to generate merkle proof");
 
         let rln_witness = rln_witness_from_values(
             identity_secret_hash,
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x,
             external_nullifier,
             user_message_limit,

--- a/rln-wasm/tests/browser.rs
+++ b/rln-wasm/tests/browser.rs
@@ -65,7 +65,7 @@ mod tests {
 
     const WITNESS_CALCULATOR_JS: &str = include_str!("../resources/witness_calculator_browser.js");
 
-    const ZKEY_BYTES: &[u8] =
+    const ARKZKEY_BYTES: &[u8] =
         include_bytes!("../../rln/resources/tree_height_20/rln_final.arkzkey");
 
     const CIRCOM_BYTES: &[u8] = include_bytes!("../../rln/resources/tree_height_20/rln.wasm");
@@ -96,7 +96,7 @@ mod tests {
         let mut results = String::from("\nbenchmarks:\n");
         let iterations = 10;
 
-        let zkey = readFile(&ZKEY_BYTES).expect("Failed to read zkey file");
+        let zkey = readFile(&ARKZKEY_BYTES).expect("Failed to read zkey file");
 
         // Benchmark wasm_new
         let start_wasm_new = Date::now();

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1.0", features = ["derive"] }
 document-features = { version = "0.2.11", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.6.0", features = ["html_reports"] }
+criterion = { version = "0.7.0", features = ["html_reports"] }
 
 [features]
 default = ["parallel", "pmtree-ft"]

--- a/rln/Makefile.toml
+++ b/rln/Makefile.toml
@@ -8,7 +8,7 @@ args = ["test", "--release", "--", "--nocapture"]
 
 [tasks.test_stateless]
 command = "cargo"
-args = ["test", "--release", "--features", "stateless"]
+args = ["test", "--release", "--no-default-features", "--features", "stateless"]
 
 [tasks.bench]
 command = "cargo"

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -13,15 +13,13 @@ pub mod public;
 pub mod public_api_tests;
 pub mod utils;
 
-// Feature validation for incompatible combinations
-#[cfg(all(feature = "fullmerkletree", feature = "optimalmerkletree"))]
-compile_error!("Cannot enable both fullmerkletree and optimalmerkletree");
-
-#[cfg(all(feature = "fullmerkletree", feature = "pmtree-ft"))]
-compile_error!("Cannot enable both fullmerkletree and pmtree-ft");
-
-#[cfg(all(feature = "optimalmerkletree", feature = "pmtree-ft"))]
-compile_error!("Cannot enable both optimalmerkletree and pmtree-ft");
+// Ensure that only one Merkle tree feature is enabled at a time
+#[cfg(any(
+    all(feature = "fullmerkletree", feature = "optimalmerkletree"),
+    all(feature = "fullmerkletree", feature = "pmtree-ft"),
+    all(feature = "optimalmerkletree", feature = "pmtree-ft"),
+))]
+compile_error!("Only one of `fullmerkletree`, `optimalmerkletree`, or `pmtree-ft` can be enabled at a time.");
 
 #[cfg(all(
     feature = "stateless",

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -29,4 +29,4 @@ compile_error!("Only one of `fullmerkletree`, `optimalmerkletree`, or `pmtree-ft
         feature = "pmtree-ft"
     )
 ))]
-compile_error!("Cannot enable any merkletree features with stateless");
+compile_error!("Cannot enable any Merkle tree features with stateless");

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -5,9 +5,30 @@ pub mod ffi;
 pub mod hashers;
 #[cfg(feature = "pmtree-ft")]
 pub mod pm_tree_adapter;
+#[cfg(not(feature = "stateless"))]
 pub mod poseidon_tree;
 pub mod protocol;
 pub mod public;
 #[cfg(test)]
 pub mod public_api_tests;
 pub mod utils;
+
+// Feature validation for incompatible combinations
+#[cfg(all(feature = "fullmerkletree", feature = "optimalmerkletree"))]
+compile_error!("Cannot enable both fullmerkletree and optimalmerkletree");
+
+#[cfg(all(feature = "fullmerkletree", feature = "pmtree-ft"))]
+compile_error!("Cannot enable both fullmerkletree and pmtree-ft");
+
+#[cfg(all(feature = "optimalmerkletree", feature = "pmtree-ft"))]
+compile_error!("Cannot enable both optimalmerkletree and pmtree-ft");
+
+#[cfg(all(
+    feature = "stateless",
+    any(
+        feature = "fullmerkletree",
+        feature = "optimalmerkletree",
+        feature = "pmtree-ft"
+    )
+))]
+compile_error!("Cannot enable any merkletree features with stateless");

--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -19,8 +19,11 @@ pub mod utils;
     all(feature = "fullmerkletree", feature = "pmtree-ft"),
     all(feature = "optimalmerkletree", feature = "pmtree-ft"),
 ))]
-compile_error!("Only one of `fullmerkletree`, `optimalmerkletree`, or `pmtree-ft` can be enabled at a time.");
+compile_error!(
+    "Only one of `fullmerkletree`, `optimalmerkletree`, or `pmtree-ft` can be enabled at a time."
+);
 
+// Ensure that the `stateless` feature is not enabled with any Merkle tree features
 #[cfg(all(
     feature = "stateless",
     any(

--- a/rln/src/poseidon_tree.rs
+++ b/rln/src/poseidon_tree.rs
@@ -1,7 +1,7 @@
 // This crate defines the RLN module default Merkle tree implementation and its Hasher
-
 // Implementation inspired by https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/poseidon_tree.rs (no differences)
 
+#![cfg(not(feature = "stateless"))]
 use cfg_if::cfg_if;
 
 // The zerokit RLN default Merkle tree implementation is the PMTree from the vacp2p_pmtree crate

--- a/rln/src/poseidon_tree.rs
+++ b/rln/src/poseidon_tree.rs
@@ -1,7 +1,8 @@
 // This crate defines the RLN module default Merkle tree implementation and its Hasher
-// Implementation inspired by https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/poseidon_tree.rs (no differences)
+// Implementation inspired by https://github.com/worldcoin/semaphore-rs/blob/d462a4372f1fd9c27610f2acfe4841fab1d396aa/src/poseidon_tree.rs
 
 #![cfg(not(feature = "stateless"))]
+
 use cfg_if::cfg_if;
 
 // The zerokit RLN default Merkle tree implementation is the PMTree from the vacp2p_pmtree crate
@@ -20,6 +21,11 @@ cfg_if! {
 
         pub type PoseidonTree = OptimalMerkleTree<PoseidonHash>;
         pub type MerkleProof = OptimalMerkleProof<PoseidonHash>;
+    } else if #[cfg(feature = "pmtree-ft")] {
+        use crate::pm_tree_adapter::{PmTree, PmTreeProof};
+
+        pub type PoseidonTree = PmTree;
+        pub type MerkleProof = PmTreeProof;
     } else {
         use crate::pm_tree_adapter::{PmTree, PmTreeProof};
 

--- a/rln/src/poseidon_tree.rs
+++ b/rln/src/poseidon_tree.rs
@@ -27,9 +27,6 @@ cfg_if! {
         pub type PoseidonTree = PmTree;
         pub type MerkleProof = PmTreeProof;
     } else {
-        use crate::pm_tree_adapter::{PmTree, PmTreeProof};
-
-        pub type PoseidonTree = PmTree;
-        pub type MerkleProof = PmTreeProof;
+        compile_error!("One of the features `fullmerkletree`, `optimalmerkletree`, or `pmtree-ft` must be enabled.");
     }
 }

--- a/rln/src/public_api_tests.rs
+++ b/rln/src/public_api_tests.rs
@@ -994,12 +994,12 @@ mod tree_test {
 #[cfg(feature = "stateless")]
 mod stateless_test {
     use crate::circuit::{Fr, TEST_TREE_HEIGHT};
-    use crate::hashers::{hash_to_field, poseidon_hash as utils_poseidon_hash};
+    use crate::hashers::{hash_to_field, poseidon_hash as utils_poseidon_hash, PoseidonHash};
     use crate::protocol::*;
     use crate::public::RLN;
     use crate::utils::*;
     use std::io::Cursor;
-    use utils::{OptimalMerkleProof, OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree};
+    use utils::{OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree};
 
     use ark_std::{rand::thread_rng, UniformRand};
     use rand::Rng;
@@ -1012,10 +1012,10 @@ mod stateless_test {
         let mut rln = RLN::new().unwrap();
 
         let default_leaf = Fr::from(0);
-        let mut tree = PoseidonTree::new(
+        let mut tree: OptimalMerkleTree<PoseidonHash> = OptimalMerkleTree::new(
             TEST_TREE_HEIGHT,
             default_leaf,
-            ConfigOf::<PoseidonTree>::default(),
+            ConfigOf::<OptimalMerkleTree<PoseidonHash>>::default(),
         )
         .unwrap();
 
@@ -1110,10 +1110,10 @@ mod stateless_test {
         let mut rln = RLN::new().unwrap();
 
         let default_leaf = Fr::from(0);
-        let mut tree = PoseidonTree::new(
+        let mut tree: OptimalMerkleTree<PoseidonHash> = OptimalMerkleTree::new(
             TEST_TREE_HEIGHT,
             default_leaf,
-            ConfigOf::<PoseidonTree>::default(),
+            ConfigOf::<OptimalMerkleTree<PoseidonHash>>::default(),
         )
         .unwrap();
 
@@ -1210,8 +1210,8 @@ mod stateless_test {
 
         let rln_witness3 = rln_witness_from_values(
             identity_secret_hash_new.clone(),
-            merkle_proof.get_path_elements(),
-            merkle_proof.get_path_index(),
+            merkle_proof_new.get_path_elements(),
+            merkle_proof_new.get_path_index(),
             x3,
             external_nullifier,
             user_message_limit,

--- a/rln/src/public_api_tests.rs
+++ b/rln/src/public_api_tests.rs
@@ -995,12 +995,11 @@ mod tree_test {
 mod stateless_test {
     use crate::circuit::{Fr, TEST_TREE_HEIGHT};
     use crate::hashers::{hash_to_field, poseidon_hash as utils_poseidon_hash};
-    use crate::poseidon_tree::PoseidonTree;
     use crate::protocol::*;
     use crate::public::RLN;
     use crate::utils::*;
     use std::io::Cursor;
-    use utils::ZerokitMerkleTree;
+    use utils::{OptimalMerkleProof, OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree};
 
     use ark_std::{rand::thread_rng, UniformRand};
     use rand::Rng;
@@ -1047,7 +1046,8 @@ mod stateless_test {
 
         let rln_witness = rln_witness_from_values(
             identity_secret_hash,
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x,
             external_nullifier,
             user_message_limit,
@@ -1142,7 +1142,8 @@ mod stateless_test {
 
         let rln_witness1 = rln_witness_from_values(
             identity_secret_hash.clone(),
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x1,
             external_nullifier,
             user_message_limit,
@@ -1152,7 +1153,8 @@ mod stateless_test {
 
         let rln_witness2 = rln_witness_from_values(
             identity_secret_hash.clone(),
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x2,
             external_nullifier,
             user_message_limit,
@@ -1208,7 +1210,8 @@ mod stateless_test {
 
         let rln_witness3 = rln_witness_from_values(
             identity_secret_hash_new.clone(),
-            &merkle_proof_new,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x3,
             external_nullifier,
             user_message_limit,

--- a/rln/tests/ffi.rs
+++ b/rln/tests/ffi.rs
@@ -990,14 +990,15 @@ mod stateless_test {
     use rln::circuit::*;
     use rln::ffi::generate_rln_proof_with_witness;
     use rln::ffi::{hash as ffi_hash, poseidon_hash as ffi_poseidon_hash, *};
-    use rln::hashers::{hash_to_field, poseidon_hash as utils_poseidon_hash, ROUND_PARAMS};
-    use rln::poseidon_tree::PoseidonTree;
+    use rln::hashers::{
+        hash_to_field, poseidon_hash as utils_poseidon_hash, PoseidonHash, ROUND_PARAMS,
+    };
     use rln::protocol::*;
     use rln::public::RLN;
     use rln::utils::*;
     use std::mem::MaybeUninit;
     use std::time::{Duration, Instant};
-    use utils::ZerokitMerkleTree;
+    use utils::{OptimalMerkleTree, ZerokitMerkleProof, ZerokitMerkleTree};
 
     type ConfigOf<T> = <T as ZerokitMerkleTree>::Config;
 
@@ -1032,10 +1033,10 @@ mod stateless_test {
     #[test]
     fn test_recover_id_secret_stateless_ffi() {
         let default_leaf = Fr::from(0);
-        let mut tree = PoseidonTree::new(
+        let mut tree: OptimalMerkleTree<PoseidonHash> = OptimalMerkleTree::new(
             TEST_TREE_HEIGHT,
             default_leaf,
-            ConfigOf::<PoseidonTree>::default(),
+            ConfigOf::<OptimalMerkleTree<PoseidonHash>>::default(),
         )
         .unwrap();
 
@@ -1068,7 +1069,8 @@ mod stateless_test {
         // We prepare input for generate_rln_proof API
         let rln_witness1 = rln_witness_from_values(
             identity_secret_hash.clone(),
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x1,
             external_nullifier,
             user_message_limit,
@@ -1079,7 +1081,8 @@ mod stateless_test {
 
         let rln_witness2 = rln_witness_from_values(
             identity_secret_hash.clone(),
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x2,
             external_nullifier,
             user_message_limit,
@@ -1134,7 +1137,8 @@ mod stateless_test {
 
         let rln_witness3 = rln_witness_from_values(
             identity_secret_hash_new.clone(),
-            &merkle_proof_new,
+            merkle_proof_new.get_path_elements(),
+            merkle_proof_new.get_path_index(),
             x3,
             external_nullifier,
             user_message_limit,
@@ -1175,10 +1179,10 @@ mod stateless_test {
     #[test]
     fn test_verify_with_roots_stateless_ffi() {
         let default_leaf = Fr::from(0);
-        let mut tree = PoseidonTree::new(
+        let mut tree: OptimalMerkleTree<PoseidonHash> = OptimalMerkleTree::new(
             TEST_TREE_HEIGHT,
             default_leaf,
-            ConfigOf::<PoseidonTree>::default(),
+            ConfigOf::<OptimalMerkleTree<PoseidonHash>>::default(),
         )
         .unwrap();
 
@@ -1208,7 +1212,8 @@ mod stateless_test {
         // We prepare input for generate_rln_proof API
         let rln_witness = rln_witness_from_values(
             identity_secret_hash,
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x,
             external_nullifier,
             user_message_limit,

--- a/rln/tests/poseidon_tree.rs
+++ b/rln/tests/poseidon_tree.rs
@@ -2,6 +2,8 @@
 // Tests
 ////////////////////////////////////////////////////////////
 
+#![cfg(not(feature = "stateless"))]
+
 #[cfg(test)]
 mod test {
     use rln::hashers::{poseidon_hash, PoseidonHash};

--- a/rln/tests/protocol.rs
+++ b/rln/tests/protocol.rs
@@ -119,7 +119,8 @@ mod test {
 
         rln_witness_from_values(
             identity_secret_hash,
-            &merkle_proof,
+            merkle_proof.get_path_elements(),
+            merkle_proof.get_path_index(),
             x,
             external_nullifier,
             user_message_limit,

--- a/rln/tests/protocol.rs
+++ b/rln/tests/protocol.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "stateless"))]
+
 #[cfg(test)]
 mod test {
     use ark_ff::BigInt;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -27,7 +27,7 @@ ark-bn254 = { version = "0.5.0", features = ["std"] }
 num-traits = "0.2.19"
 hex-literal = "0.4.1"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-criterion = { version = "0.6.0", features = ["html_reports"] }
+criterion = { version = "0.7.0", features = ["html_reports"] }
 
 [features]
 default = []


### PR DESCRIPTION
- Resolved overlap between stateless and merkletree feature flags.
- Updated every testcase related to stateless feature.
- Added compile-time feature check to avoid feature overlap.
- Added --no-default-features for all builds in nightly-release.yml [(tested)](https://github.com/vacp2p/zerokit/actions/runs/16525062203).