### PR TITLE
feat(rln-wasm-utils): extracting the generation and hash functions into a separate module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - "!rln/src/**"
       - "!rln/resources/**"
       - "!utils/src/**"
+      - "!rln-wasm-utils/**"
   pull_request:
     paths-ignore:
       - "**.md"
@@ -17,6 +18,7 @@ on:
       - "!rln/src/**"
       - "!rln/resources/**"
       - "!utils/src/**"
+      - "!rln-wasm-utils/**"
 
 name: Tests
 
@@ -124,12 +126,32 @@ jobs:
         run: cargo make test_parallel --release
         working-directory: ${{ matrix.crate }}
 
+  rln-wasm-utils-test:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+        crate: [rln-wasm-utils]
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 60
+
+    name: Test - ${{ matrix.crate }} - ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        run: make installdeps
+      - name: Test rln-wasm-utils
+        run: cargo make test --release
+        working-directory: ${{ matrix.crate }}
+
   lint:
     strategy:
       matrix:
         # we run lint tests only on ubuntu
         platform: [ubuntu-latest]
-        crate: [rln, rln-wasm, utils]
+        crate: [rln, rln-wasm, rln-wasm-utils, utils]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -145,9 +145,59 @@ jobs:
           path: rln-wasm/browser-${{ matrix.feature }}-rln-wasm.tar.gz
           retention-days: 2
 
+  rln-wasm-utils:
+    name: Browser build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature:
+          - "default"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-unknown-unknown
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm-${{ matrix.feature }}
+      - name: Install dependencies
+        run: make installdeps
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install binaryen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binaryen
+      - name: Build wasm package
+        run: |
+          wasm-pack build --release --target web --scope waku --features ${{ matrix.feature }}
+          
+          sed -i.bak 's/rln-wasm-utils/zerokit-rln-wasm-utils/g' pkg/package.json && rm pkg/package.json.bak
+          
+          wasm-opt pkg/rln_wasm_utils_bg.wasm -Oz --strip-debug --strip-dwarf \
+          --remove-unused-module-elements --vacuum -o pkg/rln_wasm_utils_bg.wasm
+          
+          mkdir release
+          cp -r pkg/* release/
+          tar -czvf browser-rln-wasm-utils-${{ matrix.feature }}.tar.gz release/
+        working-directory: rln-wasm-utils
+      - name: Upload archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Browser-${{ matrix.feature }}-rln-wasm-utils-archive
+          path: rln-wasm-utils/browser-rln-wasm-utils-${{ matrix.feature }}.tar.gz
+          retention-days: 2
+
   prepare-prerelease:
     name: Prepare pre-release
-    needs: [linux, macos, browser-rln-wasm]
+    needs: [linux, macos, browser-rln-wasm, rln-wasm-utils]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["rln", "rln-cli", "utils"]
-exclude = ["rln-wasm"]
+exclude = ["rln-wasm", "rln-wasm-utils"]
 resolver = "2"
 
 # Compilation profile for any non-workspace member.

--- a/rln-cli/src/examples/relay.rs
+++ b/rln-cli/src/examples/relay.rs
@@ -9,7 +9,7 @@ use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Report, Result};
 use rln::{
     circuit::Fr,
-    hashers::{hash_to_field, poseidon_hash},
+    hashers::{hash_to_field_le, poseidon_hash},
     protocol::{keygen, prepare_prove_input, prepare_verify_input},
     public::RLN,
     utils::{fr_to_bytes_le, generate_input_buffer, IdSecret},
@@ -244,8 +244,8 @@ fn main() -> Result<()> {
     println!("Initializing RLN instance...");
     print!("\x1B[2J\x1B[1;1H");
     let mut rln_system = RLNSystem::new()?;
-    let rln_epoch = hash_to_field(b"epoch");
-    let rln_identifier = hash_to_field(b"rln-identifier");
+    let rln_epoch = hash_to_field_le(b"epoch");
+    let rln_identifier = hash_to_field_le(b"rln-identifier");
     let external_nullifier = poseidon_hash(&[rln_epoch, rln_identifier]);
     println!("RLN Relay Example:");
     println!("Message Limit: {MESSAGE_LIMIT}");

--- a/rln-cli/src/examples/stateless.rs
+++ b/rln-cli/src/examples/stateless.rs
@@ -9,7 +9,7 @@ use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Result};
 use rln::{
     circuit::{Fr, TEST_TREE_HEIGHT},
-    hashers::{hash_to_field, poseidon_hash, PoseidonHash},
+    hashers::{hash_to_field_le, poseidon_hash, PoseidonHash},
     protocol::{keygen, prepare_verify_input, rln_witness_from_values, serialize_witness},
     public::RLN,
     utils::{fr_to_bytes_le, IdSecret},

--- a/rln-wasm-utils/.gitignore
+++ b/rln-wasm-utils/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/rln-wasm-utils/Cargo.toml
+++ b/rln-wasm-utils/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "rln-wasm-utils"
+version = "0.1.0"
+edition = "2024"
+
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# TODO: remove this once we have a proper release
+rln = { path = "../rln", default-features = false, features = ["stateless"] }
+num-bigint = { version = "0.4.6", default-features = false }
+js-sys = "0.3.77"
+wasm-bindgen = "0.2.100"
+rand = "0.8.5"
+ark-std = { version = "0.5.0"}
+
+# The `console_error_panic_xhook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.7", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.16", features = ["js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.37"
+web-sys = { version = "0.3.77", features = ["console"] }
+
+[features]
+default = ["console_error_panic_hook"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/rln-wasm-utils/Makefile.toml
+++ b/rln-wasm-utils/Makefile.toml
@@ -1,0 +1,44 @@
+[tasks.build]
+clear = true
+dependencies = ["pack_build", "pack_rename", "pack_resize"]
+
+[tasks.pack_build]
+command = "wasm-pack"
+args = ["build", "--release", "--target", "web", "--scope", "waku"]
+
+[tasks.pack_rename]
+script = "sed -i.bak 's/rln-wasm-utils/zerokit-rln-wasm-utils/g' pkg/package.json && rm pkg/package.json.bak"
+
+[tasks.pack_resize]
+command = "wasm-opt"
+args = [
+    "pkg/rln_wasm_utils_bg.wasm",
+    "-Oz",
+    "--strip-debug",
+    "--strip-dwarf",
+    "--remove-unused-module-elements",
+    "--vacuum",
+    "-o",
+    "pkg/rln_wasm_utils_bg.wasm",
+]
+
+[tasks.test]
+command = "wasm-pack"
+args = [
+    "test",
+    "--release",
+    "--node",
+    "--target",
+    "wasm32-unknown-unknown",
+    "--",
+    "--nocapture",
+]
+dependencies = ["build"]
+
+[tasks.login]
+command = "wasm-pack"
+args = ["login"]
+
+[tasks.publish]
+command = "wasm-pack"
+args = ["publish", "--access", "public", "--target", "web"]

--- a/rln-wasm-utils/README.md
+++ b/rln-wasm-utils/README.md
@@ -1,0 +1,229 @@
+# RLN WASM Utils
+
+[![npm version](https://badge.fury.io/js/@waku%2Fzerokit-rln-wasm.svg)](https://badge.fury.io/js/@waku%2Fzerokit-rln-wasm-utils)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+The Zerokit RLN WASM Utils Module provides WebAssembly bindings for Rate-Limiting Nullifier [RLN](https://rfc.vac.dev/spec/32/) cryptographic primitives.
+This module offers comprehensive functionality for identity generation and hashing needed for RLN applications.
+
+## Features
+
+### Identity Generation
+
+- **Random Identity Generation**: Generate cryptographically secure random identities
+- **Seeded Identity Generation**: Generate deterministic identities from seeds
+- **Extended Identity Generation**: Generate extended identities with additional parameters
+- **Seeded Extended Identity Generation**: Generate deterministic extended identities from seeds
+
+### Hashing
+
+- **Standard Hashing**: Hash arbitrary data to field elements
+- **Poseidon Hashing**: Advanced cryptographic hashing using Poseidon hash function
+- **Endianness Support**: Both little-endian and big-endian serialization support
+
+## API Reference
+
+### Identity Generation Functions
+
+#### `generateMembershipKey(isLittleEndian: boolean): Uint8Array`
+
+Generates a random membership key pair (identity secret and commitment).
+
+**Parameters:**
+
+- `isLittleEndian`: Boolean indicating endianness for serialization
+
+**Returns:** Serialized identity pair as `Uint8Array`
+
+#### `generateExtendedMembershipKey(isLittleEndian: boolean): Uint8Array`
+
+Generates an extended membership key with additional parameters.
+
+**Parameters:**
+
+- `isLittleEndian`: Boolean indicating endianness for serialization
+
+**Returns:** Serialized extended identity tuple as `Uint8Array`
+
+#### `generateSeededMembershipKey(seed: Uint8Array, isLittleEndian: boolean): Uint8Array`
+
+Generates a deterministic membership key from a seed.
+
+**Parameters:**
+
+- `seed`: Seed data as `Uint8Array`
+- `isLittleEndian`: Boolean indicating endianness for serialization
+
+**Returns:** Serialized identity pair as `Uint8Array`
+
+#### `generateSeededExtendedMembershipKey(seed: Uint8Array, isLittleEndian: boolean): Uint8Array`
+
+Generates a deterministic extended membership key from a seed.
+
+**Parameters:**
+
+- `seed`: Seed data as `Uint8Array`
+- `isLittleEndian`: Boolean indicating endianness for serialization
+
+**Returns:** Serialized extended identity tuple as `Uint8Array`
+
+### Hashing Functions
+
+#### `hash(input: Uint8Array, isLittleEndian: boolean): Uint8Array`
+
+Hashes input data to a field element.
+
+**Parameters:**
+
+- `input`: Input data as `Uint8Array`
+- `isLittleEndian`: Boolean indicating endianness for serialization
+
+**Returns:** Serialized hash result as `Uint8Array`
+
+#### `poseidonHash(input: Uint8Array, isLittleEndian: boolean): Uint8Array`
+
+Computes Poseidon hash of input field elements.
+
+**Parameters:**
+
+- `input`: Serialized field elements as `Uint8Array` (format: length + field elements)
+- `isLittleEndian`: Boolean indicating endianness for serialization
+
+**Returns:** Serialized hash result as `Uint8Array`
+
+## Usage Examples
+
+### JavaScript/TypeScript
+
+```javascript
+import init, { 
+  generateMembershipKey, 
+  generateSeededMembershipKey,
+  hash,
+  poseidonHash 
+} from '@waku/zerokit-rln-wasm';
+
+// Initialize the WASM module
+await init();
+
+// Generate a random membership key
+const membershipKey = generateMembershipKey(true); // little-endian
+console.log('Membership key:', membershipKey);
+
+// Generate a deterministic membership key from seed
+const seed = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const seededKey = generateSeededMembershipKey(seed, true);
+console.log('Seeded key:', seededKey);
+
+// Hash some data
+const input = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const hashResult = hash(input, true);
+console.log('Hash result:', hashResult);
+
+// Poseidon hash with field elements
+const fieldElements = new Uint8Array([
+  // Length (8 bytes) + field elements (32 bytes each)
+  1, 0, 0, 0, 0, 0, 0, 0, // length = 1
+  // field element data...
+]);
+const poseidonResult = poseidonHash(fieldElements, true);
+console.log('Poseidon hash:', poseidonResult);
+```
+
+### Node.js
+
+```javascript
+const { 
+  generateMembershipKey, 
+  generateSeededMembershipKey,
+  hash 
+} = require('@waku/zerokit-rln-wasm');
+
+// Generate random membership key
+const membershipKey = generateMembershipKey(false); // big-endian
+console.log('Membership key:', membershipKey);
+
+// Generate seeded membership key
+const seed = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const seededKey = generateSeededMembershipKey(seed, false);
+console.log('Seeded key:', seededKey);
+
+// Hash data
+const input = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+const hashResult = hash(input, false);
+console.log('Hash result:', hashResult);
+```
+
+## Install Dependencies
+
+> [!NOTE]
+> This project requires the following tools:
+>
+> - `wasm-pack` - for compiling Rust to WebAssembly
+> - `cargo-make` - for running build commands
+> - `nvm` - to install and manage Node.js
+>
+> Ensure all dependencies are installed before proceeding.
+
+### Manually
+
+#### Install `wasm-pack`
+
+```bash
+cargo install wasm-pack --version=0.13.1
+```
+
+#### Install `cargo-make`
+
+```bash
+cargo install cargo-make
+```
+
+#### Install `Node.js`
+
+If you don't have `nvm` (Node Version Manager), install it by following
+the [installation instructions](https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script).
+
+After installing `nvm`, install and use Node.js `v22.14.0`:
+
+```bash
+nvm install 22.14.0
+nvm use 22.14.0
+nvm alias default 22.14.0
+```
+
+If you already have Node.js installed,
+check your version with `node -v` command — the version must be strictly greater than 22.
+
+### Or install everything
+
+You can run the following command from the root of the repository to install all required dependencies for `zerokit`
+
+```bash
+make installdeps
+```
+
+## Building the library
+
+First, navigate to the rln-wasm-utils directory:
+
+```bash
+cd rln-wasm-utils
+```
+
+Compile zerokit for `wasm32-unknown-unknown`:
+
+```bash
+cargo make build
+```
+
+## Running tests
+
+```bash
+cargo make test
+```
+
+## License
+
+This project is licensed under both MIT and Apache 2.0 licenses. See the LICENSE files for details.

--- a/rln-wasm-utils/src/lib.rs
+++ b/rln-wasm-utils/src/lib.rs
@@ -7,8 +7,6 @@ use rln::public::{
 use std::vec::Vec;
 use wasm_bindgen::prelude::*;
 
-
-
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[wasm_bindgen(js_name = generateMembershipKey)]
 pub fn wasm_key_gen(is_little_endian: bool) -> Result<Uint8Array, String> {

--- a/rln-wasm-utils/src/lib.rs
+++ b/rln-wasm-utils/src/lib.rs
@@ -1,0 +1,114 @@
+#![cfg(target_arch = "wasm32")]
+
+use js_sys::Uint8Array;
+use rln::public::{
+    extended_key_gen, hash, key_gen, poseidon_hash, seeded_extended_key_gen, seeded_key_gen,
+};
+use std::vec::Vec;
+use wasm_bindgen::prelude::*;
+
+
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[wasm_bindgen(js_name = generateMembershipKey)]
+pub fn wasm_key_gen(is_little_endian: bool) -> Result<Uint8Array, String> {
+    let mut output_data: Vec<u8> = Vec::new();
+    if let Err(err) = key_gen(&mut output_data, is_little_endian) {
+        std::mem::forget(output_data);
+        Err(format!(
+            "Msg: could not generate membership keys, Error: {:#?}",
+            err
+        ))
+    } else {
+        let result = Uint8Array::from(&output_data[..]);
+        std::mem::forget(output_data);
+        Ok(result)
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[wasm_bindgen(js_name = generateExtendedMembershipKey)]
+pub fn wasm_extended_key_gen(is_little_endian: bool) -> Result<Uint8Array, String> {
+    let mut output_data: Vec<u8> = Vec::new();
+    if let Err(err) = extended_key_gen(&mut output_data, is_little_endian) {
+        std::mem::forget(output_data);
+        Err(format!(
+            "Msg: could not generate membership keys, Error: {:#?}",
+            err
+        ))
+    } else {
+        let result = Uint8Array::from(&output_data[..]);
+        std::mem::forget(output_data);
+        Ok(result)
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[wasm_bindgen(js_name = generateSeededMembershipKey)]
+pub fn wasm_seeded_key_gen(seed: Uint8Array, is_little_endian: bool) -> Result<Uint8Array, String> {
+    let mut output_data: Vec<u8> = Vec::new();
+    let input_data = &seed.to_vec()[..];
+    if let Err(err) = seeded_key_gen(input_data, &mut output_data, is_little_endian) {
+        std::mem::forget(output_data);
+        Err(format!(
+            "Msg: could not generate membership key, Error: {:#?}",
+            err
+        ))
+    } else {
+        let result = Uint8Array::from(&output_data[..]);
+        std::mem::forget(output_data);
+        Ok(result)
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[wasm_bindgen(js_name = generateSeededExtendedMembershipKey)]
+pub fn wasm_seeded_extended_key_gen(
+    seed: Uint8Array,
+    is_little_endian: bool,
+) -> Result<Uint8Array, String> {
+    let mut output_data: Vec<u8> = Vec::new();
+    let input_data = &seed.to_vec()[..];
+    if let Err(err) = seeded_extended_key_gen(input_data, &mut output_data, is_little_endian) {
+        std::mem::forget(output_data);
+        Err(format!(
+            "Msg: could not generate membership key, Error: {:#?}",
+            err
+        ))
+    } else {
+        let result = Uint8Array::from(&output_data[..]);
+        std::mem::forget(output_data);
+        Ok(result)
+    }
+}
+
+#[wasm_bindgen(js_name = hash)]
+pub fn wasm_hash(input: Uint8Array, is_little_endian: bool) -> Result<Uint8Array, String> {
+    let mut output_data: Vec<u8> = Vec::new();
+    let input_data = &input.to_vec()[..];
+    if let Err(err) = hash(input_data, &mut output_data, is_little_endian) {
+        std::mem::forget(output_data);
+        Err(format!("Msg: could not generate hash, Error: {:#?}", err))
+    } else {
+        let result = Uint8Array::from(&output_data[..]);
+        std::mem::forget(output_data);
+        Ok(result)
+    }
+}
+
+#[wasm_bindgen(js_name = poseidonHash)]
+pub fn wasm_poseidon_hash(input: Uint8Array, is_little_endian: bool) -> Result<Uint8Array, String> {
+    let mut output_data: Vec<u8> = Vec::new();
+    let input_data = &input.to_vec()[..];
+    if let Err(err) = poseidon_hash(input_data, &mut output_data, is_little_endian) {
+        std::mem::forget(output_data);
+        Err(format!(
+            "Msg: could not generate poseidon hash, Error: {:#?}",
+            err
+        ))
+    } else {
+        let result = Uint8Array::from(&output_data[..]);
+        std::mem::forget(output_data);
+        Ok(result)
+    }
+}

--- a/rln-wasm-utils/tests/wasm_utils_test.rs
+++ b/rln-wasm-utils/tests/wasm_utils_test.rs
@@ -1,0 +1,114 @@
+#![cfg(target_arch = "wasm32")]
+
+#[cfg(test)]
+mod test {
+    use ark_std::{UniformRand, rand::thread_rng};
+    use rand::Rng;
+    use rln::circuit::Fr;
+    use rln::hashers::{ROUND_PARAMS, hash_to_field_le, poseidon_hash};
+    use rln::protocol::{
+        deserialize_identity_pair_be, deserialize_identity_pair_le, deserialize_identity_tuple_be,
+        deserialize_identity_tuple_le,
+    };
+    use rln::utils::{bytes_le_to_fr, vec_fr_to_bytes_le};
+    use rln_wasm_utils::{
+        wasm_extended_key_gen, wasm_hash, wasm_key_gen, wasm_poseidon_hash,
+        wasm_seeded_extended_key_gen, wasm_seeded_key_gen,
+    };
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    fn test_wasm_key_gen() {
+        let result_le = wasm_key_gen(true);
+        assert!(result_le.is_ok());
+        deserialize_identity_pair_le(result_le.unwrap().to_vec());
+
+        let result_be = wasm_key_gen(false);
+        assert!(result_be.is_ok());
+        deserialize_identity_pair_be(result_be.unwrap().to_vec());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_extended_key_gen() {
+        let result_le = wasm_extended_key_gen(true);
+        assert!(result_le.is_ok());
+        deserialize_identity_tuple_le(result_le.unwrap().to_vec());
+
+        let result_be = wasm_extended_key_gen(false);
+        assert!(result_be.is_ok());
+        deserialize_identity_tuple_be(result_be.unwrap().to_vec());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_seeded_key_gen() {
+        // Create a test seed
+        let seed_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let seed = js_sys::Uint8Array::from(&seed_data[..]);
+
+        let result_le = wasm_seeded_key_gen(seed.clone(), true);
+        assert!(result_le.is_ok());
+        let fr_le = deserialize_identity_pair_le(result_le.unwrap().to_vec());
+
+        let result_be = wasm_seeded_key_gen(seed, false);
+        assert!(result_be.is_ok());
+        let fr_be = deserialize_identity_pair_be(result_be.unwrap().to_vec());
+
+        assert_eq!(fr_le, fr_be);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_seeded_extended_key_gen() {
+        // Create a test seed
+        let seed_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let seed = js_sys::Uint8Array::from(&seed_data[..]);
+
+        let result_le = wasm_seeded_extended_key_gen(seed.clone(), true);
+        assert!(result_le.is_ok());
+        let fr_le = deserialize_identity_tuple_le(result_le.unwrap().to_vec());
+
+        let result_be = wasm_seeded_extended_key_gen(seed, false);
+        assert!(result_be.is_ok());
+        let fr_be = deserialize_identity_tuple_be(result_be.unwrap().to_vec());
+
+        assert_eq!(fr_le, fr_be);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_hash() {
+        // Create test input data
+        let signal: [u8; 32] = [0; 32];
+        let input = js_sys::Uint8Array::from(&signal[..]);
+
+        let result_le = wasm_hash(input.clone(), true);
+        assert!(result_le.is_ok());
+
+        let serialized_hash = result_le.unwrap().to_vec();
+        let (hash1, _) = bytes_le_to_fr(&serialized_hash);
+
+        let hash2 = hash_to_field_le(&signal);
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_poseidon_hash() {
+        let mut rng = thread_rng();
+        let number_of_inputs = rng.gen_range(1..ROUND_PARAMS.len());
+        let mut inputs = Vec::with_capacity(number_of_inputs);
+        for _ in 0..number_of_inputs {
+            inputs.push(Fr::rand(&mut rng));
+        }
+        let inputs_ser = vec_fr_to_bytes_le(&inputs);
+        let input = js_sys::Uint8Array::from(&inputs_ser[..]);
+
+        let expected_hash = poseidon_hash(inputs.as_ref());
+
+        let result_le = wasm_poseidon_hash(input.clone(), true);
+        assert!(result_le.is_ok());
+
+        let serialized_hash = result_le.unwrap().to_vec();
+        let (received_hash, _) = bytes_le_to_fr(&serialized_hash);
+
+        assert_eq!(received_hash, expected_hash);
+    }
+}

--- a/rln/src/error.rs
+++ b/rln/src/error.rs
@@ -19,6 +19,8 @@ pub enum ConversionError {
     ToUsize(#[from] TryFromIntError),
     #[error("{0}")]
     FromSlice(#[from] TryFromSliceError),
+    #[error("Input data too short: expected at least {expected} bytes, got {actual} bytes")]
+    InsufficientData { expected: usize, actual: usize },
 }
 
 #[derive(Error, Debug)]

--- a/rln/src/hashers.rs
+++ b/rln/src/hashers.rs
@@ -1,5 +1,8 @@
 /// This crate instantiates the Poseidon hash algorithm.
-use crate::{circuit::Fr, utils::bytes_le_to_fr};
+use crate::{
+    circuit::Fr,
+    utils::{bytes_be_to_fr, bytes_le_to_fr},
+};
 use once_cell::sync::Lazy;
 use tiny_keccak::{Hasher, Keccak};
 use utils::poseidon::Poseidon;
@@ -45,7 +48,7 @@ impl utils::merkle_tree::Hasher for PoseidonHash {
 }
 
 /// Hashes arbitrary signal to the underlying prime field.
-pub fn hash_to_field(signal: &[u8]) -> Fr {
+pub fn hash_to_field_le(signal: &[u8]) -> Fr {
     // We hash the input signal using Keccak256
     let mut hash = [0; 32];
     let mut hasher = Keccak::v256();
@@ -54,5 +57,21 @@ pub fn hash_to_field(signal: &[u8]) -> Fr {
 
     // We export the hash as a field element
     let (el, _) = bytes_le_to_fr(hash.as_ref());
+    el
+}
+
+/// Hashes arbitrary signal to the underlying prime field.
+pub fn hash_to_field_be(signal: &[u8]) -> Fr {
+    // We hash the input signal using Keccak256
+    let mut hash = [0; 32];
+    let mut hasher = Keccak::v256();
+    hasher.update(signal);
+    hasher.finalize(&mut hash);
+
+    // Reverse the bytes to get big endian representation
+    hash.reverse();
+
+    // We export the hash as a field element
+    let (el, _) = bytes_be_to_fr(hash.as_ref());
     el
 }

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -1,11 +1,14 @@
 use crate::circuit::{zkey_from_raw, Curve, Fr};
-use crate::hashers::{hash_to_field, poseidon_hash as utils_poseidon_hash};
+use crate::hashers::{hash_to_field_le, poseidon_hash as utils_poseidon_hash};
 use crate::protocol::{
     compute_id_secret, deserialize_proof_values, deserialize_witness, extended_keygen,
     extended_seeded_keygen, keygen, proof_values_from_witness, rln_witness_to_bigint_json,
     rln_witness_to_json, seeded_keygen, serialize_proof_values, verify_proof,
 };
-use crate::utils::{bytes_le_to_fr, bytes_le_to_vec_fr, fr_byte_size, fr_to_bytes_le};
+use crate::utils::{
+    bytes_be_to_vec_fr, bytes_le_to_fr, bytes_le_to_vec_fr, fr_byte_size, fr_to_bytes_be,
+    fr_to_bytes_le,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use {
     crate::{
@@ -987,7 +990,7 @@ impl RLN {
         let signal: Vec<u8> = serialized[all_read..all_read + signal_len].to_vec();
 
         let verified = verify_proof(&self.verification_key, &proof, &proof_values)?;
-        let x = hash_to_field(&signal);
+        let x = hash_to_field_le(&signal);
 
         // Consistency checks to counter proof tampering
         Ok(verified && (self.tree.root() == proof_values.root) && (x == proof_values.x))
@@ -1071,7 +1074,7 @@ impl RLN {
         let verified = verify_proof(&self.verification_key, &proof, &proof_values)?;
 
         // First consistency checks to counter proof tampering
-        let x = hash_to_field(&signal);
+        let x = hash_to_field_le(&signal);
         let partial_result = verified && (x == proof_values.x);
 
         // We skip root validation if proof is already invalid
@@ -1113,151 +1116,6 @@ impl RLN {
     ////////////////////////////////////////////////////////
     // Utils
     ////////////////////////////////////////////////////////
-
-    /// Returns an identity secret and identity commitment pair.
-    ///
-    /// The identity commitment is the Poseidon hash of the identity secret.
-    ///
-    /// Output values are:
-    /// - `output_data`: a writer receiving the serialization of the identity secret and identity commitment (serialization done with `rln::utils::fr_to_bytes_le`)
-    ///
-    /// Example
-    /// ```
-    /// use rln::protocol::*;
-    ///
-    /// // We generate an identity pair
-    /// let mut buffer = Cursor::new(Vec::<u8>::new());
-    /// rln.key_gen(&mut buffer).unwrap();
-    ///
-    /// // We serialize_compressed the keygen output
-    /// let (identity_secret_hash, id_commitment) = deserialize_identity_pair(buffer.into_inner());
-    /// ```
-    pub fn key_gen<W: Write>(&self, mut output_data: W) -> Result<(), RLNError> {
-        let (identity_secret_hash, id_commitment) = keygen();
-        output_data.write_all(&identity_secret_hash.to_bytes_le())?;
-        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
-
-        Ok(())
-    }
-
-    /// Returns an identity trapdoor, nullifier, secret and commitment tuple.
-    ///
-    /// The identity secret is the Poseidon hash of the identity trapdoor and identity nullifier.
-    ///
-    /// The identity commitment is the Poseidon hash of the identity secret.
-    ///
-    /// Generated credentials are compatible with [Semaphore](https://semaphore.appliedzkp.org/docs/guides/identities)'s credentials.
-    ///
-    /// Output values are:
-    /// - `output_data`: a writer receiving the serialization of the identity trapdoor, identity nullifier, identity secret and identity commitment (serialization done with `rln::utils::fr_to_bytes_le`)
-    ///
-    /// Example
-    /// ```
-    /// use rln::protocol::*;
-    ///
-    /// // We generate an identity tuple
-    /// let mut buffer = Cursor::new(Vec::<u8>::new());
-    /// rln.extended_key_gen(&mut buffer).unwrap();
-    ///
-    /// // We serialize_compressed the keygen output
-    /// let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment) = deserialize_identity_tuple(buffer.into_inner());
-    /// ```
-    pub fn extended_key_gen<W: Write>(&self, mut output_data: W) -> Result<(), RLNError> {
-        let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment) =
-            extended_keygen();
-        output_data.write_all(&fr_to_bytes_le(&identity_trapdoor))?;
-        output_data.write_all(&fr_to_bytes_le(&identity_nullifier))?;
-        output_data.write_all(&fr_to_bytes_le(&identity_secret_hash))?;
-        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
-
-        Ok(())
-    }
-
-    /// Returns an identity secret and identity commitment pair generated using a seed.
-    ///
-    /// The identity commitment is the Poseidon hash of the identity secret.
-    ///
-    /// Input values are:
-    /// - `input_data`: a reader for the byte vector containing the seed
-    ///
-    /// Output values are:
-    /// - `output_data`: a writer receiving the serialization of the identity secret and identity commitment (serialization done with [`rln::utils::fr_to_bytes_le`](crate::utils::fr_to_bytes_le))
-    ///
-    /// Example
-    /// ```
-    /// use rln::protocol::*;
-    ///
-    /// let seed_bytes: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-    ///
-    /// let mut input_buffer = Cursor::new(&seed_bytes);
-    /// let mut output_buffer = Cursor::new(Vec::<u8>::new());
-    /// rln.seeded_key_gen(&mut input_buffer, &mut output_buffer)
-    ///     .unwrap();
-    ///
-    /// // We serialize_compressed the keygen output
-    /// let (identity_secret_hash, id_commitment) = deserialize_identity_pair(output_buffer.into_inner());
-    /// ```
-    pub fn seeded_key_gen<R: Read, W: Write>(
-        &self,
-        mut input_data: R,
-        mut output_data: W,
-    ) -> Result<(), RLNError> {
-        let mut serialized: Vec<u8> = Vec::new();
-        input_data.read_to_end(&mut serialized)?;
-
-        let (identity_secret_hash, id_commitment) = seeded_keygen(&serialized);
-        output_data.write_all(&fr_to_bytes_le(&identity_secret_hash))?;
-        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
-
-        Ok(())
-    }
-
-    /// Returns an identity trapdoor, nullifier, secret and commitment tuple generated using a seed.
-    ///
-    /// The identity secret is the Poseidon hash of the identity trapdoor and identity nullifier.
-    ///
-    /// The identity commitment is the Poseidon hash of the identity secret.
-    ///
-    /// Generated credentials are compatible with [Semaphore](https://semaphore.appliedzkp.org/docs/guides/identities)'s credentials.
-    ///
-    /// Input values are:
-    /// - `input_data`: a reader for the byte vector containing the seed
-    ///
-    /// Output values are:
-    /// - `output_data`: a writer receiving the serialization of the identity trapdoor, identity nullifier, identity secret and identity commitment (serialization done with `rln::utils::fr_to_bytes_le`)
-    ///
-    /// Example
-    /// ```
-    /// use rln::protocol::*;
-    ///
-    /// let seed_bytes: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-    ///
-    /// let mut input_buffer = Cursor::new(&seed_bytes);
-    /// let mut output_buffer = Cursor::new(Vec::<u8>::new());
-    /// rln.seeded_key_gen(&mut input_buffer, &mut output_buffer)
-    ///     .unwrap();
-    ///
-    /// // We serialize_compressed the keygen output
-    /// let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment) = deserialize_identity_tuple(buffer.into_inner());
-    /// ```
-    pub fn seeded_extended_key_gen<R: Read, W: Write>(
-        &self,
-        mut input_data: R,
-        mut output_data: W,
-    ) -> Result<(), RLNError> {
-        let mut serialized: Vec<u8> = Vec::new();
-        input_data.read_to_end(&mut serialized)?;
-
-        let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment) =
-            extended_seeded_keygen(&serialized);
-        output_data.write_all(&fr_to_bytes_le(&identity_trapdoor))?;
-        output_data.write_all(&fr_to_bytes_le(&identity_nullifier))?;
-        output_data.write_all(&fr_to_bytes_le(&identity_secret_hash))?;
-        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
-
-        Ok(())
-    }
-
     /// Recovers the identity secret from two set of proof values computed for same secret in same epoch with same rln identifier.
     ///
     /// Input values are:
@@ -1428,12 +1286,18 @@ impl Default for RLN {
 pub fn hash<R: Read, W: Write>(
     mut input_data: R,
     mut output_data: W,
+    is_little_endian: bool,
 ) -> Result<(), std::io::Error> {
     let mut serialized: Vec<u8> = Vec::new();
     input_data.read_to_end(&mut serialized)?;
 
-    let hash = hash_to_field(&serialized);
-    output_data.write_all(&fr_to_bytes_le(&hash))?;
+    if is_little_endian {
+        let hash = hash_to_field_le(&serialized);
+        output_data.write_all(&fr_to_bytes_le(&hash))?;
+    } else {
+        let hash = hash_to_field_le(&serialized);
+        output_data.write_all(&fr_to_bytes_be(&hash))?;
+    }
 
     Ok(())
 }
@@ -1464,13 +1328,208 @@ pub fn hash<R: Read, W: Write>(
 pub fn poseidon_hash<R: Read, W: Write>(
     mut input_data: R,
     mut output_data: W,
+    is_little_endian: bool,
 ) -> Result<(), RLNError> {
     let mut serialized: Vec<u8> = Vec::new();
     input_data.read_to_end(&mut serialized)?;
 
-    let (inputs, _) = bytes_le_to_vec_fr(&serialized)?;
-    let hash = utils_poseidon_hash(inputs.as_ref());
-    output_data.write_all(&fr_to_bytes_le(&hash))?;
+    if is_little_endian {
+        let (inputs, _) = bytes_le_to_vec_fr(&serialized)?;
+        let hash = utils_poseidon_hash(inputs.as_ref());
+        output_data.write_all(&fr_to_bytes_le(&hash))?;
+    } else {
+        let (inputs, _) = bytes_be_to_vec_fr(&serialized)?;
+        let hash = utils_poseidon_hash(inputs.as_ref());
+        output_data.write_all(&fr_to_bytes_be(&hash))?;
+    }
+
+    Ok(())
+}
+
+/// Generate an identity which is composed of an identity secret and identity commitment.
+/// The identity secret is a random field element.
+/// The identity commitment is the Poseidon hash of the identity secret.
+///
+/// # Inputs
+///
+/// - `output_data`: a writer receiving the serialization of
+///   the identity secret and identity commitment in correct endianness.
+/// - `is_little_endian`: a boolean indicating whether the identity secret and identity commitment
+///   should be serialized in little endian or big endian.
+///
+/// # Example
+/// ```
+/// use rln::protocol::*;
+///
+/// // We generate an identity pair
+/// let mut buffer = Cursor::new(Vec::<u8>::new());
+/// let is_little_endian = true;
+/// key_gen(&mut buffer, is_little_endian).unwrap();
+///
+/// // We serialize_compressed the keygen output
+/// let (identity_secret_hash, id_commitment) = deserialize_identity_pair_le(buffer.into_inner());
+/// ```
+pub fn key_gen<W: Write>(mut output_data: W, is_little_endian: bool) -> Result<(), RLNError> {
+    let (identity_secret_hash, id_commitment) = keygen();
+    if is_little_endian {
+        output_data.write_all(&identity_secret_hash.to_bytes_le())?;
+        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
+    } else {
+        output_data.write_all(&identity_secret_hash.to_bytes_be())?;
+        output_data.write_all(&fr_to_bytes_be(&id_commitment))?;
+    }
+
+    Ok(())
+}
+
+/// Generate an identity which is composed of an identity trapdoor, nullifier, secret and commitment.
+/// The identity secret is the Poseidon hash of the identity trapdoor and identity nullifier.
+/// The identity commitment is the Poseidon hash of the identity secret.
+///
+/// # Inputs
+///
+/// - `output_data`: a writer receiving the serialization of
+///   the identity trapdoor, nullifier, secret and commitment in correct endianness.
+/// - `is_little_endian`: a boolean indicating whether the identity trapdoor, nullifier, secret and commitment
+///   should be serialized in little endian or big endian.
+///
+/// Generated credentials are compatible with
+/// [Semaphore](https://semaphore.appliedzkp.org/docs/guides/identities)'s credentials.
+///
+/// # Example
+/// ```
+/// use rln::protocol::*;
+///
+/// // We generate an identity tuple
+/// let mut buffer = Cursor::new(Vec::<u8>::new());
+/// let is_little_endian = true;
+/// extended_key_gen(&mut buffer, is_little_endian).unwrap();
+///
+/// // We serialize_compressed the keygen output
+/// let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment)
+///     = deserialize_identity_tuple_le(buffer.into_inner());
+/// ```
+pub fn extended_key_gen<W: Write>(
+    mut output_data: W,
+    is_little_endian: bool,
+) -> Result<(), RLNError> {
+    let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment) =
+        extended_keygen();
+    if is_little_endian {
+        output_data.write_all(&fr_to_bytes_le(&identity_trapdoor))?;
+        output_data.write_all(&fr_to_bytes_le(&identity_nullifier))?;
+        output_data.write_all(&fr_to_bytes_le(&identity_secret_hash))?;
+        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
+    } else {
+        output_data.write_all(&fr_to_bytes_be(&identity_trapdoor))?;
+        output_data.write_all(&fr_to_bytes_be(&identity_nullifier))?;
+        output_data.write_all(&fr_to_bytes_be(&identity_secret_hash))?;
+        output_data.write_all(&fr_to_bytes_be(&id_commitment))?;
+    }
+
+    Ok(())
+}
+
+/// Generate an identity which is composed of an identity secret and identity commitment using a seed.
+/// The identity secret is a random field element,
+///   where RNG is instantiated using 20 rounds of ChaCha seeded with the hash of the input.
+/// The identity commitment is the Poseidon hash of the identity secret.
+///
+/// # Inputs
+///
+/// - `input_data`: a reader for the byte vector containing the seed
+/// - `output_data`: a writer receiving the serialization of
+///   the identity secret and identity commitment in correct endianness.
+/// - `is_little_endian`: a boolean indicating whether the identity secret and identity commitment
+///   should be serialized in little endian or big endian.
+///
+/// # Example
+/// ```
+/// use rln::protocol::*;
+///
+/// let seed_bytes: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+///
+/// let mut input_buffer = Cursor::new(&seed_bytes);
+/// let mut output_buffer = Cursor::new(Vec::<u8>::new());
+/// let is_little_endian = true;
+/// seeded_key_gen(&mut input_buffer, &mut output_buffer, is_little_endian).unwrap();
+///
+///
+/// // We serialize_compressed the keygen output
+/// let (identity_secret_hash, id_commitment) = deserialize_identity_pair_le(output_buffer.into_inner());
+/// ```
+pub fn seeded_key_gen<R: Read, W: Write>(
+    mut input_data: R,
+    mut output_data: W,
+    is_little_endian: bool,
+) -> Result<(), RLNError> {
+    let mut serialized: Vec<u8> = Vec::new();
+    input_data.read_to_end(&mut serialized)?;
+
+    let (identity_secret_hash, id_commitment) = seeded_keygen(&serialized);
+    if is_little_endian {
+        output_data.write_all(&fr_to_bytes_le(&identity_secret_hash))?;
+        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
+    } else {
+        output_data.write_all(&fr_to_bytes_be(&identity_secret_hash))?;
+        output_data.write_all(&fr_to_bytes_be(&id_commitment))?;
+    }
+
+    Ok(())
+}
+
+/// Generate an identity which is composed of an identity trapdoor, nullifier, secret and commitment using a seed.
+/// The identity trapdoor and nullifier are random field elements,
+///   where RNG is instantiated using 20 rounds of ChaCha seeded with the hash of the input.
+/// The identity secret is the Poseidon hash of the identity trapdoor and identity nullifier.
+/// The identity commitment is the Poseidon hash of the identity secret.
+///
+/// # Inputs
+///
+/// - `input_data`: a reader for the byte vector containing the seed
+/// - `output_data`: a writer receiving the serialization of
+///   the identity trapdoor, nullifier, secret and commitment in correct endianness.
+/// - `is_little_endian`: a boolean indicating whether the identity trapdoor, nullifier, secret and commitment
+///   should be serialized in little endian or big endian.
+///
+/// Generated credentials are compatible with
+/// [Semaphore](https://semaphore.appliedzkp.org/docs/guides/identities)'s credentials.
+///
+/// # Example
+/// ```
+/// use rln::protocol::*;
+///
+/// let seed_bytes: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+///
+/// let mut input_buffer = Cursor::new(&seed_bytes);
+/// let mut output_buffer = Cursor::new(Vec::<u8>::new());
+/// let is_little_endian = true;
+/// seeded_extended_key_gen(&mut input_buffer, &mut output_buffer, is_little_endian).unwrap();
+///
+/// // We serialize_compressed the keygen output
+/// let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment) = deserialize_identity_tuple(buffer.into_inner());
+/// ```
+pub fn seeded_extended_key_gen<R: Read, W: Write>(
+    mut input_data: R,
+    mut output_data: W,
+    is_little_endian: bool,
+) -> Result<(), RLNError> {
+    let mut serialized: Vec<u8> = Vec::new();
+    input_data.read_to_end(&mut serialized)?;
+
+    let (identity_trapdoor, identity_nullifier, identity_secret_hash, id_commitment) =
+        extended_seeded_keygen(&serialized);
+    if is_little_endian {
+        output_data.write_all(&fr_to_bytes_le(&identity_trapdoor))?;
+        output_data.write_all(&fr_to_bytes_le(&identity_nullifier))?;
+        output_data.write_all(&fr_to_bytes_le(&identity_secret_hash))?;
+        output_data.write_all(&fr_to_bytes_le(&id_commitment))?;
+    } else {
+        output_data.write_all(&fr_to_bytes_be(&identity_trapdoor))?;
+        output_data.write_all(&fr_to_bytes_be(&identity_nullifier))?;
+        output_data.write_all(&fr_to_bytes_be(&identity_secret_hash))?;
+        output_data.write_all(&fr_to_bytes_be(&id_commitment))?;
+    }
 
     Ok(())
 }

--- a/rln/src/public_api_tests.rs
+++ b/rln/src/public_api_tests.rs
@@ -172,7 +172,7 @@ fn test_groth16_proof() {
 #[cfg(not(feature = "stateless"))]
 mod tree_test {
     use crate::circuit::{Fr, TEST_TREE_HEIGHT};
-    use crate::hashers::{hash_to_field, poseidon_hash as utils_poseidon_hash};
+    use crate::hashers::{hash_to_field_le, poseidon_hash as utils_poseidon_hash};
     use crate::protocol::*;
     use crate::public::RLN;
     use crate::utils::*;
@@ -622,9 +622,9 @@ mod tree_test {
         let signal: [u8; 32] = rng.gen();
 
         // We generate a random epoch
-        let epoch = hash_to_field(b"test-epoch");
+        let epoch = hash_to_field_le(b"test-epoch");
         // We generate a random rln_identifier
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        let rln_identifier = hash_to_field_le(b"test-rln-identifier");
         // We generate a external nullifier
         let external_nullifier = utils_poseidon_hash(&[epoch, rln_identifier]);
         // We choose a message_id satisfy 0 <= message_id < MESSAGE_LIMIT
@@ -694,9 +694,9 @@ mod tree_test {
         let signal: [u8; 32] = rng.gen();
 
         // We generate a random epoch
-        let epoch = hash_to_field(b"test-epoch");
+        let epoch = hash_to_field_le(b"test-epoch");
         // We generate a random rln_identifier
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        let rln_identifier = hash_to_field_le(b"test-rln-identifier");
         // We generate a external nullifier
         let external_nullifier = utils_poseidon_hash(&[epoch, rln_identifier]);
         // We choose a message_id satisfy 0 <= message_id < MESSAGE_LIMIT
@@ -777,9 +777,9 @@ mod tree_test {
         let signal: [u8; 32] = rng.gen();
 
         // We generate a random epoch
-        let epoch = hash_to_field(b"test-epoch");
+        let epoch = hash_to_field_le(b"test-epoch");
         // We generate a random rln_identifier
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        let rln_identifier = hash_to_field_le(b"test-rln-identifier");
         // We generate a external nullifier
         let external_nullifier = utils_poseidon_hash(&[epoch, rln_identifier]);
         // We choose a message_id satisfy 0 <= message_id < MESSAGE_LIMIT
@@ -869,9 +869,9 @@ mod tree_test {
         let signal2: [u8; 32] = rng.gen();
 
         // We generate a random epoch
-        let epoch = hash_to_field(b"test-epoch");
+        let epoch = hash_to_field_le(b"test-epoch");
         // We generate a random rln_identifier
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        let rln_identifier = hash_to_field_le(b"test-rln-identifier");
         // We generate a external nullifier
         let external_nullifier = utils_poseidon_hash(&[epoch, rln_identifier]);
         // We choose a message_id satisfy 0 <= message_id < MESSAGE_LIMIT
@@ -994,7 +994,7 @@ mod tree_test {
 #[cfg(feature = "stateless")]
 mod stateless_test {
     use crate::circuit::{Fr, TEST_TREE_HEIGHT};
-    use crate::hashers::{hash_to_field, poseidon_hash as utils_poseidon_hash, PoseidonHash};
+    use crate::hashers::{hash_to_field_le, poseidon_hash as utils_poseidon_hash, PoseidonHash};
     use crate::protocol::*;
     use crate::public::RLN;
     use crate::utils::*;
@@ -1033,15 +1033,15 @@ mod stateless_test {
         let signal: [u8; 32] = rng.gen();
 
         // We generate a random epoch
-        let epoch = hash_to_field(b"test-epoch");
+        let epoch = hash_to_field_le(b"test-epoch");
         // We generate a random rln_identifier
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        let rln_identifier = hash_to_field_le(b"test-rln-identifier");
         let external_nullifier = utils_poseidon_hash(&[epoch, rln_identifier]);
 
         // We prepare input for generate_rln_proof API
         // input_data is [ identity_secret<32> | id_index<8> | user_message_limit<32> | message_id<32> | external_nullifier<32> | signal_len<8> | signal<var> ]
 
-        let x = hash_to_field(&signal);
+        let x = hash_to_field_le(&signal);
         let merkle_proof = tree.proof(identity_index).expect("proof should exist");
 
         let rln_witness = rln_witness_from_values(
@@ -1124,18 +1124,18 @@ mod stateless_test {
         tree.update_next(rate_commitment).unwrap();
 
         // We generate a random epoch
-        let epoch = hash_to_field(b"test-epoch");
+        let epoch = hash_to_field_le(b"test-epoch");
         // We generate a random rln_identifier
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        let rln_identifier = hash_to_field_le(b"test-rln-identifier");
         let external_nullifier = utils_poseidon_hash(&[epoch, rln_identifier]);
 
         // We generate a random signal
         let mut rng = thread_rng();
         let signal1: [u8; 32] = rng.gen();
-        let x1 = hash_to_field(&signal1);
+        let x1 = hash_to_field_le(&signal1);
 
         let signal2: [u8; 32] = rng.gen();
-        let x2 = hash_to_field(&signal2);
+        let x2 = hash_to_field_le(&signal2);
 
         let identity_index = tree.leaves_set();
         let merkle_proof = tree.proof(identity_index).expect("proof should exist");
@@ -1203,7 +1203,7 @@ mod stateless_test {
         tree.update_next(rate_commitment_new).unwrap();
 
         let signal3: [u8; 32] = rng.gen();
-        let x3 = hash_to_field(&signal3);
+        let x3 = hash_to_field_le(&signal3);
 
         let identity_index_new = tree.leaves_set();
         let merkle_proof_new = tree.proof(identity_index_new).expect("proof should exist");

--- a/rln/tests/protocol.rs
+++ b/rln/tests/protocol.rs
@@ -5,7 +5,7 @@ mod test {
     use ark_ff::BigInt;
     use rln::circuit::{graph_from_folder, zkey_from_folder};
     use rln::circuit::{Fr, TEST_TREE_HEIGHT};
-    use rln::hashers::{hash_to_field, poseidon_hash};
+    use rln::hashers::{hash_to_field_le, poseidon_hash};
     use rln::poseidon_tree::PoseidonTree;
     use rln::protocol::{
         deserialize_proof_values, deserialize_witness, generate_proof, keygen,
@@ -24,7 +24,7 @@ mod test {
         let leaf_index = 3;
 
         // generate identity
-        let identity_secret_hash = hash_to_field(b"test-merkle-proof");
+        let identity_secret_hash = hash_to_field_le(b"test-merkle-proof");
         let id_commitment = poseidon_hash(&[identity_secret_hash]);
         let rate_commitment = poseidon_hash(&[id_commitment, 100.into()]);
 
@@ -112,11 +112,11 @@ mod test {
         let merkle_proof = tree.proof(leaf_index).expect("proof should exist");
 
         let signal = b"hey hey";
-        let x = hash_to_field(signal);
+        let x = hash_to_field_le(signal);
 
         // We set the remaining values to random ones
-        let epoch = hash_to_field(b"test-epoch");
-        let rln_identifier = hash_to_field(b"test-rln-identifier");
+        let epoch = hash_to_field_le(b"test-epoch");
+        let rln_identifier = hash_to_field_le(b"test-rln-identifier");
         let external_nullifier = poseidon_hash(&[epoch, rln_identifier]);
 
         rln_witness_from_values(

--- a/rln/tests/utils.rs
+++ b/rln/tests/utils.rs
@@ -1,0 +1,414 @@
+#[cfg(test)]
+mod test {
+    use rln::utils::{
+        bytes_be_to_fr, bytes_be_to_vec_fr, bytes_be_to_vec_u8, bytes_be_to_vec_usize,
+        bytes_le_to_fr, bytes_le_to_vec_fr, bytes_le_to_vec_u8, bytes_le_to_vec_usize,
+        fr_to_bytes_be, fr_to_bytes_le, normalize_usize_be, normalize_usize_le, str_to_fr,
+        vec_fr_to_bytes_be, vec_fr_to_bytes_le, vec_u8_to_bytes_be, vec_u8_to_bytes_le,
+    };
+
+    use ark_std::{rand::thread_rng, UniformRand};
+    use rln::circuit::Fr;
+
+    #[test]
+    fn test_normalize_usize_le() {
+        // Test basic cases
+        assert_eq!(normalize_usize_le(0), [0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(normalize_usize_le(1), [1, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(normalize_usize_le(255), [255, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(normalize_usize_le(256), [0, 1, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(normalize_usize_le(65535), [255, 255, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(normalize_usize_le(65536), [0, 0, 1, 0, 0, 0, 0, 0]);
+
+        // Test 32-bit boundary
+        assert_eq!(
+            normalize_usize_le(4294967295),
+            [255, 255, 255, 255, 0, 0, 0, 0]
+        );
+        assert_eq!(normalize_usize_le(4294967296), [0, 0, 0, 0, 1, 0, 0, 0]);
+
+        // Test maximum value
+        assert_eq!(
+            normalize_usize_le(usize::MAX),
+            [255, 255, 255, 255, 255, 255, 255, 255]
+        );
+
+        // Test that result is always 8 bytes
+        assert_eq!(normalize_usize_le(0).len(), 8);
+        assert_eq!(normalize_usize_le(usize::MAX).len(), 8);
+    }
+
+    #[test]
+    fn test_normalize_usize_be() {
+        // Test basic cases
+        assert_eq!(normalize_usize_be(0), [0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(normalize_usize_be(1), [0, 0, 0, 0, 0, 0, 0, 1]);
+        assert_eq!(normalize_usize_be(255), [0, 0, 0, 0, 0, 0, 0, 255]);
+        assert_eq!(normalize_usize_be(256), [0, 0, 0, 0, 0, 0, 1, 0]);
+        assert_eq!(normalize_usize_be(65535), [0, 0, 0, 0, 0, 0, 255, 255]);
+        assert_eq!(normalize_usize_be(65536), [0, 0, 0, 0, 0, 1, 0, 0]);
+
+        // Test 32-bit boundary
+        assert_eq!(
+            normalize_usize_be(4294967295),
+            [0, 0, 0, 0, 255, 255, 255, 255]
+        );
+        assert_eq!(normalize_usize_be(4294967296), [0, 0, 0, 1, 0, 0, 0, 0]);
+
+        // Test maximum value
+        assert_eq!(
+            normalize_usize_be(usize::MAX),
+            [255, 255, 255, 255, 255, 255, 255, 255]
+        );
+
+        // Test that result is always 8 bytes
+        assert_eq!(normalize_usize_be(0).len(), 8);
+        assert_eq!(normalize_usize_be(usize::MAX).len(), 8);
+    }
+
+    #[test]
+    fn test_normalize_usize_endianness() {
+        // Test that little-endian and big-endian produce different results for non-zero values
+        let test_values = vec![1, 255, 256, 65535, 65536, 4294967295, 4294967296];
+
+        for &value in &test_values {
+            let le_result = normalize_usize_le(value);
+            let be_result = normalize_usize_be(value);
+
+            // For non-zero values, LE and BE should be different
+            assert_ne!(
+                le_result, be_result,
+                "LE and BE should differ for value {}",
+                value
+            );
+
+            // Both should be 8 bytes
+            assert_eq!(le_result.len(), 8);
+            assert_eq!(be_result.len(), 8);
+        }
+
+        // Zero should be the same in both endianness
+        assert_eq!(normalize_usize_le(0), normalize_usize_be(0));
+    }
+
+    #[test]
+    fn test_normalize_usize_roundtrip() {
+        // Test that we can reconstruct the original value from the normalized bytes
+        let test_values = vec![
+            0,
+            1,
+            255,
+            256,
+            65535,
+            65536,
+            4294967295,
+            4294967296,
+            usize::MAX,
+        ];
+
+        for &value in &test_values {
+            let le_bytes = normalize_usize_le(value);
+            let be_bytes = normalize_usize_be(value);
+
+            // Reconstruct from little-endian bytes
+            let reconstructed_le = usize::from_le_bytes(le_bytes);
+            assert_eq!(
+                reconstructed_le, value,
+                "LE roundtrip failed for value {}",
+                value
+            );
+
+            // Reconstruct from big-endian bytes
+            let reconstructed_be = usize::from_be_bytes(be_bytes);
+            assert_eq!(
+                reconstructed_be, value,
+                "BE roundtrip failed for value {}",
+                value
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalize_usize_edge_cases() {
+        // Test edge cases and boundary values
+        let edge_cases = vec![
+            0,
+            1,
+            255,
+            256,
+            65535,
+            65536,
+            16777215,          // 2^24 - 1
+            16777216,          // 2^24
+            4294967295,        // 2^32 - 1
+            4294967296,        // 2^32
+            1099511627775,     // 2^40 - 1
+            1099511627776,     // 2^40
+            281474976710655,   // 2^48 - 1
+            281474976710656,   // 2^48
+            72057594037927935, // 2^56 - 1
+            72057594037927936, // 2^56
+            usize::MAX,
+        ];
+
+        for &value in &edge_cases {
+            let le_result = normalize_usize_le(value);
+            let be_result = normalize_usize_be(value);
+
+            // Both should be 8 bytes
+            assert_eq!(le_result.len(), 8);
+            assert_eq!(be_result.len(), 8);
+
+            // Roundtrip should work
+            assert_eq!(usize::from_le_bytes(le_result), value);
+            assert_eq!(usize::from_be_bytes(be_result), value);
+        }
+    }
+
+    #[test]
+    fn test_normalize_usize_architecture_independence() {
+        // Test that the functions work consistently regardless of the underlying architecture
+        // This test ensures that the functions provide consistent 8-byte output
+        // even on 32-bit systems where usize might be 4 bytes
+
+        let test_values = vec![0, 1, 255, 256, 65535, 65536, 4294967295, 4294967296];
+
+        for &value in &test_values {
+            let le_result = normalize_usize_le(value);
+            let be_result = normalize_usize_be(value);
+
+            // Always 8 bytes regardless of architecture
+            assert_eq!(le_result.len(), 8);
+            assert_eq!(be_result.len(), 8);
+
+            // The result should be consistent with the original value
+            assert_eq!(usize::from_le_bytes(le_result), value);
+            assert_eq!(usize::from_be_bytes(be_result), value);
+        }
+    }
+
+    #[test]
+    fn test_fr_serialization_roundtrip() {
+        let mut rng = thread_rng();
+
+        // Test multiple random Fr values
+        for _ in 0..10 {
+            let fr = Fr::rand(&mut rng);
+
+            // Test little-endian roundtrip
+            let le_bytes = fr_to_bytes_le(&fr);
+            let (reconstructed_le, _) = bytes_le_to_fr(&le_bytes);
+            assert_eq!(fr, reconstructed_le);
+
+            // Test big-endian roundtrip
+            let be_bytes = fr_to_bytes_be(&fr);
+            let (reconstructed_be, _) = bytes_be_to_fr(&be_bytes);
+            assert_eq!(fr, reconstructed_be);
+        }
+    }
+
+    #[test]
+    fn test_vec_fr_serialization_roundtrip() {
+        let mut rng = thread_rng();
+
+        // Test with different vector sizes
+        for size in [0, 1, 5, 10] {
+            let fr_vec: Vec<Fr> = (0..size).map(|_| Fr::rand(&mut rng)).collect();
+
+            // Test little-endian roundtrip
+            let le_bytes = vec_fr_to_bytes_le(&fr_vec);
+            let (reconstructed_le, _) = bytes_le_to_vec_fr(&le_bytes).unwrap();
+            assert_eq!(fr_vec, reconstructed_le);
+
+            // Test big-endian roundtrip
+            let be_bytes = vec_fr_to_bytes_be(&fr_vec);
+            let (reconstructed_be, _) = bytes_be_to_vec_fr(&be_bytes).unwrap();
+            assert_eq!(fr_vec, reconstructed_be);
+        }
+    }
+
+    #[test]
+    fn test_vec_u8_serialization_roundtrip() {
+        // Test with different vector sizes and content
+        let test_cases = vec![
+            vec![],
+            vec![0],
+            vec![255],
+            vec![1, 2, 3, 4, 5],
+            vec![0, 255, 128, 64, 32, 16, 8, 4, 2, 1],
+            (0..100).collect::<Vec<u8>>(),
+        ];
+
+        for test_case in test_cases {
+            // Test little-endian roundtrip
+            let le_bytes = vec_u8_to_bytes_le(&test_case);
+            let (reconstructed_le, _) = bytes_le_to_vec_u8(&le_bytes).unwrap();
+            assert_eq!(test_case, reconstructed_le);
+
+            // Test big-endian roundtrip
+            let be_bytes = vec_u8_to_bytes_be(&test_case);
+            let (reconstructed_be, _) = bytes_be_to_vec_u8(&be_bytes).unwrap();
+            assert_eq!(test_case, reconstructed_be);
+        }
+    }
+
+    #[test]
+    fn test_vec_usize_serialization_roundtrip() {
+        // Test with different vector sizes and content
+        let test_cases = vec![
+            vec![],
+            vec![0],
+            vec![usize::MAX],
+            vec![1, 2, 3, 4, 5],
+            vec![0, 255, 65535, 4294967295, usize::MAX],
+            (0..10).collect::<Vec<usize>>(),
+        ];
+
+        for test_case in test_cases {
+            // Test little-endian roundtrip
+            let le_bytes = {
+                let mut bytes = Vec::new();
+                bytes.extend_from_slice(&normalize_usize_le(test_case.len()));
+                for &value in &test_case {
+                    bytes.extend_from_slice(&normalize_usize_le(value));
+                }
+                bytes
+            };
+            let reconstructed_le = bytes_le_to_vec_usize(&le_bytes).unwrap();
+            assert_eq!(test_case, reconstructed_le);
+
+            // Test big-endian roundtrip
+            let be_bytes = {
+                let mut bytes = Vec::new();
+                bytes.extend_from_slice(&normalize_usize_be(test_case.len()));
+                for &value in &test_case {
+                    bytes.extend_from_slice(&normalize_usize_be(value));
+                }
+                bytes
+            };
+            let reconstructed_be = bytes_be_to_vec_usize(&be_bytes).unwrap();
+            assert_eq!(test_case, reconstructed_be);
+        }
+    }
+
+    #[test]
+    fn test_str_to_fr() {
+        // Test valid hex strings
+        let test_cases = vec![
+            ("0x0", 16, Fr::from(0u64)),
+            ("0x1", 16, Fr::from(1u64)),
+            ("0xff", 16, Fr::from(255u64)),
+            ("0x100", 16, Fr::from(256u64)),
+        ];
+
+        for (input, radix, expected) in test_cases {
+            let result = str_to_fr(input, radix).unwrap();
+            assert_eq!(result, expected);
+        }
+
+        // Test invalid inputs
+        assert!(str_to_fr("invalid", 16).is_err());
+        assert!(str_to_fr("0x", 16).is_err());
+    }
+
+    #[test]
+    fn test_endianness_differences() {
+        let mut rng = thread_rng();
+        let fr = Fr::rand(&mut rng);
+
+        // Test that LE and BE produce different byte representations
+        let le_bytes = fr_to_bytes_le(&fr);
+        let be_bytes = fr_to_bytes_be(&fr);
+
+        // They should be different (unless the value is symmetric)
+        if le_bytes != be_bytes {
+            // Verify they can both be reconstructed correctly
+            let (reconstructed_le, _) = bytes_le_to_fr(&le_bytes);
+            let (reconstructed_be, _) = bytes_be_to_fr(&be_bytes);
+            assert_eq!(fr, reconstructed_le);
+            assert_eq!(fr, reconstructed_be);
+        }
+    }
+
+    #[test]
+    fn test_error_handling() {
+        // Test with valid length but insufficient data
+        let valid_length_invalid_data = vec![0u8; 8]; // Length 0, but no data
+        assert!(bytes_le_to_vec_u8(&valid_length_invalid_data).is_ok());
+        assert!(bytes_be_to_vec_u8(&valid_length_invalid_data).is_ok());
+        assert!(bytes_le_to_vec_fr(&valid_length_invalid_data).is_ok());
+        assert!(bytes_be_to_vec_fr(&valid_length_invalid_data).is_ok());
+        assert!(bytes_le_to_vec_usize(&valid_length_invalid_data).is_ok());
+        assert!(bytes_be_to_vec_usize(&valid_length_invalid_data).is_ok());
+
+        // Test with reasonable length but insufficient data for vector deserialization
+        let reasonable_length = {
+            let mut bytes = vec![0u8; 8];
+            bytes[0] = 1; // Length 1
+            bytes
+        };
+        // This should fail because we don't have enough data for the vector elements
+        assert!(bytes_le_to_vec_u8(&reasonable_length).is_err());
+        assert!(bytes_be_to_vec_u8(&reasonable_length).is_err());
+        assert!(bytes_le_to_vec_fr(&reasonable_length).is_err());
+        assert!(bytes_be_to_vec_fr(&reasonable_length).is_err());
+        assert!(bytes_le_to_vec_usize(&reasonable_length).is_err());
+        assert!(bytes_be_to_vec_usize(&reasonable_length).is_err());
+
+        // Test with valid data for u8 vector
+        let valid_u8_data_le = {
+            let mut bytes = vec![0u8; 9];
+            bytes[..8].copy_from_slice(&(1u64.to_le_bytes())); // Length 1, little-endian
+            bytes[8] = 42; // One byte of data
+            bytes
+        };
+        let valid_u8_data_be = {
+            let mut bytes = vec![0u8; 9];
+            bytes[..8].copy_from_slice(&(1u64.to_be_bytes())); // Length 1, big-endian
+            bytes[8] = 42; // One byte of data
+            bytes
+        };
+        assert!(bytes_le_to_vec_u8(&valid_u8_data_le).is_ok());
+        assert!(bytes_be_to_vec_u8(&valid_u8_data_be).is_ok());
+    }
+
+    #[test]
+    fn test_empty_vectors() {
+        // Test empty vector serialization/deserialization
+        let empty_fr: Vec<Fr> = vec![];
+        let empty_u8: Vec<u8> = vec![];
+        let empty_usize: Vec<usize> = vec![];
+
+        // Test Fr vectors
+        let le_fr_bytes = vec_fr_to_bytes_le(&empty_fr);
+        let be_fr_bytes = vec_fr_to_bytes_be(&empty_fr);
+        let (reconstructed_le_fr, _) = bytes_le_to_vec_fr(&le_fr_bytes).unwrap();
+        let (reconstructed_be_fr, _) = bytes_be_to_vec_fr(&be_fr_bytes).unwrap();
+        assert_eq!(empty_fr, reconstructed_le_fr);
+        assert_eq!(empty_fr, reconstructed_be_fr);
+
+        // Test u8 vectors
+        let le_u8_bytes = vec_u8_to_bytes_le(&empty_u8);
+        let be_u8_bytes = vec_u8_to_bytes_be(&empty_u8);
+        let (reconstructed_le_u8, _) = bytes_le_to_vec_u8(&le_u8_bytes).unwrap();
+        let (reconstructed_be_u8, _) = bytes_be_to_vec_u8(&be_u8_bytes).unwrap();
+        assert_eq!(empty_u8, reconstructed_le_u8);
+        assert_eq!(empty_u8, reconstructed_be_u8);
+
+        // Test usize vectors
+        let le_usize_bytes = {
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&normalize_usize_le(0));
+            bytes
+        };
+        let be_usize_bytes = {
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&normalize_usize_be(0));
+            bytes
+        };
+        let reconstructed_le_usize = bytes_le_to_vec_usize(&le_usize_bytes).unwrap();
+        let reconstructed_be_usize = bytes_be_to_vec_usize(&be_usize_bytes).unwrap();
+        assert_eq!(empty_usize, reconstructed_le_usize);
+        assert_eq!(empty_usize, reconstructed_be_usize);
+    }
+}


### PR DESCRIPTION
- separated all identity generation functions as separate functions, rather than RLN methods
- added BE support - only for these functions so far
- covered the functions with tests, as well as conversion to big endian
- prepared for publication, but is actually awaiting the initial publication of the RLN module

@vinhtc27, please check that everything is correct from the wasm point of view. This module does not require parallel computing, so if there are any unnecessary dependencies, builds, etc., please let me know.