### PR TITLE
chore: remove cmake due to CI error and skip tests and benchmarks on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ name: Tests
 
 jobs:
   utils-test:
+    # skip tests on draft PRs
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
@@ -46,6 +48,8 @@ jobs:
         working-directory: ${{ matrix.crate }}
 
   rln-test:
+    # skip tests on draft PRs
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
@@ -73,6 +77,8 @@ jobs:
         working-directory: ${{ matrix.crate }}
 
   rln-wasm-test:
+    # skip tests on draft PRs
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
@@ -100,6 +106,8 @@ jobs:
         working-directory: ${{ matrix.crate }}
 
   rln-wasm-parallel-test:
+    # skip tests on draft PRs
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
@@ -127,6 +135,8 @@ jobs:
         working-directory: ${{ matrix.crate }}
 
   rln-wasm-utils-test:
+    # skip tests on draft PRs
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
@@ -147,6 +157,8 @@ jobs:
         working-directory: ${{ matrix.crate }}
 
   lint:
+    # run on both ready and draft PRs
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     strategy:
       matrix:
         # we run lint tests only on ubuntu
@@ -177,8 +189,8 @@ jobs:
         working-directory: ${{ matrix.crate }}
 
   benchmark-utils:
-    # run only in pull requests
-    if: github.event_name == 'pull_request'
+    # run only on ready pull requests
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     strategy:
       matrix:
         # we run benchmark tests only on ubuntu
@@ -198,8 +210,8 @@ jobs:
           cwd: ${{ matrix.crate }}
 
   benchmark-rln:
-    # run only in pull requests
-    if: github.event_name == 'pull_request'
+    # run only on ready pull requests
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     strategy:
       matrix:
         # we run benchmark tests only on ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
       - "!utils/src/**"
       - "!rln-wasm-utils/**"
 
-name: Tests
+name: CI
 
 jobs:
   utils-test:
@@ -168,7 +168,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
 
-    name: lint - ${{ matrix.crate }} - ${{ matrix.platform }}
+    name: Lint - ${{ matrix.crate }} - ${{ matrix.platform }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -200,7 +200,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
 
-    name: benchmark - ${{ matrix.crate }} - ${{ matrix.platform }}
+    name: Benchmark - ${{ matrix.crate }} - ${{ matrix.platform }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -222,7 +222,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
 
-    name: benchmark - ${{ matrix.crate }} - ${{ matrix.platform }} - ${{ matrix.feature }}
+    name: Benchmark - ${{ matrix.crate }} - ${{ matrix.platform }} - ${{ matrix.feature }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - "!utils/src/**"
       - "!rln-wasm-utils/**"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "**.md"
       - "!.github/workflows/*.yml"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 installdeps: .pre-build
 ifeq ($(shell uname),Darwin)
-	@brew install cmake ninja binaryen
+	@brew install ninja binaryen
 else ifeq ($(shell uname),Linux)
 	@if [ -f /etc/os-release ] && grep -q "ID=nixos" /etc/os-release; then \
 		echo "Detected NixOS, skipping apt-get installation."; \


### PR DESCRIPTION
- Add a CI rule to skip tests and benchmarks on draft pull requests
- Remove CMake installation from the installdeps command due to [this](https://github.com/actions/runner-images/issues/12912) 