### PR TITLE
chore(rln-wasm): remove wasm-bindgen-cli installation

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -122,9 +122,6 @@ jobs:
             env RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals" \
             rustup run nightly wasm-pack build --release --target web --scope waku \
             --features ${{ matrix.feature }} -Z build-std=panic_abort,std
-
-            wasm-bindgen --target web --split-linked-modules --out-dir ./pkg \
-            ./target/wasm32-unknown-unknown/release/rln_wasm.wasm
           else
             wasm-pack build --release --target web --scope waku
           fi

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ else ifeq ($(shell uname),Linux)
 	fi
 endif
 	@which wasm-pack > /dev/null && wasm-pack --version | grep -q "0.13.1" || cargo install wasm-pack --version=0.13.1
-	@which wasm-bindgen > /dev/null && wasm-bindgen --version | grep -q "0.2.100" || cargo install wasm-bindgen-cli --version=0.2.100
 	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v22.14.0" ] || nvm install 22.14.0; nvm use 22.14.0; nvm alias default 22.14.0'
 

--- a/rln-wasm/Makefile.toml
+++ b/rln-wasm/Makefile.toml
@@ -4,12 +4,7 @@ dependencies = ["pack_build", "pack_rename", "pack_resize"]
 
 [tasks.build_parallel]
 clear = true
-dependencies = [
-    "pack_build_parallel",
-    "post_build_parallel",
-    "pack_rename",
-    "pack_resize",
-]
+dependencies = ["pack_build_parallel", "pack_rename", "pack_resize"]
 
 [tasks.pack_build]
 command = "wasm-pack"
@@ -34,12 +29,6 @@ args = [
     "-Z",
     "build-std=panic_abort,std",
 ]
-
-[tasks.post_build_parallel]
-script = '''
-wasm-bindgen --target web --split-linked-modules --out-dir ./pkg ./target/wasm32-unknown-unknown/release/rln_wasm.wasm
-'''
-
 [tasks.pack_rename]
 script = "sed -i.bak 's/rln-wasm/zerokit-rln-wasm/g' pkg/package.json && rm pkg/package.json.bak"
 

--- a/rln-wasm/README.md
+++ b/rln-wasm/README.md
@@ -91,7 +91,7 @@ enabling multi-threaded execution in the browser.
 
 > [!NOTE]
 > Parallel support is not enabled by default due to WebAssembly and browser limitations. \
-> Compiling this feature requires `nightly` Rust and the `wasm-bindgen-cli` tool.
+> Compiling this feature requires `nightly` Rust.
 
 ### Build Setup
 
@@ -99,12 +99,6 @@ enabling multi-threaded execution in the browser.
 
 ```bash
 rustup install nightly
-```
-
-#### Install `wasm-bindgen-cli`
-
-```bash
-cargo install wasm-bindgen-cli --version=0.2.100
 ```
 
 ### Build Commands


### PR DESCRIPTION
Currently, the new wasm-bindgen-cli version [causes CI to fail](https://github.com/vacp2p/zerokit/actions/runs/17699917161/job/50313998747), and it isn't needed for the parallel feature anymore.
So it's better to remove it from the codebase.