### PR TITLE
fix(ci): update binary name generaion in CI 

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -22,6 +22,10 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+    env:
+      FEATURES_CARGO: ${{ join(matrix.features, ',') }}
+      FEATURES_TAG: ${{ join(matrix.features, '-') }}
+      TARGET: ${{ matrix.target }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -34,15 +38,15 @@ jobs:
         run: make installdeps
       - name: Cross build
         run: |
-          cross build --release --target ${{ matrix.target }} --no-default-features --features ${{ matrix.feature }} --workspace
+          cross build --release --target $TARGET --no-default-features --features "$FEATURES_CARGO" --workspace
           mkdir release
-          cp target/${{ matrix.target }}/release/librln* release/
-          tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/
+          cp target/$TARGET/release/librln* release/
+          tar -czvf $TARGET-$FEATURES_TAG-rln.tar.gz release/
       - name: Upload archive artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}-${{ matrix.feature }}-archive
-          path: ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz
+          name: ${{ env.TARGET }}-${{ env.FEATURES_TAG }}-archive
+          path: ${{ env.TARGET }}-${{ env.FEATURES_TAG }}-rln.tar.gz
           retention-days: 2
 
   macos:
@@ -62,27 +66,31 @@ jobs:
         target:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
+    env:
+      FEATURES_CARGO: ${{ join(matrix.features, ',') }}
+      FEATURES_TAG: ${{ join(matrix.features, '-') }}
+      TARGET: ${{ matrix.target }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          target: ${{ matrix.target }}
+          target: $TARGET
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: make installdeps
       - name: Cross build
         run: |
-          cross build --release --target ${{ matrix.target }} --no-default-features --features ${{ matrix.feature }} --workspace
+          cross build --release --target $TARGET --no-default-features --features "$FEATURES_CARGO" --workspace
           mkdir release
-          cp target/${{ matrix.target }}/release/librln* release/
-          tar -czvf ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz release/
+          cp target/$TARGET/release/librln* release/
+          tar -czvf $TARGET-$FEATURES_TAG-rln.tar.gz release/
       - name: Upload archive artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}-${{ matrix.feature }}-archive
-          path: ${{ matrix.target }}-${{ matrix.feature }}-rln.tar.gz
+          name: ${{ env.TARGET }}-${{ env.FEATURES_TAG }}-archive
+          path: ${{ env.TARGET }}-${{ env.FEATURES_TAG }}-rln.tar.gz
           retention-days: 2
 
   rln-wasm:


### PR DESCRIPTION
Clean feature naming with env vars

- Use arrays for feature sets in matrix.
- Add job-level env (FEATURES_CARGO, FEATURES_TAG, TARGET).
- Use FEATURES_TAG for artifact/file names → no more dots/commas.

Example:
`x86_64-unknown-linux-gnu-fullmerkletree.parallel-rln.tar.gz` →
`x86_64-unknown-linux-gnu-fullmerkletree-parallel-rln.tar.gz`