### PR TITLE
fix(ci): nightly build failed due to incorrect config flag for pm_tree_adapter

### DIFF
--- a/rln/src/lib.rs
+++ b/rln/src/lib.rs
@@ -2,7 +2,6 @@ pub mod circuit;
 pub mod error;
 pub mod ffi;
 pub mod hashers;
-#[cfg(feature = "pmtree-ft")]
 pub mod pm_tree_adapter;
 pub mod poseidon_tree;
 pub mod prelude;


### PR DESCRIPTION
Success build:
https://github.com/vacp2p/zerokit/actions/runs/20063084959
https://github.com/vacp2p/zerokit/actions/runs/20063354977