### PR TITLE
fix(ci): add Binaryen installation to CI workflows and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,23 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install Binaryen
+        if: matrix.crate == 'rln-wasm'
+        run: |
+          BINARYEN_VERSION=125
+          if [[ "${{ matrix.platform }}" == "ubuntu-latest" ]]; then
+            ARCHIVE_NAME=binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz
+            wget https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${ARCHIVE_NAME}
+            tar -xzf ${ARCHIVE_NAME}
+            sudo cp binaryen-version_${BINARYEN_VERSION}/bin/* /usr/local/bin/
+            rm -rf binaryen-version_${BINARYEN_VERSION} ${ARCHIVE_NAME}
+          elif [[ "${{ matrix.platform }}" == "macos-latest" ]]; then
+            ARCHIVE_NAME=binaryen-version_${BINARYEN_VERSION}-x86_64-macos.tar.gz
+            wget https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${ARCHIVE_NAME}
+            tar -xzf ${ARCHIVE_NAME}
+            sudo cp binaryen-version_${BINARYEN_VERSION}/bin/* /usr/local/bin/
+            rm -rf binaryen-version_${BINARYEN_VERSION} ${ARCHIVE_NAME}
+          fi
       - name: Install dependencies
         run: make installdeps
       - name: Build rln-wasm
@@ -124,6 +141,22 @@ jobs:
           components: rust-src
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - name: Install Binaryen
+        run: |
+          BINARYEN_VERSION=125
+          if [[ "${{ matrix.platform }}" == "ubuntu-latest" ]]; then
+            ARCHIVE_NAME=binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz
+            wget https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${ARCHIVE_NAME}
+            tar -xzf ${ARCHIVE_NAME}
+            sudo cp binaryen-version_${BINARYEN_VERSION}/bin/* /usr/local/bin/
+            rm -rf binaryen-version_${BINARYEN_VERSION} ${ARCHIVE_NAME}
+          elif [[ "${{ matrix.platform }}" == "macos-latest" ]]; then
+            ARCHIVE_NAME=binaryen-version_${BINARYEN_VERSION}-x86_64-macos.tar.gz
+            wget https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${ARCHIVE_NAME}
+            tar -xzf ${ARCHIVE_NAME}
+            sudo cp binaryen-version_${BINARYEN_VERSION}/bin/* /usr/local/bin/
+            rm -rf binaryen-version_${BINARYEN_VERSION} ${ARCHIVE_NAME}
+          fi
       - name: Install dependencies
         run: make installdeps
       - name: Build rln-wasm in parallel mode

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -111,6 +111,14 @@ jobs:
           components: rust-src
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - name: Install Binaryen
+        run: |
+          BINARYEN_VERSION=125
+          ARCHIVE_NAME=binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz
+          wget https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${ARCHIVE_NAME}
+          tar -xzf ${ARCHIVE_NAME}
+          sudo cp binaryen-version_${BINARYEN_VERSION}/bin/* /usr/local/bin/
+          rm -rf binaryen-version_${BINARYEN_VERSION} ${ARCHIVE_NAME}
       - name: Install dependencies
         run: make installdeps
       - name: Build rln-wasm package

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ endif
 
 installdeps: .pre-build
 ifeq ($(shell uname),Darwin)
-	@brew install ninja
+	@brew install ninja binaryen
 else ifeq ($(shell uname),Linux)
 	@if [ -f /etc/os-release ] && grep -q "ID=nixos" /etc/os-release; then \
 		echo "Detected NixOS, skipping apt installation."; \
 	else \
 		sudo apt update; \
-		sudo apt install -y cmake ninja-build; \
+		sudo apt install -y cmake ninja-build binaryen; \
 	fi
 endif
 	@which wasm-pack > /dev/null && wasm-pack --version | grep -q "0.13.1" || cargo install wasm-pack --version=0.13.1


### PR DESCRIPTION
Installing software for wasm-opt to avoid timeout errors when CI attempts to install from scratch via wasm-pack
 