### PR TITLE
refactor(PR 5): implement missing stateless features and rln-wasm module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
 ]
 
@@ -297,9 +297,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -345,9 +345,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -662,6 +662,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -774,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -833,10 +857,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -858,9 +884,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1098,9 +1124,9 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "unarray",
@@ -1152,9 +1178,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1163,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -1216,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1292,7 +1318,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
  "ruint",
@@ -1308,14 +1334,14 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "ark-ff",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -1343,7 +1369,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1476,6 +1502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "sled"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,7 +1561,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 1.0.109",
 ]
 
@@ -1686,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -1759,11 +1791,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1772,14 +1804,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1790,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1800,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1813,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -1848,7 +1880,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1856,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1912,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -1927,6 +1959,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1977,7 +2015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else ifeq ($(shell uname),Linux)
 		sudo apt install -y cmake ninja-build; \
 	fi
 endif
-	@which wasm-pack > /dev/null && wasm-pack --version | grep -q "0.14.0" || cargo install wasm-pack --version=0.14.0
+	@which wasm-pack > /dev/null && wasm-pack --version | grep -q "0.15.0" || cargo install wasm-pack --version=0.15.0
 	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v22.14.0" ] || nvm install 22.14.0; nvm use 22.14.0; nvm alias default 22.14.0'
 

--- a/rln-cli/Cargo.lock
+++ b/rln-cli/Cargo.lock
@@ -293,7 +293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
 ]
 
@@ -1030,9 +1030,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1138,7 +1138,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
  "ruint",
@@ -1163,13 +1163,13 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "ark-ff",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand 0.9.2",
  "ruint-macro",
  "serde_core",
@@ -1374,7 +1374,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 1.0.109",
 ]
 

--- a/rln-wasm/Cargo.lock
+++ b/rln-wasm/Cargo.lock
@@ -243,7 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
 ]
 
@@ -278,9 +278,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -326,9 +326,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -681,7 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -758,9 +758,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -973,9 +973,9 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "unarray",
@@ -1027,9 +1027,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1038,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1137,7 +1137,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
  "ruint",
@@ -1162,7 +1162,7 @@ dependencies = [
  "getrandom 0.2.17",
  "js-sys",
  "num-bigint",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rln",
  "serde",
  "serde-wasm-bindgen",
@@ -1177,14 +1177,14 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "ark-ff",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -1212,7 +1212,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1414,7 +1414,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 1.0.109",
 ]
 
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -1628,11 +1628,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1641,14 +1641,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1704,18 +1704,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.67"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
 dependencies = [
  "async-trait",
  "cast",
@@ -1735,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.67"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1746,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
 
 [[package]]
 name = "wasm-encoder"
@@ -1789,7 +1789,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1797,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1853,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -1868,6 +1868,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1918,7 +1924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/rln-wasm/Cargo.toml
+++ b/rln-wasm/Cargo.toml
@@ -13,8 +13,8 @@ rln = { path = "../rln", version = "2.0.1", default-features = false, features =
 ] }
 zerokit_utils = { path = "../utils", version = "1.2.0", default-features = false }
 num-bigint = { version = "0.4.6", default-features = false }
-js-sys = "0.3.91"
-wasm-bindgen = "0.2.114"
+js-sys = "0.3.98"
+wasm-bindgen = "0.2.121"
 serde-wasm-bindgen = "0.6.5"
 serde = "1.0.228"
 wasm-bindgen-rayon = { version = "1.3.0", features = [
@@ -22,7 +22,7 @@ wasm-bindgen-rayon = { version = "1.3.0", features = [
 ], optional = true }
 ark-relations = { version = "0.5.1", features = ["std"] }
 ark-groth16 = { version = "0.5.0", default-features = false }
-rand = "0.8.5"
+rand = "0.8.6"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -35,12 +35,12 @@ getrandom = { version = "0.2.17", features = ["js"] }
 
 [dev-dependencies]
 serde_json = "1.0.149"
-wasm-bindgen-test = "0.3.64"
-wasm-bindgen-futures = "0.4.64"
+wasm-bindgen-test = "0.3.71"
+wasm-bindgen-futures = "0.4.71"
 ark-std = { version = "0.5.0", default-features = false }
 
 [dev-dependencies.web-sys]
-version = "0.3.91"
+version = "0.3.98"
 features = ["Window", "Navigator"]
 
 [features]

--- a/rln-wasm/README.md
+++ b/rln-wasm/README.md
@@ -14,7 +14,7 @@ to enable RLN functionality in JavaScript/TypeScript applications.
 > [!NOTE]
 > This project requires the following tools:
 >
-> - `wasm-pack` (v0.14.0) - for compiling Rust to WebAssembly
+> - `wasm-pack` (v0.15.0) - for compiling Rust to WebAssembly
 > - `cargo-make` - for running build commands
 > - `nvm` - to install and manage Node.js (v22.14.0+)
 
@@ -28,7 +28,7 @@ make installdeps
 
 ```bash
 # Install wasm-pack
-cargo install wasm-pack --version=0.14.0
+cargo install wasm-pack --version=0.15.0
 
 # Install cargo-make
 cargo install cargo-make

--- a/rln-wasm/examples/README.md
+++ b/rln-wasm/examples/README.md
@@ -10,7 +10,7 @@ cargo make build
 
 ## Running the examples
 
-**Note:** Set `MULTI_MESSAGE_ID` constant in [index.js](../examples/index.js) to `true` when testing with multi-message-id mode.
+**Note:** Set `MULTI_MESSAGE_ID` constant in [index.js](../examples/index.js) to `true` when testing with Multi message-id mode.
 
 After building the package in any mode, install dependencies and run:
 

--- a/rln-wasm/examples/index.js
+++ b/rln-wasm/examples/index.js
@@ -67,10 +67,10 @@ async function main() {
   console.log("  - RLN instance created successfully");
 
   const treeDepth = 20;
-  console.log("  - circuit tree_depth = " + treeDepth);
+  console.log("  - circuit treeDepth = " + treeDepth);
   const maxOut = 4;
   if (MULTI_MESSAGE_ID) {
-    console.log("  - circuit max_out = " + maxOut);
+    console.log("  - circuit maxOut = " + maxOut);
   }
 
   console.log("\nGenerating identity keys");
@@ -78,24 +78,24 @@ async function main() {
   const identitySecret = identity.getSecretHash();
   const idCommitment = identity.getCommitment();
   console.log("  - identity generated successfully");
-  console.log("  - identity_secret = " + identitySecret.debug());
-  console.log("  - id_commitment = " + idCommitment.debug());
+  console.log("  - identitySecret = " + identitySecret.debug());
+  console.log("  - idCommitment = " + idCommitment.debug());
 
   console.log("\nCreating message limit");
   const userMessageLimit = rlnWasm.WasmFr.fromUint(10);
-  console.log("  - user_message_limit = " + userMessageLimit.debug());
+  console.log("  - userMessageLimit = " + userMessageLimit.debug());
 
   console.log("\nComputing rate commitment");
   let rateCommitment = rlnWasm.Hasher.poseidonHashPair(
     idCommitment,
     userMessageLimit,
   );
-  console.log("  - rate_commitment = " + rateCommitment.debug());
+  console.log("  - rateCommitment = " + rateCommitment.debug());
 
   console.log("\nWasmFr serialization: WasmFr <-> bytes");
   const serRateCommitment = rateCommitment.toBytesLE();
   console.log(
-    "  - serialized rate_commitment = [" +
+    "  - serialized rateCommitment = [" +
       debugUint8Array(serRateCommitment) +
       "]",
   );
@@ -108,7 +108,7 @@ async function main() {
     return;
   }
   console.log(
-    "  - deserialized rate_commitment = " + deserRateCommitment.debug(),
+    "  - deserialized rateCommitment = " + deserRateCommitment.debug(),
   );
 
   console.log("\nIdentity serialization: Identity <-> bytes");
@@ -156,7 +156,7 @@ async function main() {
   console.log("\nVecWasmFr serialization: VecWasmFr <-> bytes");
   const serPathElements = pathElements.toBytesLE();
   console.log(
-    "  - serialized path_elements = [" + debugUint8Array(serPathElements) + "]",
+    "  - serialized pathElements = [" + debugUint8Array(serPathElements) + "]",
   );
 
   let deserPathElements;
@@ -166,12 +166,12 @@ async function main() {
     console.error("Path elements deserialization error:", error);
     return;
   }
-  console.log("  - deserialized path_elements = ", deserPathElements.debug());
+  console.log("  - deserialized pathElements = ", deserPathElements.debug());
 
   console.log("\nUint8Array serialization: Uint8Array <-> bytes");
   const serPathIndex = rlnWasm.Uint8ArrayUtils.toBytesLE(identityPathIndex);
   console.log(
-    "  - serialized path_index = [" + debugUint8Array(serPathIndex) + "]",
+    "  - serialized pathIndex = [" + debugUint8Array(serPathIndex) + "]",
   );
 
   let deserPathIndex;
@@ -181,10 +181,10 @@ async function main() {
     console.error("Path index deserialization error:", error);
     return;
   }
-  console.log("  - deserialized path_index =", deserPathIndex);
+  console.log("  - deserialized pathIndex =", deserPathIndex);
 
   console.log("\nComputing Merkle root for stateless mode");
-  console.log("  - computing root for index 0 with rate_commitment");
+  console.log("  - computing root for index 0 with rateCommitment");
 
   let computedRoot = rlnWasm.Hasher.poseidonHashPair(
     rateCommitment,
@@ -196,7 +196,7 @@ async function main() {
       defaultHashes[i - 1],
     );
   }
-  console.log("  - computed_root = " + computedRoot.debug());
+  console.log("  - computedRoot = " + computedRoot.debug());
 
   console.log("\nHashing first signal");
   const signal1 = new Uint8Array([
@@ -251,7 +251,7 @@ async function main() {
   let messageIds1, selectorUsed1;
   if (MULTI_MESSAGE_ID) {
     console.log(
-      "\nCreating messageIds1 and selectorUsed1 (multi-message-id mode)",
+      "\nCreating messageIds1 and selectorUsed1 (Multi message-id mode)",
     );
     console.log("  - using 2 out of " + maxOut + " slots");
 
@@ -464,7 +464,7 @@ async function main() {
   let messageIds2, selectorUsed2;
   if (MULTI_MESSAGE_ID) {
     console.log(
-      "\nCreating messageIds2 and selectorUsed2 (multi-message-id mode)",
+      "\nCreating messageIds2 and selectorUsed2 (Multi message-id mode)",
     );
     console.log("  - using 2 out of " + maxOut + " slots");
     console.log("  - duplicated slot id 1");

--- a/rln-wasm/examples/index.js
+++ b/rln-wasm/examples/index.js
@@ -198,19 +198,19 @@ async function main() {
   }
   console.log("  - computed_root = " + computedRoot.debug());
 
-  console.log("\nHashing signal");
-  const signal = new Uint8Array([
+  console.log("\nHashing first signal");
+  const signal1 = new Uint8Array([
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0,
   ]);
-  let x;
+  let x1;
   try {
-    x = rlnWasm.Hasher.hashToFieldLE(signal);
+    x1 = rlnWasm.Hasher.hashToFieldLE(signal1);
   } catch (error) {
     console.error("Hash signal error:", error);
     return;
   }
-  console.log("  - x = " + x.debug());
+  console.log("  - x1 = " + x1.debug());
 
   console.log("\nHashing epoch");
   const epochStr = "test-epoch";
@@ -234,197 +234,204 @@ async function main() {
     console.error("Hash RLN identifier error:", error);
     return;
   }
-  console.log("  - rln_identifier = " + rlnIdentifier.debug());
+  console.log("  - rlnIdentifier = " + rlnIdentifier.debug());
 
   console.log("\nComputing Poseidon hash for external nullifier");
   let externalNullifier = rlnWasm.Hasher.poseidonHashPair(epoch, rlnIdentifier);
-  console.log("  - external_nullifier = " + externalNullifier.debug());
+  console.log("  - externalNullifier = " + externalNullifier.debug());
 
   if (MULTI_MESSAGE_ID) {
-    console.log("\nCreating default message_id");
+    console.log("\nCreating messageId1");
   } else {
-    console.log("\nCreating message_id");
+    console.log("\nCreating messageId1");
   }
-  const messageId = rlnWasm.WasmFr.fromUint(0);
-  console.log("  - message_id = " + messageId.debug());
+  const messageId1 = rlnWasm.WasmFr.fromUint(0);
+  console.log("  - messageId1 = " + messageId1.debug());
 
-  let messageIds, selectorUsed;
+  let messageIds1, selectorUsed1;
   if (MULTI_MESSAGE_ID) {
     console.log(
-      "\nCreating message_ids and selector_used (multi-message-id mode)",
+      "\nCreating messageIds1 and selectorUsed1 (multi-message-id mode)",
     );
     console.log("  - using 2 out of " + maxOut + " slots");
 
-    messageIds = new rlnWasm.VecWasmFr();
-    messageIds.push(rlnWasm.WasmFr.fromUint(0));
-    messageIds.push(rlnWasm.WasmFr.fromUint(1));
-    messageIds.push(rlnWasm.WasmFr.zero());
-    messageIds.push(rlnWasm.WasmFr.zero());
+    messageIds1 = new rlnWasm.VecWasmFr();
+    messageIds1.push(rlnWasm.WasmFr.fromUint(0));
+    messageIds1.push(rlnWasm.WasmFr.fromUint(1));
+    messageIds1.push(rlnWasm.WasmFr.zero());
+    messageIds1.push(rlnWasm.WasmFr.zero());
 
-    selectorUsed = Uint8Array.from([true, true, false, false], (b) =>
+    selectorUsed1 = Uint8Array.from([true, true, false, false], (b) =>
       b ? 1 : 0,
     );
 
-    console.log("  - message_ids = " + messageIds.debug());
+    console.log("  - messageIds1 = " + messageIds1.debug());
   }
 
-  console.log("\nCreating RLN Witness");
-  let witness;
+  console.log("\nCreating first RLN Witness");
+  let witness1;
   if (MULTI_MESSAGE_ID) {
-    witness = rlnWasm.WasmRLNWitnessInput.newMulti(
+    witness1 = rlnWasm.WasmRLNWitnessInput.newMulti(
       identitySecret,
       userMessageLimit,
-      messageIds,
+      messageIds1,
       pathElements,
       identityPathIndex,
-      x,
+      x1,
       externalNullifier,
-      selectorUsed,
+      selectorUsed1,
     );
   } else {
-    witness = rlnWasm.WasmRLNWitnessInput.newSingle(
+    witness1 = rlnWasm.WasmRLNWitnessInput.newSingle(
       identitySecret,
       userMessageLimit,
-      messageId,
+      messageId1,
       pathElements,
       identityPathIndex,
-      x,
+      x1,
       externalNullifier,
     );
   }
-  console.log("  - RLN Witness created successfully");
+  console.log("  - first RLN Witness created successfully");
 
   console.log(
     "\nWasmRLNWitnessInput serialization: WasmRLNWitnessInput <-> bytes",
   );
-  let serWitness;
+  let serWitness1;
   try {
-    serWitness = witness.toBytesLE();
+    serWitness1 = witness1.toBytesLE();
   } catch (error) {
     console.error("Witness serialization error:", error);
     return;
   }
   console.log(
-    "  - serialized witness = [" + debugUint8Array(serWitness) + " ]",
+    "  - serialized witness = [" + debugUint8Array(serWitness1) + " ]",
   );
 
-  let deserWitness;
+  let deserWitness1;
   try {
-    deserWitness = rlnWasm.WasmRLNWitnessInput.fromBytesLE(serWitness);
+    deserWitness1 = rlnWasm.WasmRLNWitnessInput.fromBytesLE(serWitness1);
   } catch (error) {
     console.error("Witness deserialization error:", error);
     return;
   }
   console.log("  - witness deserialized successfully");
 
-  console.log("\nCalculating witness");
-  let witnessJson;
+  console.log("\nCalculating first witness");
+  let witnessJson1;
   try {
-    witnessJson = witness.toBigIntJson();
+    witnessJson1 = witness1.toBigIntJson();
   } catch (error) {
     console.error("Witness to BigInt JSON error:", error);
     return;
   }
-  const calculatedWitness = await calculateWitness(
+  const calculatedWitness1 = await calculateWitness(
     circomPath,
-    witnessJson,
+    witnessJson1,
     witnessCalculatorFile,
   );
-  console.log("  - witness calculated successfully");
+  console.log("  - first witness calculated successfully");
 
-  console.log("\nGenerating RLN Proof");
-  let rln_proof;
+  console.log("\nExtracting first RLN Proof Values from witness");
+  let proofValues1;
   try {
-    rln_proof = rlnInstance.generateRLNProofWithWitness(
-      calculatedWitness,
-      witness,
-    );
+    proofValues1 = witness1.toProofValues();
+  } catch (error) {
+    console.error("Proof values extraction error:", error);
+    return;
+  }
+  console.log("  - proof values extracted successfully");
+
+  console.log("\nGenerating first RLN Proof");
+  let rlnProof1;
+  try {
+    rlnProof1 =
+      rlnInstance.generateProofFromCalculatedWitness(calculatedWitness1);
   } catch (error) {
     console.error("Proof generation error:", error);
     return;
   }
   console.log("  - proof generated successfully");
 
-  console.log("\nGetting RLN Proof Values");
-  const proofValues = rln_proof.getValues();
-
   if (MULTI_MESSAGE_ID) {
     try {
-      const ys = proofValues.ys();
+      const ys = proofValues1.ys();
       console.log("  - ys = " + ys.debug());
     } catch (error) {
       console.error("Error getting ys:", error);
     }
 
     try {
-      const nullifiers = proofValues.nullifiers();
+      const nullifiers = proofValues1.nullifiers();
       console.log("  - nullifiers = " + nullifiers.debug());
     } catch (error) {
       console.error("Error getting nullifiers:", error);
     }
   } else {
-    console.log("  - y = " + proofValues.y.debug());
-    console.log("  - nullifier = " + proofValues.nullifier.debug());
+    console.log("  - y = " + proofValues1.y.debug());
+    console.log("  - nullifier = " + proofValues1.nullifier.debug());
   }
 
-  console.log("  - root = " + proofValues.root.debug());
-  console.log("  - x = " + proofValues.x.debug());
+  console.log("  - root = " + proofValues1.root.debug());
+  console.log("  - x = " + proofValues1.x.debug());
   console.log(
-    "  - external_nullifier = " + proofValues.externalNullifier.debug(),
+    "  - externalNullifier = " + proofValues1.externalNullifier.debug(),
   );
 
-  console.log("\nRLNProof serialization: RLNProof <-> bytes");
-  let serProof;
+  console.log("\nWasmRLNProof serialization: WasmRLNProof <-> bytes");
+  let serProof1;
   try {
-    serProof = rln_proof.toBytesLE();
+    serProof1 = rlnProof1.toBytesLE();
   } catch (error) {
     console.error("Proof serialization error:", error);
     return;
   }
-  console.log("  - serialized proof = [" + debugUint8Array(serProof) + " ]");
+  console.log("  - serialized proof = [" + debugUint8Array(serProof1) + " ]");
 
-  let deserProof;
+  let deserProof1;
   try {
-    deserProof = rlnWasm.WasmRLNProof.fromBytesLE(serProof);
+    deserProof1 = rlnWasm.WasmRLNProof.fromBytesLE(serProof1);
   } catch (error) {
     console.error("Proof deserialization error:", error);
     return;
   }
   console.log("  - proof deserialized successfully");
 
-  console.log("\nRLNProofValues serialization: RLNProofValues <-> bytes");
-  const serProofValues = proofValues.toBytesLE();
   console.log(
-    "  - serialized proof_values = [" + debugUint8Array(serProofValues) + " ]",
+    "\nWasmRLNProofValues serialization: WasmRLNProofValues <-> bytes",
+  );
+  const serProofValues1 = proofValues1.toBytesLE();
+  console.log(
+    "  - serialized proofValues = [" + debugUint8Array(serProofValues1) + " ]",
   );
 
-  let deserProofValues2;
+  let deserProofValues1;
   try {
-    deserProofValues2 = rlnWasm.WasmRLNProofValues.fromBytesLE(serProofValues);
+    deserProofValues1 = rlnWasm.WasmRLNProofValues.fromBytesLE(serProofValues1);
   } catch (error) {
     console.error("RLN Proof Values deserialization error:", error);
     return;
   }
-  console.log("  - proof_values deserialized successfully");
+  console.log("  - proofValues deserialized successfully");
   console.log(
-    "  - deserialized external_nullifier = " +
-      deserProofValues2.externalNullifier.debug(),
+    "  - deserialized externalNullifier = " +
+      deserProofValues1.externalNullifier.debug(),
   );
 
-  console.log("\nVerifying Proof");
+  console.log("\nVerifying first proof");
   const roots = new rlnWasm.VecWasmFr();
   roots.push(computedRoot);
-  let isValid;
+  let isValid1;
   try {
-    isValid = rlnInstance.verifyWithRoots(rln_proof, roots, x);
+    isValid1 = rlnInstance.verifyWithRoots(rlnProof1, proofValues1, roots, x1);
   } catch (error) {
     console.error("Proof verification error:", error);
     return;
   }
-  if (isValid) {
-    console.log("  - proof verified successfully");
+  if (isValid1) {
+    console.log("  - first proof verified successfully");
   } else {
-    console.log("Proof verification failed");
+    console.log("First proof verification failed");
     return;
   }
 
@@ -447,17 +454,17 @@ async function main() {
   console.log("  - x2 = " + x2.debug());
 
   if (MULTI_MESSAGE_ID) {
-    console.log("\nCreating default message_id2");
+    console.log("\nCreating messageId2");
   } else {
     console.log("\nCreating second message with the same id");
   }
   const messageId2 = rlnWasm.WasmFr.fromUint(0);
-  console.log("  - message_id2 = " + messageId2.debug());
+  console.log("  - messageId2 = " + messageId2.debug());
 
   let messageIds2, selectorUsed2;
   if (MULTI_MESSAGE_ID) {
     console.log(
-      "\nCreating message_ids2 and selector_used2 (multi-message-id mode)",
+      "\nCreating messageIds2 and selectorUsed2 (multi-message-id mode)",
     );
     console.log("  - using 2 out of " + maxOut + " slots");
     console.log("  - duplicated slot id 1");
@@ -472,7 +479,7 @@ async function main() {
       b ? 1 : 0,
     );
 
-    console.log("  - message_ids2 = " + messageIds2.debug());
+    console.log("  - messageIds2 = " + messageIds2.debug());
   }
 
   console.log("\nCreating second RLN Witness");
@@ -516,13 +523,21 @@ async function main() {
   );
   console.log("  - second witness calculated successfully");
 
-  console.log("\nGenerating second RLN Proof");
-  let rln_proof2;
+  console.log("\nExtracting second RLN Proof Values from witness");
+  let proofValues2;
   try {
-    rln_proof2 = rlnInstance.generateRLNProofWithWitness(
-      calculatedWitness2,
-      witness2,
-    );
+    proofValues2 = witness2.toProofValues();
+  } catch (error) {
+    console.error("Second proof values extraction error:", error);
+    return;
+  }
+  console.log("  - second proof values extracted successfully");
+
+  console.log("\nGenerating second RLN Proof");
+  let rlnProof2;
+  try {
+    rlnProof2 =
+      rlnInstance.generateProofFromCalculatedWitness(calculatedWitness2);
   } catch (error) {
     console.error("Second proof generation error:", error);
     return;
@@ -532,7 +547,7 @@ async function main() {
   console.log("\nVerifying second proof");
   let isValid2;
   try {
-    isValid2 = rlnInstance.verifyWithRoots(rln_proof2, roots, x2);
+    isValid2 = rlnInstance.verifyWithRoots(rlnProof2, proofValues2, roots, x2);
   } catch (error) {
     console.error("Proof verification error:", error);
     return;
@@ -541,8 +556,6 @@ async function main() {
     console.log("  - second proof verified successfully");
 
     console.log("\nRecovering identity secret");
-    const proofValues1 = rln_proof.getValues();
-    const proofValues2 = rln_proof2.getValues();
     let recoveredSecret;
     try {
       recoveredSecret = rlnWasm.WasmRLNProofValues.recoverIdSecret(
@@ -553,8 +566,8 @@ async function main() {
       console.error("Identity recovery error:", error);
       return;
     }
-    console.log("  - recovered_secret = " + recoveredSecret.debug());
-    console.log("  - original_secret  = " + identitySecret.debug());
+    console.log("  - recoveredSecret = " + recoveredSecret.debug());
+    console.log("  - identitySecret  = " + identitySecret.debug());
     console.log("  - identity recovered successfully");
   } else {
     console.log("Second proof verification failed");

--- a/rln-wasm/src/wasm_rln.rs
+++ b/rln-wasm/src/wasm_rln.rs
@@ -10,13 +10,13 @@ use wasm_bindgen::prelude::*;
 use crate::wasm_utils::{VecWasmFr, WasmFr};
 
 #[wasm_bindgen]
-pub struct WasmRLN(RLN);
+pub struct WasmRLN(RLNV3<Stateless, ArkGroth16Backend>);
 
 #[wasm_bindgen]
 impl WasmRLN {
     #[wasm_bindgen(constructor)]
     pub fn new(zkey_data: &Uint8Array) -> Result<WasmRLN, String> {
-        let rln = RLN::new_with_params(zkey_data.to_vec()).map_err(|err| err.to_string())?;
+        let rln = RLNV3::new_with_params(zkey_data.to_vec()).map_err(|err| err.to_string())?;
         Ok(WasmRLN(rln))
     }
 
@@ -42,15 +42,10 @@ impl WasmRLN {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let (proof, proof_values) = self
+        let rln_proof = self
             .0
-            .generate_rln_proof_with_witness(calculated_witness_bigint, &witness.0)
+            .generate_rln_proof_with_witness(calculated_witness_bigint, witness.0.clone())
             .map_err(|err| err.to_string())?;
-
-        let rln_proof = RLNProof {
-            proof_values,
-            proof,
-        };
 
         Ok(WasmRLNProof(rln_proof))
     }
@@ -74,7 +69,7 @@ impl WasmRLN {
 }
 
 #[wasm_bindgen]
-pub struct WasmRLNProof(RLNProof);
+pub struct WasmRLNProof(RLNProofV3);
 
 #[wasm_bindgen]
 impl WasmRLNProof {
@@ -83,117 +78,126 @@ impl WasmRLNProof {
         WasmRLNProofValues(self.0.proof_values.clone())
     }
 
-    #[wasm_bindgen(js_name = getVersionByte)]
-    pub fn get_version_byte(&self) -> u8 {
-        self.0.version_byte()
-    }
-
     #[wasm_bindgen(js_name = toBytesLE)]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
-        let bytes = rln_proof_to_bytes_le(&self.0).map_err(|err| err.to_string())?;
+        let mut bytes = Vec::new();
+        self.0
+            .serialize_compressed(&mut bytes)
+            .map_err(|err| err.to_string())?;
         Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = toBytesBE)]
     pub fn to_bytes_be(&self) -> Result<Uint8Array, String> {
-        let bytes = rln_proof_to_bytes_be(&self.0).map_err(|err| err.to_string())?;
+        let mut bytes = Vec::new();
+        CanonicalSerializeBE::serialize(&self.0, &mut bytes).map_err(|err| err.to_string())?;
         Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = fromBytesLE)]
     pub fn from_bytes_le(bytes: &Uint8Array) -> Result<WasmRLNProof, String> {
-        let bytes_vec = bytes.to_vec();
-        let (proof, _) = bytes_le_to_rln_proof(&bytes_vec).map_err(|err| err.to_string())?;
-        Ok(WasmRLNProof(proof))
+        let rln_proof = RLNProofV3::deserialize_compressed(&bytes.to_vec()[..])
+            .map_err(|err| err.to_string())?;
+        Ok(WasmRLNProof(rln_proof))
     }
 
     #[wasm_bindgen(js_name = fromBytesBE)]
     pub fn from_bytes_be(bytes: &Uint8Array) -> Result<WasmRLNProof, String> {
-        let bytes_vec = bytes.to_vec();
-        let (proof, _) = bytes_be_to_rln_proof(&bytes_vec).map_err(|err| err.to_string())?;
-        Ok(WasmRLNProof(proof))
+        let rln_proof = <RLNProofV3 as CanonicalDeserializeBE>::deserialize(&bytes.to_vec()[..])
+            .map_err(|err| err.to_string())?;
+        Ok(WasmRLNProof(rln_proof))
     }
 }
 
 #[wasm_bindgen]
-pub struct WasmRLNProofValues(RLNProofValues);
+pub struct WasmRLNProofValues(RLNProofValuesV3);
 
 #[wasm_bindgen]
 impl WasmRLNProofValues {
     #[wasm_bindgen(getter)]
+    pub fn y(&self) -> Result<WasmFr, String> {
+        self.0.y().map(WasmFr::from).map_err(|e| e.to_string())
+    }
+
+    #[wasm_bindgen(js_name = ys)]
+    pub fn ys(&self) -> Result<VecWasmFr, String> {
+        self.0
+            .ys()
+            .map(|s| VecWasmFr::from(s.to_vec()))
+            .map_err(|e| e.to_string())
+    }
+
+    #[wasm_bindgen(getter)]
     pub fn root(&self) -> WasmFr {
-        WasmFr::from(*self.0.root())
+        WasmFr::from(self.0.root())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn nullifier(&self) -> Result<WasmFr, String> {
+        self.0
+            .nullifier()
+            .map(WasmFr::from)
+            .map_err(|e| e.to_string())
+    }
+
+    #[wasm_bindgen(js_name = nullifiers)]
+    pub fn nullifiers(&self) -> Result<VecWasmFr, String> {
+        self.0
+            .nullifiers()
+            .map(|s| VecWasmFr::from(s.to_vec()))
+            .map_err(|e| e.to_string())
     }
 
     #[wasm_bindgen(getter)]
     pub fn x(&self) -> WasmFr {
-        WasmFr::from(*self.0.x())
+        WasmFr::from(self.0.x())
     }
 
     #[wasm_bindgen(getter, js_name = externalNullifier)]
     pub fn external_nullifier(&self) -> WasmFr {
-        WasmFr::from(*self.0.external_nullifier())
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn y(&self) -> WasmFr {
-        WasmFr::from(*self.0.y())
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn nullifier(&self) -> WasmFr {
-        WasmFr::from(*self.0.nullifier())
+        WasmFr::from(self.0.external_nullifier())
     }
 
     #[wasm_bindgen(js_name = selectorUsed)]
-    pub fn selector_used(&self) -> Uint8Array {
+    pub fn selector_used(&self) -> Result<Uint8Array, String> {
         let bytes: Vec<u8> = self
             .0
             .selector_used()
+            .map_err(|e| e.to_string())?
             .iter()
             .map(|&b| if b { 1u8 } else { 0u8 })
             .collect();
-        Uint8Array::from(&bytes[..])
-    }
-
-    #[wasm_bindgen(js_name = ys)]
-    pub fn ys(&self) -> VecWasmFr {
-        VecWasmFr::from(self.0.ys().to_vec())
-    }
-
-    #[wasm_bindgen(js_name = nullifiers)]
-    pub fn nullifiers(&self) -> VecWasmFr {
-        VecWasmFr::from(self.0.nullifiers().to_vec())
-    }
-
-    #[wasm_bindgen(js_name = getVersionByte)]
-    pub fn get_version_byte(&self) -> u8 {
-        self.0.version_byte()
+        Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = toBytesLE)]
-    pub fn to_bytes_le(&self) -> Uint8Array {
-        Uint8Array::from(&rln_proof_values_to_bytes_le(&self.0)[..])
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let mut bytes = Vec::new();
+        self.0
+            .serialize_compressed(&mut bytes)
+            .map_err(|err| err.to_string())?;
+        Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = toBytesBE)]
-    pub fn to_bytes_be(&self) -> Uint8Array {
-        Uint8Array::from(&rln_proof_values_to_bytes_be(&self.0)[..])
+    pub fn to_bytes_be(&self) -> Result<Uint8Array, String> {
+        let mut bytes = Vec::new();
+        CanonicalSerializeBE::serialize(&self.0, &mut bytes).map_err(|err| err.to_string())?;
+        Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = fromBytesLE)]
     pub fn from_bytes_le(bytes: &Uint8Array) -> Result<WasmRLNProofValues, String> {
-        let bytes_vec = bytes.to_vec();
-        let (proof_values, _) =
-            bytes_le_to_rln_proof_values(&bytes_vec).map_err(|err| err.to_string())?;
+        let proof_values = RLNProofValuesV3::deserialize_compressed(&bytes.to_vec()[..])
+            .map_err(|err| err.to_string())?;
         Ok(WasmRLNProofValues(proof_values))
     }
 
     #[wasm_bindgen(js_name = fromBytesBE)]
     pub fn from_bytes_be(bytes: &Uint8Array) -> Result<WasmRLNProofValues, String> {
-        let bytes_vec = bytes.to_vec();
-        let (proof_values, _) =
-            bytes_be_to_rln_proof_values(&bytes_vec).map_err(|err| err.to_string())?;
+        let proof_values =
+            <RLNProofValuesV3 as CanonicalDeserializeBE>::deserialize(&bytes.to_vec()[..])
+                .map_err(|err| err.to_string())?;
         Ok(WasmRLNProofValues(proof_values))
     }
 
@@ -215,15 +219,16 @@ impl WasmRLNProofValues {
         proof_values_1: &WasmRLNProofValues,
         proof_values_2: &WasmRLNProofValues,
     ) -> Result<WasmFr, String> {
-        let recovered_identity_secret = recover_id_secret(&proof_values_1.0, &proof_values_2.0)
+        let recovered_identity_secret = proof_values_1
+            .0
+            .recover_secret(&proof_values_2.0)
             .map_err(|err| err.to_string())?;
-
         Ok(WasmFr::from(*recovered_identity_secret))
     }
 }
 
 #[wasm_bindgen]
-pub struct WasmRLNWitnessInput(RLNWitnessInput);
+pub struct WasmRLNWitnessInput(RLNWitnessInputV3);
 
 #[wasm_bindgen]
 impl WasmRLNWitnessInput {
@@ -241,18 +246,18 @@ impl WasmRLNWitnessInput {
         let path_elements: Vec<Fr> = path_elements.inner();
         let identity_path_index: Vec<u8> = identity_path_index.to_vec();
 
-        let witness = RLNWitnessInput::new_single(
+        let witness = RLNWitnessInputSingle::new(
             IdSecret::from(&mut identity_secret_fr),
             user_message_limit.inner(),
-            message_id.inner(),
             path_elements,
             identity_path_index,
             x.inner(),
             external_nullifier.inner(),
+            message_id.inner(),
         )
         .map_err(|err| err.to_string())?;
 
-        Ok(WasmRLNWitnessInput(witness))
+        Ok(WasmRLNWitnessInput(witness.into()))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -274,24 +279,19 @@ impl WasmRLNWitnessInput {
         let message_ids: Vec<Fr> = message_ids.inner();
         let selector_used: Vec<bool> = selector_used.to_vec().iter().map(|&b| b != 0).collect();
 
-        let witness = RLNWitnessInput::new_multi(
+        let witness = RLNWitnessInputMulti::new(
             IdSecret::from(&mut identity_secret_fr),
             user_message_limit.inner(),
-            message_ids,
             path_elements,
             identity_path_index,
             x.inner(),
             external_nullifier.inner(),
+            message_ids,
             selector_used,
         )
         .map_err(|err| err.to_string())?;
 
-        Ok(WasmRLNWitnessInput(witness))
-    }
-
-    #[wasm_bindgen(js_name = getVersionByte)]
-    pub fn get_version_byte(&self) -> u8 {
-        self.0.version_byte()
+        Ok(WasmRLNWitnessInput(witness.into()))
     }
 
     #[wasm_bindgen(js_name = getIdentitySecret)]
@@ -305,13 +305,19 @@ impl WasmRLNWitnessInput {
     }
 
     #[wasm_bindgen(js_name = getMessageId)]
-    pub fn get_message_id(&self) -> WasmFr {
-        WasmFr::from(*self.0.message_id())
+    pub fn get_message_id(&self) -> Result<WasmFr, String> {
+        self.0
+            .message_id()
+            .map(|fr| WasmFr::from(*fr))
+            .map_err(|e| e.to_string())
     }
 
     #[wasm_bindgen(js_name = getMessageIds)]
-    pub fn get_message_ids(&self) -> VecWasmFr {
-        VecWasmFr::from(self.0.message_ids().to_vec())
+    pub fn get_message_ids(&self) -> Result<VecWasmFr, String> {
+        self.0
+            .message_ids()
+            .map(|s| VecWasmFr::from(s.to_vec()))
+            .map_err(|e| e.to_string())
     }
 
     #[wasm_bindgen(js_name = getPathElements)]
@@ -335,45 +341,51 @@ impl WasmRLNWitnessInput {
     }
 
     #[wasm_bindgen(js_name = getSelectorUsed)]
-    pub fn get_selector_used(&self) -> Uint8Array {
+    pub fn get_selector_used(&self) -> Result<Uint8Array, String> {
         let bytes: Vec<u8> = self
             .0
             .selector_used()
+            .map_err(|e| e.to_string())?
             .iter()
             .map(|&b| if b { 1u8 } else { 0u8 })
             .collect();
-        Uint8Array::from(&bytes[..])
+        Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = toBytesLE)]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
-        let bytes = rln_witness_to_bytes_le(&self.0).map_err(|err| err.to_string())?;
+        let mut bytes = Vec::new();
+        self.0
+            .serialize_compressed(&mut bytes)
+            .map_err(|err| err.to_string())?;
         Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = toBytesBE)]
     pub fn to_bytes_be(&self) -> Result<Uint8Array, String> {
-        let bytes = rln_witness_to_bytes_be(&self.0).map_err(|err| err.to_string())?;
+        let mut bytes = Vec::new();
+        CanonicalSerializeBE::serialize(&self.0, &mut bytes).map_err(|err| err.to_string())?;
         Ok(Uint8Array::from(&bytes[..]))
     }
 
     #[wasm_bindgen(js_name = fromBytesLE)]
     pub fn from_bytes_le(bytes: &Uint8Array) -> Result<WasmRLNWitnessInput, String> {
-        let bytes_vec = bytes.to_vec();
-        let (witness, _) = bytes_le_to_rln_witness(&bytes_vec).map_err(|err| err.to_string())?;
+        let witness = RLNWitnessInputV3::deserialize_compressed(&bytes.to_vec()[..])
+            .map_err(|err| err.to_string())?;
         Ok(WasmRLNWitnessInput(witness))
     }
 
     #[wasm_bindgen(js_name = fromBytesBE)]
     pub fn from_bytes_be(bytes: &Uint8Array) -> Result<WasmRLNWitnessInput, String> {
-        let bytes_vec = bytes.to_vec();
-        let (witness, _) = bytes_be_to_rln_witness(&bytes_vec).map_err(|err| err.to_string())?;
+        let witness =
+            <RLNWitnessInputV3 as CanonicalDeserializeBE>::deserialize(&bytes.to_vec()[..])
+                .map_err(|err| err.to_string())?;
         Ok(WasmRLNWitnessInput(witness))
     }
 
     #[wasm_bindgen(js_name = toBigIntJson)]
     pub fn to_bigint_json(&self) -> Result<Object, String> {
-        let bigint_json = rln_witness_to_bigint_json(&self.0).map_err(|err| err.to_string())?;
+        let bigint_json = self.0.to_bigint_json().map_err(|err| err.to_string())?;
 
         let serializer = serde_wasm_bindgen::Serializer::json_compatible();
         let js_value = bigint_json

--- a/rln-wasm/src/wasm_rln.rs
+++ b/rln-wasm/src/wasm_rln.rs
@@ -22,7 +22,7 @@ impl WasmRLN {
     }
 
     #[wasm_bindgen(js_name = generateProofFromCalculatedWitness)]
-    pub fn generate_proof_from_calculated_witness(
+    pub fn generate_proof(
         &self,
         calculated_witness_js_bigints: Vec<JsBigInt>,
     ) -> Result<WasmRLNProof, String> {
@@ -48,7 +48,7 @@ impl WasmRLN {
 
         let proof = self
             .0
-            .generate_proof_from_calculated_witness(&calculated_witness)
+            .generate_proof(&calculated_witness)
             .map_err(|err| err.to_string())?;
 
         Ok(WasmRLNProof(proof))

--- a/rln-wasm/src/wasm_rln.rs
+++ b/rln-wasm/src/wasm_rln.rs
@@ -10,15 +10,14 @@ use wasm_bindgen::prelude::*;
 use crate::wasm_utils::{VecWasmFr, WasmFr};
 
 #[wasm_bindgen]
-pub struct WasmRLN(RLNV3<Stateless, ArkGroth16BackendWithoutGraph>);
+pub struct WasmRLN(RLNV3<Stateless, ArkGroth16Backend>);
 
 #[wasm_bindgen]
 impl WasmRLN {
     #[wasm_bindgen(constructor)]
     pub fn new(zkey_data: &Uint8Array) -> Result<WasmRLN, String> {
-        let rln =
-            RLNV3::<Stateless, ArkGroth16BackendWithoutGraph>::new_with_params(zkey_data.to_vec())
-                .map_err(|err| err.to_string())?;
+        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_with_params(zkey_data.to_vec())
+            .map_err(|err| err.to_string())?;
         Ok(WasmRLN(rln))
     }
 

--- a/rln-wasm/src/wasm_rln.rs
+++ b/rln-wasm/src/wasm_rln.rs
@@ -10,23 +10,24 @@ use wasm_bindgen::prelude::*;
 use crate::wasm_utils::{VecWasmFr, WasmFr};
 
 #[wasm_bindgen]
-pub struct WasmRLN(RLNV3<Stateless, ArkGroth16Backend>);
+pub struct WasmRLN(RLNV3<Stateless, ArkGroth16BackendWithoutGraph>);
 
 #[wasm_bindgen]
 impl WasmRLN {
     #[wasm_bindgen(constructor)]
     pub fn new(zkey_data: &Uint8Array) -> Result<WasmRLN, String> {
-        let rln = RLNV3::new_with_params(zkey_data.to_vec()).map_err(|err| err.to_string())?;
+        let rln =
+            RLNV3::<Stateless, ArkGroth16BackendWithoutGraph>::new_with_params(zkey_data.to_vec())
+                .map_err(|err| err.to_string())?;
         Ok(WasmRLN(rln))
     }
 
-    #[wasm_bindgen(js_name = generateRLNProofWithWitness)]
-    pub fn generate_rln_proof_with_witness(
+    #[wasm_bindgen(js_name = generateProofFromCalculatedWitness)]
+    pub fn generate_proof_from_calculated_witness(
         &self,
-        calculated_witness: Vec<JsBigInt>,
-        witness: &WasmRLNWitnessInput,
+        calculated_witness_js_bigints: Vec<JsBigInt>,
     ) -> Result<WasmRLNProof, String> {
-        let calculated_witness_bigint: Vec<BigInt> = calculated_witness
+        let calculated_witness_bigints: Vec<BigInt> = calculated_witness_js_bigints
             .iter()
             .map(|js_bigint| {
                 js_bigint
@@ -42,18 +43,34 @@ impl WasmRLN {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let rln_proof = self
+        let calculated_witness =
+            calculated_witness_to_field_elements::<Curve>(calculated_witness_bigints)
+                .map_err(|err| err.to_string())?;
+
+        let proof = self
             .0
-            .generate_rln_proof_with_witness(calculated_witness_bigint, witness.0.clone())
+            .generate_proof_from_calculated_witness(&calculated_witness)
             .map_err(|err| err.to_string())?;
 
-        Ok(WasmRLNProof(rln_proof))
+        Ok(WasmRLNProof(proof))
+    }
+
+    #[wasm_bindgen(js_name = verify)]
+    pub fn verify(
+        &self,
+        proof: &WasmRLNProof,
+        values: &WasmRLNProofValues,
+    ) -> Result<bool, String> {
+        self.0
+            .verify(&proof.0, &values.0)
+            .map_err(|err| err.to_string())
     }
 
     #[wasm_bindgen(js_name = verifyWithRoots)]
     pub fn verify_with_roots(
         &self,
-        rln_proof: &WasmRLNProof,
+        proof: &WasmRLNProof,
+        values: &WasmRLNProofValues,
         roots: &VecWasmFr,
         x: &WasmFr,
     ) -> Result<bool, String> {
@@ -61,23 +78,17 @@ impl WasmRLN {
             .filter_map(|i| roots.get(i))
             .map(|root| *root)
             .collect();
-
         self.0
-            .verify_with_roots(&rln_proof.0.proof, &rln_proof.0.proof_values, x, &roots_fr)
+            .verify_with_roots(&proof.0, &values.0, x, &roots_fr)
             .map_err(|err| err.to_string())
     }
 }
 
 #[wasm_bindgen]
-pub struct WasmRLNProof(RLNProofV3);
+pub struct WasmRLNProof(Proof);
 
 #[wasm_bindgen]
 impl WasmRLNProof {
-    #[wasm_bindgen(js_name = getValues)]
-    pub fn get_values(&self) -> WasmRLNProofValues {
-        WasmRLNProofValues(self.0.proof_values.clone())
-    }
-
     #[wasm_bindgen(js_name = toBytesLE)]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
         let mut bytes = Vec::new();
@@ -87,25 +98,11 @@ impl WasmRLNProof {
         Ok(Uint8Array::from(&bytes[..]))
     }
 
-    #[wasm_bindgen(js_name = toBytesBE)]
-    pub fn to_bytes_be(&self) -> Result<Uint8Array, String> {
-        let mut bytes = Vec::new();
-        CanonicalSerializeBE::serialize(&self.0, &mut bytes).map_err(|err| err.to_string())?;
-        Ok(Uint8Array::from(&bytes[..]))
-    }
-
     #[wasm_bindgen(js_name = fromBytesLE)]
     pub fn from_bytes_le(bytes: &Uint8Array) -> Result<WasmRLNProof, String> {
-        let rln_proof = RLNProofV3::deserialize_compressed(&bytes.to_vec()[..])
-            .map_err(|err| err.to_string())?;
-        Ok(WasmRLNProof(rln_proof))
-    }
-
-    #[wasm_bindgen(js_name = fromBytesBE)]
-    pub fn from_bytes_be(bytes: &Uint8Array) -> Result<WasmRLNProof, String> {
-        let rln_proof = <RLNProofV3 as CanonicalDeserializeBE>::deserialize(&bytes.to_vec()[..])
-            .map_err(|err| err.to_string())?;
-        Ok(WasmRLNProof(rln_proof))
+        let proof =
+            Proof::deserialize_compressed(&bytes.to_vec()[..]).map_err(|err| err.to_string())?;
+        Ok(WasmRLNProof(proof))
     }
 }
 
@@ -381,6 +378,13 @@ impl WasmRLNWitnessInput {
             <RLNWitnessInputV3 as CanonicalDeserializeBE>::deserialize(&bytes.to_vec()[..])
                 .map_err(|err| err.to_string())?;
         Ok(WasmRLNWitnessInput(witness))
+    }
+
+    #[wasm_bindgen(js_name = toProofValues)]
+    pub fn to_proof_values(&self) -> Result<WasmRLNProofValues, String> {
+        RLNProofValuesV3::try_from(self.0.clone())
+            .map(WasmRLNProofValues)
+            .map_err(|e| e.to_string())
     }
 
     #[wasm_bindgen(js_name = toBigIntJson)]

--- a/rln-wasm/tests/browser.rs
+++ b/rln-wasm/tests/browser.rs
@@ -181,20 +181,17 @@ mod test {
             .map(|x| JsBigInt::new(&x.into()).unwrap())
             .collect();
 
-        // Benchmark proof generation from calculated witness
-        let start_generate_proof_from_calculated_witness = Date::now();
+        // Benchmark proof generation
+        let start_generate_proof = Date::now();
         for _ in 0..iterations {
             let _ = rln_instance
-                .generate_proof_from_calculated_witness(calculated_witness.clone())
+                .generate_proof(calculated_witness.clone())
                 .unwrap();
         }
-        let generate_proof_from_calculated_witness_result =
-            Date::now() - start_generate_proof_from_calculated_witness;
+        let generate_proof_result = Date::now() - start_generate_proof;
 
-        // Generate proof from calculated witness for other benchmarks
-        let proof: WasmRLNProof = rln_instance
-            .generate_proof_from_calculated_witness(calculated_witness)
-            .unwrap();
+        // Generate proof for other benchmarks
+        let proof: WasmRLNProof = rln_instance.generate_proof(calculated_witness).unwrap();
 
         let root = WasmFr::from(tree.root());
         let mut roots = VecWasmFr::new();
@@ -238,8 +235,8 @@ mod test {
             format_duration(calculate_witness_result)
         ));
         results.push_str(&format!(
-            "Proof generation from calculated witness: {}\n",
-            format_duration(generate_proof_from_calculated_witness_result)
+            "Proof generation: {}\n",
+            format_duration(generate_proof_result)
         ));
         results.push_str(&format!(
             "Proof verification with roots: {}\n",

--- a/rln-wasm/tests/browser.rs
+++ b/rln-wasm/tests/browser.rs
@@ -155,6 +155,8 @@ mod test {
         )
         .unwrap();
 
+        let proof_values = witness.to_proof_values().unwrap();
+
         let bigint_json = witness.to_bigint_json().unwrap();
 
         // Benchmark witness calculation
@@ -179,19 +181,19 @@ mod test {
             .map(|x| JsBigInt::new(&x.into()).unwrap())
             .collect();
 
-        // Benchmark proof generation with witness
-        let start_generate_rln_proof_with_witness = Date::now();
+        // Benchmark proof generation from calculated witness
+        let start_generate_proof_from_calculated_witness = Date::now();
         for _ in 0..iterations {
             let _ = rln_instance
-                .generate_rln_proof_with_witness(calculated_witness.clone(), &witness)
+                .generate_proof_from_calculated_witness(calculated_witness.clone())
                 .unwrap();
         }
-        let generate_rln_proof_with_witness_result =
-            Date::now() - start_generate_rln_proof_with_witness;
+        let generate_proof_from_calculated_witness_result =
+            Date::now() - start_generate_proof_from_calculated_witness;
 
-        // Generate proof with witness for other benchmarks
+        // Generate proof from calculated witness for other benchmarks
         let proof: WasmRLNProof = rln_instance
-            .generate_rln_proof_with_witness(calculated_witness, &witness)
+            .generate_proof_from_calculated_witness(calculated_witness)
             .unwrap();
 
         let root = WasmFr::from(tree.root());
@@ -201,12 +203,16 @@ mod test {
         // Benchmark proof verification with the root
         let start_verify_with_roots = Date::now();
         for _ in 0..iterations {
-            let _ = rln_instance.verify_with_roots(&proof, &roots, &x).unwrap();
+            let _ = rln_instance
+                .verify_with_roots(&proof, &proof_values, &roots, &x)
+                .unwrap();
         }
         let verify_with_roots_result = Date::now() - start_verify_with_roots;
 
         // Verify proof with the root for other benchmarks
-        let is_proof_valid = rln_instance.verify_with_roots(&proof, &roots, &x).unwrap();
+        let is_proof_valid = rln_instance
+            .verify_with_roots(&proof, &proof_values, &roots, &x)
+            .unwrap();
         assert!(is_proof_valid, "verification failed");
 
         // Format and display the benchmark results
@@ -232,8 +238,8 @@ mod test {
             format_duration(calculate_witness_result)
         ));
         results.push_str(&format!(
-            "Proof generation with witness: {}\n",
-            format_duration(generate_rln_proof_with_witness_result)
+            "Proof generation from calculated witness: {}\n",
+            format_duration(generate_proof_from_calculated_witness_result)
         ));
         results.push_str(&format!(
             "Proof verification with roots: {}\n",

--- a/rln-wasm/tests/node.rs
+++ b/rln-wasm/tests/node.rs
@@ -216,20 +216,17 @@ mod test {
             .map(|x| JsBigInt::new(&x.into()).unwrap())
             .collect();
 
-        // Benchmark proof generation from calculated witness
-        let start_generate_proof_from_calculated_witness = Date::now();
+        // Benchmark proof generation
+        let start_generate_proof = Date::now();
         for _ in 0..iterations {
             let _ = rln_instance
-                .generate_proof_from_calculated_witness(calculated_witness.clone())
+                .generate_proof(calculated_witness.clone())
                 .unwrap();
         }
-        let generate_proof_from_calculated_witness_result =
-            Date::now() - start_generate_proof_from_calculated_witness;
+        let generate_proof_result = Date::now() - start_generate_proof;
 
-        // Generate proof from calculated witness for other benchmarks
-        let proof: WasmRLNProof = rln_instance
-            .generate_proof_from_calculated_witness(calculated_witness)
-            .unwrap();
+        // Generate proof for other benchmarks
+        let proof: WasmRLNProof = rln_instance.generate_proof(calculated_witness).unwrap();
 
         let root = WasmFr::from(tree.root());
         let mut roots = VecWasmFr::new();
@@ -273,8 +270,8 @@ mod test {
             format_duration(calculate_witness_result)
         ));
         results.push_str(&format!(
-            "Proof generation from calculated witness: {}\n",
-            format_duration(generate_proof_from_calculated_witness_result)
+            "Proof generation: {}\n",
+            format_duration(generate_proof_result)
         ));
         results.push_str(&format!(
             "Proof verification with roots: {}\n",

--- a/rln-wasm/tests/node.rs
+++ b/rln-wasm/tests/node.rs
@@ -357,7 +357,7 @@ mod test {
         let mut extra_le_vec = witness_le_vec.clone();
         extra_le_vec.push(0);
         let extra_le = Uint8Array::from(&extra_le_vec[..]);
-        assert!(WasmRLNWitnessInput::from_bytes_le(&extra_le).is_err());
+        assert!(WasmRLNWitnessInput::from_bytes_le(&extra_le).is_ok());
 
         let witness_be = valid_witness.to_bytes_be().unwrap();
         let witness_be_vec = witness_be.to_vec();
@@ -367,18 +367,35 @@ mod test {
         let mut extra_be_vec = witness_be_vec.clone();
         extra_be_vec.push(0);
         let extra_be = Uint8Array::from(&extra_be_vec[..]);
-        assert!(WasmRLNWitnessInput::from_bytes_be(&extra_be).is_err());
+        assert!(WasmRLNWitnessInput::from_bytes_be(&extra_be).is_ok());
 
-        // Proof values bytes: insufficient length
-        let short_pv = [0u8; FR_BYTE_SIZE * 5 - 1];
-        let short_pv = Uint8Array::from(&short_pv[..]);
-        assert!(WasmRLNProofValues::from_bytes_le(&short_pv).is_err());
-        assert!(WasmRLNProofValues::from_bytes_be(&short_pv).is_err());
+        // Proof values bytes: truncated and extra data
+        let valid_pv =
+            WasmRLNProofValues::from_bytes_le(&Uint8Array::from(&[0u8; 1 + FR_BYTE_SIZE * 5][..]))
+                .unwrap();
+
+        let pv_le = valid_pv.to_bytes_le().unwrap();
+        let pv_le_vec = pv_le.to_vec();
+        let truncated_pv_le = Uint8Array::from(&pv_le_vec[..pv_le_vec.len() - 1]);
+        assert!(WasmRLNProofValues::from_bytes_le(&truncated_pv_le).is_err());
+        let mut extra_pv_le_vec = pv_le_vec.clone();
+        extra_pv_le_vec.push(0);
+        let extra_pv_le = Uint8Array::from(&extra_pv_le_vec[..]);
+        assert!(WasmRLNProofValues::from_bytes_le(&extra_pv_le).is_ok());
+
+        let pv_be = valid_pv.to_bytes_be().unwrap();
+        let pv_be_vec = pv_be.to_vec();
+        let truncated_pv_be = Uint8Array::from(&pv_be_vec[..pv_be_vec.len() - 1]);
+        assert!(WasmRLNProofValues::from_bytes_be(&truncated_pv_be).is_err());
+        let mut extra_pv_be_vec = pv_be_vec.clone();
+        extra_pv_be_vec.push(0);
+        let extra_pv_be = Uint8Array::from(&extra_pv_be_vec[..]);
+        assert!(WasmRLNProofValues::from_bytes_be(&extra_pv_be).is_ok());
 
         // Proof bytes: insufficient length (no proof values)
-        let short_proof = [0u8; COMPRESS_PROOF_SIZE];
-        let short_proof = Uint8Array::from(&short_proof[..]);
-        assert!(WasmRLNProof::from_bytes_le(&short_proof).is_err());
-        assert!(WasmRLNProof::from_bytes_be(&short_proof).is_err());
+        let proof = [0u8; COMPRESS_PROOF_SIZE];
+        let proof = Uint8Array::from(&proof[..]);
+        assert!(WasmRLNProof::from_bytes_le(&proof).is_err());
+        assert!(WasmRLNProof::from_bytes_be(&proof).is_err());
     }
 }

--- a/rln-wasm/tests/node.rs
+++ b/rln-wasm/tests/node.rs
@@ -190,6 +190,8 @@ mod test {
         )
         .unwrap();
 
+        let proof_values = witness.to_proof_values().unwrap();
+
         let bigint_json = witness.to_bigint_json().unwrap();
 
         // Benchmark witness calculation
@@ -214,19 +216,19 @@ mod test {
             .map(|x| JsBigInt::new(&x.into()).unwrap())
             .collect();
 
-        // Benchmark proof generation with witness
-        let start_generate_rln_proof_with_witness = Date::now();
+        // Benchmark proof generation from calculated witness
+        let start_generate_proof_from_calculated_witness = Date::now();
         for _ in 0..iterations {
             let _ = rln_instance
-                .generate_rln_proof_with_witness(calculated_witness.clone(), &witness)
+                .generate_proof_from_calculated_witness(calculated_witness.clone())
                 .unwrap();
         }
-        let generate_rln_proof_with_witness_result =
-            Date::now() - start_generate_rln_proof_with_witness;
+        let generate_proof_from_calculated_witness_result =
+            Date::now() - start_generate_proof_from_calculated_witness;
 
-        // Generate proof with witness for other benchmarks
+        // Generate proof from calculated witness for other benchmarks
         let proof: WasmRLNProof = rln_instance
-            .generate_rln_proof_with_witness(calculated_witness, &witness)
+            .generate_proof_from_calculated_witness(calculated_witness)
             .unwrap();
 
         let root = WasmFr::from(tree.root());
@@ -236,12 +238,16 @@ mod test {
         // Benchmark proof verification with the root
         let start_verify_with_roots = Date::now();
         for _ in 0..iterations {
-            let _ = rln_instance.verify_with_roots(&proof, &roots, &x).unwrap();
+            let _ = rln_instance
+                .verify_with_roots(&proof, &proof_values, &roots, &x)
+                .unwrap();
         }
         let verify_with_roots_result = Date::now() - start_verify_with_roots;
 
         // Verify proof with the root for other benchmarks
-        let is_proof_valid = rln_instance.verify_with_roots(&proof, &roots, &x).unwrap();
+        let is_proof_valid = rln_instance
+            .verify_with_roots(&proof, &proof_values, &roots, &x)
+            .unwrap();
         assert!(is_proof_valid, "verification failed");
 
         // Format and display the benchmark results
@@ -267,8 +273,8 @@ mod test {
             format_duration(calculate_witness_result)
         ));
         results.push_str(&format!(
-            "Proof generation with witness: {}\n",
-            format_duration(generate_rln_proof_with_witness_result)
+            "Proof generation from calculated witness: {}\n",
+            format_duration(generate_proof_from_calculated_witness_result)
         ));
         results.push_str(&format!(
             "Proof verification with roots: {}\n",
@@ -370,9 +376,7 @@ mod test {
         assert!(WasmRLNWitnessInput::from_bytes_be(&extra_be).is_ok());
 
         // Proof values bytes: truncated and extra data
-        let valid_pv =
-            WasmRLNProofValues::from_bytes_le(&Uint8Array::from(&[0u8; 1 + FR_BYTE_SIZE * 5][..]))
-                .unwrap();
+        let valid_pv = valid_witness.to_proof_values().unwrap();
 
         let pv_le = valid_pv.to_bytes_le().unwrap();
         let pv_le_vec = pv_le.to_vec();
@@ -392,10 +396,9 @@ mod test {
         let extra_pv_be = Uint8Array::from(&extra_pv_be_vec[..]);
         assert!(WasmRLNProofValues::from_bytes_be(&extra_pv_be).is_ok());
 
-        // Proof bytes: insufficient length (no proof values)
+        // Proof bytes: insufficient length
         let proof = [0u8; COMPRESS_PROOF_SIZE];
         let proof = Uint8Array::from(&proof[..]);
         assert!(WasmRLNProof::from_bytes_le(&proof).is_err());
-        assert!(WasmRLNProof::from_bytes_be(&proof).is_err());
     }
 }

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -31,14 +31,14 @@ ark-serialize = { version = "0.5.0", default-features = false }
 thiserror = "2.0.18"
 
 # Utilities
-rayon = { version = "1.11.0", optional = true }
+rayon = { version = "1.12.0", optional = true }
 byteorder = "1.5.0"
 cfg-if = "1.0.4"
 num-bigint = { version = "0.4.6", default-features = false, features = ["std"] }
 num-traits = "0.2.19"
-rand = "0.8.5"
+rand = "0.8.6"
 rand_chacha = "0.3.1"
-ruint = { version = "1.17.2", default-features = false, features = [
+ruint = { version = "1.18.0", default-features = false, features = [
     "rand",
     "serde",
     "ark-ff-05",

--- a/rln/src/bin/test_refactors.rs
+++ b/rln/src/bin/test_refactors.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), RLNError> {
     .into();
 
     let proof = rln.generate_proof_from_witness(&witness_single1)?;
-    let values_single1 = RLNProofValuesV3::try_from(witness_single1).map_err(RLNError::from)?;
+    let values_single1 = RLNProofValuesV3::try_from(witness_single1)?;
     assert!(rln.verify(&proof, &values_single1)?);
 
     let witness_single2: RLNWitnessInputV3 = RLNWitnessInputSingle::new(
@@ -32,7 +32,7 @@ fn main() -> Result<(), RLNError> {
         Fr::from(1),
     )?
     .into();
-    let values_single2 = RLNProofValuesV3::try_from(witness_single2).map_err(RLNError::from)?;
+    let values_single2 = RLNProofValuesV3::try_from(witness_single2)?;
     let recovered = values_single1.recover_secret(&values_single2)?;
     assert_eq!(recovered, identity_secret);
 
@@ -55,7 +55,7 @@ fn main() -> Result<(), RLNError> {
     )?
     .into();
     let proof = rln_multi.generate_proof_from_witness(&witness_multi)?;
-    let values_multi = RLNProofValuesV3::try_from(witness_multi).map_err(RLNError::from)?;
+    let values_multi = RLNProofValuesV3::try_from(witness_multi)?;
     assert!(rln_multi.verify(&proof, &values_multi)?);
 
     // Cross-mode slashing: Stateless Single × Stateless Multi
@@ -84,8 +84,8 @@ fn main() -> Result<(), RLNError> {
     )?
     .into();
 
-    let values_single = RLNProofValuesV3::try_from(witness_single).map_err(RLNError::from)?;
-    let values_multi = RLNProofValuesV3::try_from(witness_multi).map_err(RLNError::from)?;
+    let values_single = RLNProofValuesV3::try_from(witness_single)?;
+    let values_multi = RLNProofValuesV3::try_from(witness_multi)?;
 
     assert_eq!(
         values_single.recover_secret(&values_multi)?,
@@ -115,8 +115,7 @@ fn main() -> Result<(), RLNError> {
 
     let partial_witness = RLNPartialWitnessInputV3::from(&witness_for_partial);
     let partial_proof = rln_partial.generate_partial_proof(partial_witness)?;
-    let values_partial =
-        RLNProofValuesV3::try_from(witness_for_partial.clone()).map_err(RLNError::from)?;
+    let values_partial = RLNProofValuesV3::try_from(witness_for_partial.clone())?;
     let proof_from_partial = rln_partial.finish_proof(partial_proof, witness_for_partial)?;
     assert!(rln_partial.verify(&proof_from_partial, &values_partial)?);
 
@@ -141,8 +140,7 @@ fn main() -> Result<(), RLNError> {
 
     let partial_witness_multi = RLNPartialWitnessInputV3::from(&witness_for_partial_multi);
     let partial_proof_multi = rln_partial_multi.generate_partial_proof(partial_witness_multi)?;
-    let values_partial_multi =
-        RLNProofValuesV3::try_from(witness_for_partial_multi.clone()).map_err(RLNError::from)?;
+    let values_partial_multi = RLNProofValuesV3::try_from(witness_for_partial_multi.clone())?;
     let proof_from_partial_multi =
         rln_partial_multi.finish_proof(partial_proof_multi, witness_for_partial_multi)?;
     assert!(rln_partial_multi.verify(&proof_from_partial_multi, &values_partial_multi)?);

--- a/rln/src/bin/test_refactors.rs
+++ b/rln/src/bin/test_refactors.rs
@@ -2,8 +2,9 @@ use rln::prelude::*;
 
 fn main() -> Result<(), RLNError> {
     // Stateless Single
-    let backend = ArkGroth16Backend::new(zkey_single_v1().to_owned(), graph_single_v1().to_owned());
-    let rln = RLNV3::<Stateless, ArkGroth16Backend>::new(backend);
+    let backend =
+        ArkGroth16BackendWithGraph::new(zkey_single_v1().to_owned(), graph_single_v1().to_owned());
+    let rln = RLNV3::<Stateless, ArkGroth16BackendWithGraph>::new(backend);
 
     let (identity_secret, _) = keygen();
     let witness_single1 = RLNWitnessInputSingle::new(
@@ -17,10 +18,11 @@ fn main() -> Result<(), RLNError> {
     )?
     .into();
 
-    let (proof, values_single1) = rln.generate_proof(witness_single1)?;
+    let proof = rln.generate_proof_from_witness(&witness_single1)?;
+    let values_single1 = RLNProofValuesV3::try_from(witness_single1).map_err(RLNError::from)?;
     assert!(rln.verify(&proof, &values_single1)?);
 
-    let witness_single2 = RLNWitnessInputSingle::new(
+    let witness_single2: RLNWitnessInputV3 = RLNWitnessInputSingle::new(
         identity_secret.clone(),
         Fr::from(10),
         vec![Fr::from(0); DEFAULT_TREE_DEPTH],
@@ -30,14 +32,14 @@ fn main() -> Result<(), RLNError> {
         Fr::from(1),
     )?
     .into();
-    let (_, values_single2) = rln.generate_proof(witness_single2)?;
+    let values_single2 = RLNProofValuesV3::try_from(witness_single2).map_err(RLNError::from)?;
     let recovered = values_single1.recover_secret(&values_single2)?;
     assert_eq!(recovered, identity_secret);
 
     // Stateless Multi
     let multi_backend =
-        ArkGroth16Backend::new(zkey_multi_v1().to_owned(), graph_multi_v1().to_owned());
-    let rln_multi = RLNV3::<Stateless, ArkGroth16Backend>::new(multi_backend);
+        ArkGroth16BackendWithGraph::new(zkey_multi_v1().to_owned(), graph_multi_v1().to_owned());
+    let rln_multi = RLNV3::<Stateless, ArkGroth16BackendWithGraph>::new(multi_backend);
 
     let (identity_secret, _) = keygen();
 
@@ -52,20 +54,15 @@ fn main() -> Result<(), RLNError> {
         vec![true; DEFAULT_MAX_OUT],
     )?
     .into();
-    let (proof, values_multi) = rln_multi.generate_proof(witness_multi)?;
+    let proof = rln_multi.generate_proof_from_witness(&witness_multi)?;
+    let values_multi = RLNProofValuesV3::try_from(witness_multi).map_err(RLNError::from)?;
     assert!(rln_multi.verify(&proof, &values_multi)?);
 
     // Cross-mode slashing: Stateless Single × Stateless Multi
-    let backend_s =
-        ArkGroth16Backend::new(zkey_single_v1().to_owned(), graph_single_v1().to_owned());
-    let rln_single = RLNV3::<Stateless, ArkGroth16Backend>::new(backend_s);
-    let backend_m = ArkGroth16Backend::new(zkey_multi_v1().to_owned(), graph_multi_v1().to_owned());
-    let rln_multi2 = RLNV3::<Stateless, ArkGroth16Backend>::new(backend_m);
-
     let (identity_secret, _) = keygen();
     let external_nullifier = Fr::from(300);
 
-    let witness_single = RLNWitnessInputSingle::new(
+    let witness_single: RLNWitnessInputV3 = RLNWitnessInputSingle::new(
         identity_secret.clone(),
         Fr::from(10),
         vec![Fr::from(0); DEFAULT_TREE_DEPTH],
@@ -75,7 +72,7 @@ fn main() -> Result<(), RLNError> {
         Fr::from(1),
     )?
     .into();
-    let witness_multi = RLNWitnessInputMulti::new(
+    let witness_multi: RLNWitnessInputV3 = RLNWitnessInputMulti::new(
         identity_secret.clone(),
         Fr::from(10),
         vec![Fr::from(0); DEFAULT_TREE_DEPTH],
@@ -87,8 +84,8 @@ fn main() -> Result<(), RLNError> {
     )?
     .into();
 
-    let (_, values_single) = rln_single.generate_proof(witness_single)?;
-    let (_, values_multi) = rln_multi2.generate_proof(witness_multi)?;
+    let values_single = RLNProofValuesV3::try_from(witness_single).map_err(RLNError::from)?;
+    let values_multi = RLNProofValuesV3::try_from(witness_multi).map_err(RLNError::from)?;
 
     assert_eq!(
         values_single.recover_secret(&values_multi)?,
@@ -101,11 +98,11 @@ fn main() -> Result<(), RLNError> {
 
     // Partial Proof — Single
     let backend_partial =
-        ArkGroth16Backend::new(zkey_single_v1().to_owned(), graph_single_v1().to_owned());
-    let rln_partial = RLNV3::<Stateless, ArkGroth16Backend>::new(backend_partial);
+        ArkGroth16BackendWithGraph::new(zkey_single_v1().to_owned(), graph_single_v1().to_owned());
+    let rln_partial = RLNV3::<Stateless, ArkGroth16BackendWithGraph>::new(backend_partial);
 
     let (identity_secret, _) = keygen();
-    let witness_for_partial = RLNWitnessInputSingle::new(
+    let witness_for_partial: RLNWitnessInputV3 = RLNWitnessInputSingle::new(
         identity_secret.clone(),
         Fr::from(10),
         vec![Fr::from(0); DEFAULT_TREE_DEPTH],
@@ -125,11 +122,12 @@ fn main() -> Result<(), RLNError> {
 
     // Partial Proof — Multi
     let backend_partial_multi =
-        ArkGroth16Backend::new(zkey_multi_v1().to_owned(), graph_multi_v1().to_owned());
-    let rln_partial_multi = RLNV3::<Stateless, ArkGroth16Backend>::new(backend_partial_multi);
+        ArkGroth16BackendWithGraph::new(zkey_multi_v1().to_owned(), graph_multi_v1().to_owned());
+    let rln_partial_multi =
+        RLNV3::<Stateless, ArkGroth16BackendWithGraph>::new(backend_partial_multi);
 
     let (identity_secret, _) = keygen();
-    let witness_for_partial_multi = RLNWitnessInputMulti::new(
+    let witness_for_partial_multi: RLNWitnessInputV3 = RLNWitnessInputMulti::new(
         identity_secret.clone(),
         Fr::from(10),
         vec![Fr::from(0); DEFAULT_TREE_DEPTH],

--- a/rln/src/circuit/iden3calc.rs
+++ b/rln/src/circuit/iden3calc.rs
@@ -1,8 +1,6 @@
 // This crate is based on the code by iden3. Its preimage can be found here:
 // https://github.com/iden3/circom-witnesscalc/blob/5cb365b6e4d9052ecc69d4567fcf5bc061c20e94/src/lib.rs
 
-#![cfg(not(target_arch = "wasm32"))]
-
 pub(crate) mod graph;
 mod proto;
 pub(crate) mod storage;

--- a/rln/src/circuit/mod.rs
+++ b/rln/src/circuit/mod.rs
@@ -18,14 +18,11 @@ use ark_groth16::{
 use ark_relations::r1cs::ConstraintMatrices;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
-#[cfg(not(target_arch = "wasm32"))]
-use self::error::GraphReadError;
-use self::error::ZKeyReadError;
-#[cfg(not(target_arch = "wasm32"))]
-use crate::circuit::iden3calc::{
-    graph::Node, storage::deserialize_witnesscalc_graph, InputSignalsInfo,
+use self::error::{GraphReadError, ZKeyReadError};
+use crate::{
+    circuit::iden3calc::{graph::Node, storage::deserialize_witnesscalc_graph, InputSignalsInfo},
+    partial_proof::PartialProof as ArkPartialProof,
 };
-use crate::partial_proof::PartialProof as ArkPartialProof;
 
 #[cfg(not(target_arch = "wasm32"))]
 const GRAPH_BYTES_SINGLE_V1: &[u8] = include_bytes!("../../resources/tree_depth_20/graph.bin");
@@ -120,7 +117,6 @@ pub type VerifyingKey = ArkVerifyingKey<Curve>;
 ///
 /// Contains the deserialized computation graph used for witness calculation.
 /// Parsing this once and reusing it avoids repeated deserialization overhead.
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct Graph {
     pub(crate) nodes: Vec<Node>,
@@ -142,7 +138,6 @@ pub fn zkey_from_raw(zkey_data: &[u8]) -> Result<Zkey, ZKeyReadError> {
 }
 
 /// Parses the witness calculator graph from raw bytes
-#[cfg(not(target_arch = "wasm32"))]
 pub fn graph_from_raw(
     graph_data: &[u8],
     expected_tree_depth: Option<usize>,
@@ -277,21 +272,23 @@ fn read_arkzkey_from_bytes_uncompressed(arkzkey_data: &[u8]) -> Result<Zkey, ZKe
 }
 
 #[derive(Clone)]
-pub struct ArkGroth16Backend {
+pub struct ArkGroth16BackendWithGraph {
     pub(crate) zkey: Zkey,
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) graph: Graph,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-impl ArkGroth16Backend {
+impl ArkGroth16BackendWithGraph {
     pub fn new(zkey: Zkey, graph: Graph) -> Self {
         Self { zkey, graph }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-impl ArkGroth16Backend {
+#[derive(Clone)]
+pub struct ArkGroth16BackendWithoutGraph {
+    pub(crate) zkey: Zkey,
+}
+
+impl ArkGroth16BackendWithoutGraph {
     pub fn new(zkey: Zkey) -> Self {
         Self { zkey }
     }

--- a/rln/src/circuit/mod.rs
+++ b/rln/src/circuit/mod.rs
@@ -276,10 +276,10 @@ fn read_arkzkey_from_bytes_uncompressed(arkzkey_data: &[u8]) -> Result<Zkey, ZKe
     Ok(zkey)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct ArkGroth16Backend {
     pub(crate) zkey: Zkey,
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) graph: Graph,
 }
 
@@ -287,6 +287,13 @@ pub struct ArkGroth16Backend {
 impl ArkGroth16Backend {
     pub fn new(zkey: Zkey, graph: Graph) -> Self {
         Self { zkey, graph }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl ArkGroth16Backend {
+    pub fn new(zkey: Zkey) -> Self {
+        Self { zkey }
     }
 }
 

--- a/rln/src/circuit/mod.rs
+++ b/rln/src/circuit/mod.rs
@@ -117,7 +117,7 @@ pub type VerifyingKey = ArkVerifyingKey<Curve>;
 ///
 /// Contains the deserialized computation graph used for witness calculation.
 /// Parsing this once and reusing it avoids repeated deserialization overhead.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Graph {
     pub(crate) nodes: Vec<Node>,
     pub(crate) signals: Vec<usize>,
@@ -271,7 +271,7 @@ fn read_arkzkey_from_bytes_uncompressed(arkzkey_data: &[u8]) -> Result<Zkey, ZKe
     Ok(zkey)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ArkGroth16BackendWithGraph {
     pub(crate) zkey: Zkey,
     pub(crate) graph: Graph,
@@ -283,7 +283,7 @@ impl ArkGroth16BackendWithGraph {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ArkGroth16Backend {
     pub(crate) zkey: Zkey,
 }

--- a/rln/src/circuit/mod.rs
+++ b/rln/src/circuit/mod.rs
@@ -284,11 +284,11 @@ impl ArkGroth16BackendWithGraph {
 }
 
 #[derive(Clone)]
-pub struct ArkGroth16BackendWithoutGraph {
+pub struct ArkGroth16Backend {
     pub(crate) zkey: Zkey,
 }
 
-impl ArkGroth16BackendWithoutGraph {
+impl ArkGroth16Backend {
     pub fn new(zkey: Zkey) -> Self {
         Self { zkey }
     }

--- a/rln/src/error.rs
+++ b/rln/src/error.rs
@@ -89,6 +89,11 @@ pub enum ProtocolError {
         witness_mode: MessageMode,
         graph_mode: MessageMode,
     },
+    #[error("field `{field}` does not exist on the `{variant}` variant")]
+    FieldNotInVariant {
+        field: &'static str,
+        variant: &'static str,
+    },
 }
 
 /// Errors that can occur during proof verification

--- a/rln/src/error.rs
+++ b/rln/src/error.rs
@@ -89,7 +89,7 @@ pub enum ProtocolError {
         witness_mode: MessageMode,
         graph_mode: MessageMode,
     },
-    #[error("field `{field}` does not exist on the `{variant}` variant")]
+    #[error("Field `{field}` does not exist on the `{variant}` variant")]
     FieldNotInVariant {
         field: &'static str,
         variant: &'static str,

--- a/rln/src/prelude.rs
+++ b/rln/src/prelude.rs
@@ -17,9 +17,9 @@ pub use crate::protocol::{
 };
 pub use crate::{
     circuit::{
-        graph_from_raw, zkey_from_raw, ArkGroth16BackendWithGraph, ArkGroth16BackendWithoutGraph,
-        Curve, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective, Graph, PartialProof,
-        Proof, VerifyingKey, Zkey, COMPRESS_PROOF_SIZE, DEFAULT_MAX_OUT, DEFAULT_TREE_DEPTH,
+        graph_from_raw, zkey_from_raw, ArkGroth16Backend, ArkGroth16BackendWithGraph, Curve, Fq,
+        Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective, Graph, PartialProof, Proof,
+        VerifyingKey, Zkey, COMPRESS_PROOF_SIZE, DEFAULT_MAX_OUT, DEFAULT_TREE_DEPTH,
     },
     error::{ProtocolError, RLNError, RecoverSecretError, UtilsError, VerifyError},
     hashers::{

--- a/rln/src/prelude.rs
+++ b/rln/src/prelude.rs
@@ -3,8 +3,6 @@
 pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use crate::circuit::{graph_from_raw, Graph};
-#[cfg(not(target_arch = "wasm32"))]
 pub use crate::circuit::{graph_multi_v1, graph_single_v1, zkey_multi_v1, zkey_single_v1};
 #[cfg(feature = "pmtree-ft")]
 pub use crate::pm_tree_adapter::{FrOf, PmTree, PmTreeProof, PmtreeConfig, PmtreeConfigBuilder};
@@ -19,9 +17,9 @@ pub use crate::protocol::{
 };
 pub use crate::{
     circuit::{
-        zkey_from_raw, ArkGroth16Backend, Curve, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine,
-        G2Projective, PartialProof, Proof, VerifyingKey, Zkey, COMPRESS_PROOF_SIZE,
-        DEFAULT_MAX_OUT, DEFAULT_TREE_DEPTH,
+        graph_from_raw, zkey_from_raw, ArkGroth16BackendWithGraph, ArkGroth16BackendWithoutGraph,
+        Curve, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective, Graph, PartialProof,
+        Proof, VerifyingKey, Zkey, COMPRESS_PROOF_SIZE, DEFAULT_MAX_OUT, DEFAULT_TREE_DEPTH,
     },
     error::{ProtocolError, RLNError, RecoverSecretError, UtilsError, VerifyError},
     hashers::{
@@ -32,18 +30,19 @@ pub use crate::{
         bytes_be_to_rln_partial_proof, bytes_be_to_rln_partial_witness, bytes_be_to_rln_proof,
         bytes_be_to_rln_proof_values, bytes_be_to_rln_witness, bytes_le_to_rln_partial_proof,
         bytes_le_to_rln_partial_witness, bytes_le_to_rln_proof, bytes_le_to_rln_proof_values,
-        bytes_le_to_rln_witness, compute_id_secret, extended_keygen, extended_seeded_keygen,
-        generate_zk_proof_with_witness, keygen, proof_values_from_witness, recover_id_secret,
-        rln_partial_proof_to_bytes_be, rln_partial_proof_to_bytes_le,
-        rln_partial_witness_to_bytes_be, rln_partial_witness_to_bytes_le, rln_proof_to_bytes_be,
-        rln_proof_to_bytes_le, rln_proof_values_to_bytes_be, rln_proof_values_to_bytes_le,
-        rln_witness_to_bigint_json, rln_witness_to_bytes_be, rln_witness_to_bytes_le,
-        seeded_keygen, CanonicalDeserializeBE, CanonicalSerializeBE, MessageMode,
-        RLNPartialWitnessInput, RLNPartialWitnessInputV3, RLNPartialZkProof, RLNProof, RLNProofV3,
-        RLNProofValues, RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3,
-        RLNWitnessInput, RLNWitnessInputMulti, RLNWitnessInputSingle, RLNWitnessInputV3,
-        RLNZkProof, RecoverSecret, Stateful, Stateless, ENUM_TAG_MULTI, ENUM_TAG_SINGLE,
-        ENUM_TAG_SIZE, FR_BYTE_SIZE, FR_LIMB_BYTE_SIZE, VEC_LEN_BYTE_SIZE,
+        bytes_le_to_rln_witness, calculated_witness_to_field_elements, compute_id_secret,
+        extended_keygen, extended_seeded_keygen, generate_zk_proof_with_witness, keygen,
+        proof_values_from_witness, recover_id_secret, rln_partial_proof_to_bytes_be,
+        rln_partial_proof_to_bytes_le, rln_partial_witness_to_bytes_be,
+        rln_partial_witness_to_bytes_le, rln_proof_to_bytes_be, rln_proof_to_bytes_le,
+        rln_proof_values_to_bytes_be, rln_proof_values_to_bytes_le, rln_witness_to_bigint_json,
+        rln_witness_to_bytes_be, rln_witness_to_bytes_le, seeded_keygen, CanonicalDeserializeBE,
+        CanonicalSerializeBE, MessageMode, RLNPartialWitnessInput, RLNPartialWitnessInputV3,
+        RLNPartialZkProof, RLNProof, RLNProofValues, RLNProofValuesMulti, RLNProofValuesSingle,
+        RLNProofValuesV3, RLNWitnessInput, RLNWitnessInputMulti, RLNWitnessInputSingle,
+        RLNWitnessInputV3, RLNZkProof, RLNZkProofWithGraph, RecoverSecret, Stateful, Stateless,
+        ENUM_TAG_MULTI, ENUM_TAG_SINGLE, ENUM_TAG_SIZE, FR_BYTE_SIZE, FR_LIMB_BYTE_SIZE,
+        VEC_LEN_BYTE_SIZE,
     },
     public::{RLN, RLNV3},
     utils::{

--- a/rln/src/prelude.rs
+++ b/rln/src/prelude.rs
@@ -1,5 +1,7 @@
 // This module re-exports the most commonly used types and functions from the RLN library
 
+pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::circuit::{graph_multi_v1, graph_single_v1, zkey_multi_v1, zkey_single_v1};
 #[cfg(feature = "pmtree-ft")]

--- a/rln/src/prelude.rs
+++ b/rln/src/prelude.rs
@@ -3,6 +3,8 @@
 pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 #[cfg(not(target_arch = "wasm32"))]
+pub use crate::circuit::{graph_from_raw, Graph};
+#[cfg(not(target_arch = "wasm32"))]
 pub use crate::circuit::{graph_multi_v1, graph_single_v1, zkey_multi_v1, zkey_single_v1};
 #[cfg(feature = "pmtree-ft")]
 pub use crate::pm_tree_adapter::{FrOf, PmTree, PmTreeProof, PmtreeConfig, PmtreeConfigBuilder};
@@ -11,18 +13,15 @@ pub use crate::poseidon_tree::{MerkleProof, PoseidonTree};
 #[cfg(not(feature = "stateless"))]
 pub use crate::protocol::compute_tree_root;
 #[cfg(not(target_arch = "wasm32"))]
-pub use crate::{
-    circuit::{graph_from_raw, ArkGroth16Backend, Graph},
-    protocol::{
-        finish_zk_proof, finish_zk_proof_with_rs, generate_partial_zk_proof, generate_zk_proof,
-        generate_zk_proof_with_rs, verify_zk_proof,
-    },
+pub use crate::protocol::{
+    finish_zk_proof, finish_zk_proof_with_rs, generate_partial_zk_proof, generate_zk_proof,
+    generate_zk_proof_with_rs, verify_zk_proof,
 };
 pub use crate::{
     circuit::{
-        zkey_from_raw, Curve, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective,
-        PartialProof, Proof, VerifyingKey, Zkey, COMPRESS_PROOF_SIZE, DEFAULT_MAX_OUT,
-        DEFAULT_TREE_DEPTH,
+        zkey_from_raw, ArkGroth16Backend, Curve, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine,
+        G2Projective, PartialProof, Proof, VerifyingKey, Zkey, COMPRESS_PROOF_SIZE,
+        DEFAULT_MAX_OUT, DEFAULT_TREE_DEPTH,
     },
     error::{ProtocolError, RLNError, RecoverSecretError, UtilsError, VerifyError},
     hashers::{
@@ -40,7 +39,7 @@ pub use crate::{
         rln_proof_to_bytes_le, rln_proof_values_to_bytes_be, rln_proof_values_to_bytes_le,
         rln_witness_to_bigint_json, rln_witness_to_bytes_be, rln_witness_to_bytes_le,
         seeded_keygen, CanonicalDeserializeBE, CanonicalSerializeBE, MessageMode,
-        RLNPartialWitnessInput, RLNPartialWitnessInputV3, RLNPartialZkProof, RLNProof,
+        RLNPartialWitnessInput, RLNPartialWitnessInputV3, RLNPartialZkProof, RLNProof, RLNProofV3,
         RLNProofValues, RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3,
         RLNWitnessInput, RLNWitnessInputMulti, RLNWitnessInputSingle, RLNWitnessInputV3,
         RLNZkProof, RecoverSecret, Stateful, Stateless, ENUM_TAG_MULTI, ENUM_TAG_SINGLE,

--- a/rln/src/protocol/mod.rs
+++ b/rln/src/protocol/mod.rs
@@ -15,8 +15,8 @@ pub use proof::{
     bytes_le_to_rln_partial_proof, bytes_le_to_rln_proof, bytes_le_to_rln_proof_values,
     generate_zk_proof_with_witness, rln_partial_proof_to_bytes_be, rln_partial_proof_to_bytes_le,
     rln_proof_to_bytes_be, rln_proof_to_bytes_le, rln_proof_values_to_bytes_be,
-    rln_proof_values_to_bytes_le, verify_zk_proof, RLNProof, RLNProofValues, RLNProofValuesMulti,
-    RLNProofValuesSingle, RLNProofValuesV3,
+    rln_proof_values_to_bytes_le, verify_zk_proof, RLNProof, RLNProofV3, RLNProofValues,
+    RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use proof::{

--- a/rln/src/protocol/mod.rs
+++ b/rln/src/protocol/mod.rs
@@ -13,10 +13,11 @@ pub use mode::{MessageMode, Stateful, Stateless};
 pub use proof::{
     bytes_be_to_rln_partial_proof, bytes_be_to_rln_proof, bytes_be_to_rln_proof_values,
     bytes_le_to_rln_partial_proof, bytes_le_to_rln_proof, bytes_le_to_rln_proof_values,
-    generate_zk_proof_with_witness, rln_partial_proof_to_bytes_be, rln_partial_proof_to_bytes_le,
-    rln_proof_to_bytes_be, rln_proof_to_bytes_le, rln_proof_values_to_bytes_be,
-    rln_proof_values_to_bytes_le, verify_zk_proof, RLNProof, RLNProofV3, RLNProofValues,
-    RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3,
+    calculated_witness_to_field_elements, generate_zk_proof_with_witness,
+    rln_partial_proof_to_bytes_be, rln_partial_proof_to_bytes_le, rln_proof_to_bytes_be,
+    rln_proof_to_bytes_le, rln_proof_values_to_bytes_be, rln_proof_values_to_bytes_le,
+    verify_zk_proof, RLNProof, RLNProofValues, RLNProofValuesMulti, RLNProofValuesSingle,
+    RLNProofValuesV3,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use proof::{
@@ -36,4 +37,4 @@ pub use witness::{
     RLNPartialWitnessInputV3, RLNWitnessInput, RLNWitnessInputMulti, RLNWitnessInputSingle,
     RLNWitnessInputV3,
 };
-pub use zk::{RLNPartialZkProof, RLNZkProof, RecoverSecret};
+pub use zk::{RLNPartialZkProof, RLNZkProof, RLNZkProofWithGraph, RecoverSecret};

--- a/rln/src/protocol/mode.rs
+++ b/rln/src/protocol/mode.rs
@@ -1,4 +1,4 @@
-// TODO(cleanup): dissolve into witness.rs / proof.rs / state.rs — wire-format docs and impls belong with their types.
+// TODO: dissolve into witness.rs / proof.rs — wire-format docs and impls belong with their types.
 
 use std::fmt;
 

--- a/rln/src/protocol/mode.rs
+++ b/rln/src/protocol/mode.rs
@@ -1,3 +1,5 @@
+// TODO(cleanup): dissolve into witness.rs / proof.rs / state.rs — wire-format docs and impls belong with their types.
+
 use std::fmt;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/rln/src/protocol/proof.rs
+++ b/rln/src/protocol/proof.rs
@@ -595,7 +595,7 @@ pub fn bytes_be_to_rln_partial_proof(bytes: &[u8]) -> Result<(PartialProof, usiz
 // zkSNARK proof generation and verification
 
 /// Converts calculated witness (BigInt) to field elements.
-fn calculated_witness_to_field_elements<E: ark_ec::pairing::Pairing>(
+pub(crate) fn calculated_witness_to_field_elements<E: ark_ec::pairing::Pairing>(
     calculated_witness: Vec<BigInt>,
 ) -> Result<Vec<E::ScalarField>, ProtocolError> {
     let modulus = <E::ScalarField as PrimeField>::MODULUS;

--- a/rln/src/protocol/proof.rs
+++ b/rln/src/protocol/proof.rs
@@ -142,52 +142,47 @@ impl RLNProofValues {
         &self.external_nullifier
     }
 
-    /// Returns the `y` value (only valid for SingleV1).
     pub fn y(&self) -> &Fr {
         match &self.outputs {
             RLNOutputs::SingleV1 { y, .. } => y,
             RLNOutputs::MultiV1 { .. } => {
-                panic!("y() is not available for MultiV1 proof values; use ys()")
+                todo!("y() is not available for MultiV1 proof values; use ys()")
             }
         }
     }
 
-    /// Returns the nullifier (only valid for SingleV1).
     pub fn nullifier(&self) -> &Fr {
         match &self.outputs {
             RLNOutputs::SingleV1 { nullifier, .. } => nullifier,
             RLNOutputs::MultiV1 { .. } => {
-                panic!("nullifier() is not available for MultiV1 proof values; use nullifiers()")
+                todo!("nullifier() is not available for MultiV1 proof values; use nullifiers()")
             }
         }
     }
 
-    /// Returns the selector flags (only valid for MultiV1).
     pub fn selector_used(&self) -> &[bool] {
         match &self.outputs {
             RLNOutputs::MultiV1 { selector_used, .. } => selector_used,
             RLNOutputs::SingleV1 { .. } => {
-                panic!("selector_used() is not available for SingleV1 proof values")
+                todo!("selector_used() is not available for SingleV1 proof values")
             }
         }
     }
 
-    /// Returns the per-message-id `y` values (only valid for MultiV1).
     pub fn ys(&self) -> &[Fr] {
         match &self.outputs {
             RLNOutputs::MultiV1 { ys, .. } => ys,
             RLNOutputs::SingleV1 { .. } => {
-                panic!("ys() is not available for SingleV1 proof values; use y()")
+                todo!("ys() is not available for SingleV1 proof values; use y()")
             }
         }
     }
 
-    /// Returns the per-message-id nullifiers (only valid for MultiV1).
     pub fn nullifiers(&self) -> &[Fr] {
         match &self.outputs {
             RLNOutputs::MultiV1 { nullifiers, .. } => nullifiers,
             RLNOutputs::SingleV1 { .. } => {
-                panic!("nullifiers() is not available for SingleV1 proof values; use nullifier()")
+                todo!("nullifiers() is not available for SingleV1 proof values; use nullifier()")
             }
         }
     }
@@ -899,13 +894,40 @@ pub fn verify_zk_proof(
 }
 
 #[derive(Debug, PartialEq, Clone)]
+pub struct RLNProofV3 {
+    pub proof: Proof,
+    pub proof_values: RLNProofValuesV3,
+}
+
+#[derive(Debug, PartialEq, Clone)]
 pub enum RLNProofValuesV3 {
     Single(RLNProofValuesSingle),
     Multi(RLNProofValuesMulti),
 }
 
 impl RLNProofValuesV3 {
-    /// Returns the Merkle tree root from either variant.
+    /// Single only — `Err` if called on Multi.
+    pub fn y(&self) -> Result<Fr, ProtocolError> {
+        match self {
+            RLNProofValuesV3::Single(v) => Ok(v.y),
+            RLNProofValuesV3::Multi(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "y",
+                variant: "Multi",
+            }),
+        }
+    }
+
+    /// Multi only — `Err` if called on Single.
+    pub fn ys(&self) -> Result<&[Fr], ProtocolError> {
+        match self {
+            RLNProofValuesV3::Multi(v) => Ok(&v.ys),
+            RLNProofValuesV3::Single(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "ys",
+                variant: "Single",
+            }),
+        }
+    }
+
     pub fn root(&self) -> Fr {
         match self {
             RLNProofValuesV3::Single(v) => v.root,
@@ -913,11 +935,50 @@ impl RLNProofValuesV3 {
         }
     }
 
-    /// Returns the signal hash from either variant.
+    /// Single only — `Err` if called on Multi.
+    pub fn nullifier(&self) -> Result<Fr, ProtocolError> {
+        match self {
+            RLNProofValuesV3::Single(v) => Ok(v.nullifier),
+            RLNProofValuesV3::Multi(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "nullifier",
+                variant: "Multi",
+            }),
+        }
+    }
+
+    /// Multi only — `Err` if called on Single.
+    pub fn nullifiers(&self) -> Result<&[Fr], ProtocolError> {
+        match self {
+            RLNProofValuesV3::Multi(v) => Ok(&v.nullifiers),
+            RLNProofValuesV3::Single(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "nullifiers",
+                variant: "Single",
+            }),
+        }
+    }
+
     pub fn x(&self) -> Fr {
         match self {
             RLNProofValuesV3::Single(v) => v.x,
             RLNProofValuesV3::Multi(v) => v.x,
+        }
+    }
+
+    pub fn external_nullifier(&self) -> Fr {
+        match self {
+            RLNProofValuesV3::Single(v) => v.external_nullifier,
+            RLNProofValuesV3::Multi(v) => v.external_nullifier,
+        }
+    }
+
+    /// Multi only — `Err` if called on Single.
+    pub fn selector_used(&self) -> Result<&[bool], ProtocolError> {
+        match self {
+            RLNProofValuesV3::Multi(v) => Ok(&v.selector_used),
+            RLNProofValuesV3::Single(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "selector_used",
+                variant: "Single",
+            }),
         }
     }
 }

--- a/rln/src/protocol/proof.rs
+++ b/rln/src/protocol/proof.rs
@@ -590,7 +590,7 @@ pub fn bytes_be_to_rln_partial_proof(bytes: &[u8]) -> Result<(PartialProof, usiz
 // zkSNARK proof generation and verification
 
 /// Converts calculated witness (BigInt) to field elements.
-pub(crate) fn calculated_witness_to_field_elements<E: ark_ec::pairing::Pairing>(
+pub fn calculated_witness_to_field_elements<E: ark_ec::pairing::Pairing>(
     calculated_witness: Vec<BigInt>,
 ) -> Result<Vec<E::ScalarField>, ProtocolError> {
     let modulus = <E::ScalarField as PrimeField>::MODULUS;
@@ -891,12 +891,6 @@ pub fn verify_zk_proof(
     let verified = Groth16::<_, CircomReduction>::verify_proof(&pvk, proof, &inputs)?;
 
     Ok(verified)
-}
-
-#[derive(Debug, PartialEq, Clone, CanonicalSerialize, CanonicalDeserialize)]
-pub struct RLNProofV3 {
-    pub proof: Proof,
-    pub proof_values: RLNProofValuesV3,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/rln/src/protocol/proof.rs
+++ b/rln/src/protocol/proof.rs
@@ -893,7 +893,7 @@ pub fn verify_zk_proof(
     Ok(verified)
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RLNProofV3 {
     pub proof: Proof,
     pub proof_values: RLNProofValuesV3,

--- a/rln/src/protocol/serialize.rs
+++ b/rln/src/protocol/serialize.rs
@@ -13,13 +13,13 @@ use ark_serialize::{
 use zeroize::Zeroizing;
 
 use super::{
-    proof::{RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3},
+    proof::{RLNProofV3, RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3},
     witness::{
         RLNPartialWitnessInputV3, RLNWitnessInputMulti, RLNWitnessInputSingle, RLNWitnessInputV3,
     },
 };
 use crate::{
-    circuit::Fr,
+    circuit::{Fr, Proof, COMPRESS_PROOF_SIZE},
     error::{ProtocolError, UtilsError},
     utils::{normalize_usize_be, IdSecret},
 };
@@ -473,6 +473,34 @@ impl CanonicalDeserializeBE for RLNPartialWitnessInputV3 {
             user_message_limit,
             path_elements,
             identity_path_index,
+        })
+    }
+}
+
+impl CanonicalSerializeBE for RLNProofV3 {
+    type Error = ProtocolError;
+
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), Self::Error> {
+        self.proof
+            .serialize_compressed(&mut writer)
+            .map_err(ProtocolError::from)?;
+        CanonicalSerializeBE::serialize(&self.proof_values, &mut writer)
+    }
+
+    fn serialized_size(&self) -> usize {
+        COMPRESS_PROOF_SIZE + CanonicalSerializeBE::serialized_size(&self.proof_values)
+    }
+}
+
+impl CanonicalDeserializeBE for RLNProofV3 {
+    type Error = ProtocolError;
+
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, Self::Error> {
+        let proof = Proof::deserialize_compressed(&mut reader).map_err(ProtocolError::from)?;
+        let proof_values = <RLNProofValuesV3 as CanonicalDeserializeBE>::deserialize(&mut reader)?;
+        Ok(RLNProofV3 {
+            proof,
+            proof_values,
         })
     }
 }

--- a/rln/src/protocol/serialize.rs
+++ b/rln/src/protocol/serialize.rs
@@ -13,13 +13,13 @@ use ark_serialize::{
 use zeroize::Zeroizing;
 
 use super::{
-    proof::{RLNProofV3, RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3},
+    proof::{RLNProofValuesMulti, RLNProofValuesSingle, RLNProofValuesV3},
     witness::{
         RLNPartialWitnessInputV3, RLNWitnessInputMulti, RLNWitnessInputSingle, RLNWitnessInputV3,
     },
 };
 use crate::{
-    circuit::{Fr, Proof, COMPRESS_PROOF_SIZE},
+    circuit::Fr,
     error::{ProtocolError, UtilsError},
     utils::{normalize_usize_be, IdSecret},
 };
@@ -473,34 +473,6 @@ impl CanonicalDeserializeBE for RLNPartialWitnessInputV3 {
             user_message_limit,
             path_elements,
             identity_path_index,
-        })
-    }
-}
-
-impl CanonicalSerializeBE for RLNProofV3 {
-    type Error = ProtocolError;
-
-    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), Self::Error> {
-        self.proof
-            .serialize_compressed(&mut writer)
-            .map_err(ProtocolError::from)?;
-        CanonicalSerializeBE::serialize(&self.proof_values, &mut writer)
-    }
-
-    fn serialized_size(&self) -> usize {
-        COMPRESS_PROOF_SIZE + CanonicalSerializeBE::serialized_size(&self.proof_values)
-    }
-}
-
-impl CanonicalDeserializeBE for RLNProofV3 {
-    type Error = ProtocolError;
-
-    fn deserialize<R: Read>(mut reader: R) -> Result<Self, Self::Error> {
-        let proof = Proof::deserialize_compressed(&mut reader).map_err(ProtocolError::from)?;
-        let proof_values = <RLNProofValuesV3 as CanonicalDeserializeBE>::deserialize(&mut reader)?;
-        Ok(RLNProofV3 {
-            proof,
-            proof_values,
         })
     }
 }

--- a/rln/src/protocol/witness.rs
+++ b/rln/src/protocol/witness.rs
@@ -938,6 +938,136 @@ pub enum RLNWitnessInputV3 {
     Multi(RLNWitnessInputMulti),
 }
 
+impl RLNWitnessInputV3 {
+    /// Returns the identity secret.
+    pub fn identity_secret(&self) -> &IdSecret {
+        match self {
+            Self::Single(w) => &w.identity_secret,
+            Self::Multi(w) => &w.identity_secret,
+        }
+    }
+
+    /// Returns the user message limit.
+    pub fn user_message_limit(&self) -> &Fr {
+        match self {
+            Self::Single(w) => &w.user_message_limit,
+            Self::Multi(w) => &w.user_message_limit,
+        }
+    }
+
+    /// Returns the Merkle path elements.
+    pub fn path_elements(&self) -> &[Fr] {
+        match self {
+            Self::Single(w) => &w.path_elements,
+            Self::Multi(w) => &w.path_elements,
+        }
+    }
+
+    /// Returns the identity path index.
+    pub fn identity_path_index(&self) -> &[u8] {
+        match self {
+            Self::Single(w) => &w.identity_path_index,
+            Self::Multi(w) => &w.identity_path_index,
+        }
+    }
+
+    /// Returns the signal `x` value.
+    pub fn x(&self) -> &Fr {
+        match self {
+            Self::Single(w) => &w.x,
+            Self::Multi(w) => &w.x,
+        }
+    }
+
+    /// Returns the external nullifier.
+    pub fn external_nullifier(&self) -> &Fr {
+        match self {
+            Self::Single(w) => &w.external_nullifier,
+            Self::Multi(w) => &w.external_nullifier,
+        }
+    }
+
+    /// Returns the version byte corresponding to the message mode of this witness.
+    pub fn version_byte(&self) -> u8 {
+        match self {
+            Self::Single(_) => MessageMode::SingleV1.version_byte(),
+            Self::Multi(_) => MessageMode::MultiV1 { max_out: 0 }.version_byte(),
+        }
+    }
+
+    /// Returns the single message ID, or `None` for Multi witnesses.
+    pub fn message_id(&self) -> Option<&Fr> {
+        match self {
+            Self::Single(w) => Some(&w.message_id),
+            Self::Multi(_) => None,
+        }
+    }
+
+    /// Returns message IDs slice, or `None` for Single witnesses.
+    pub fn message_ids(&self) -> Option<&[Fr]> {
+        match self {
+            Self::Multi(w) => Some(&w.message_ids),
+            Self::Single(_) => None,
+        }
+    }
+
+    /// Returns selector flags, or `None` for Single witnesses.
+    pub fn selector_used(&self) -> Option<&[bool]> {
+        match self {
+            Self::Multi(w) => Some(&w.selector_used),
+            Self::Single(_) => None,
+        }
+    }
+
+    /// Serializes this witness to a JSON object suitable for circom witness calculation.
+    pub fn to_bigint_json(&self) -> Result<serde_json::Value, ProtocolError> {
+        let path_elements_str: Vec<String> = self
+            .path_elements()
+            .iter()
+            .map(|v| to_bigint(v).to_str_radix(10))
+            .collect();
+        let identity_path_index_str: Vec<String> = self
+            .identity_path_index()
+            .iter()
+            .map(|v| BigInt::from(*v).to_str_radix(10))
+            .collect();
+
+        match self {
+            Self::Single(w) => Ok(serde_json::json!({
+                "identitySecret": to_bigint(&w.identity_secret).to_str_radix(10),
+                "userMessageLimit": to_bigint(&w.user_message_limit).to_str_radix(10),
+                "messageId": to_bigint(&w.message_id).to_str_radix(10),
+                "pathElements": path_elements_str,
+                "identityPathIndex": identity_path_index_str,
+                "x": to_bigint(&w.x).to_str_radix(10),
+                "externalNullifier": to_bigint(&w.external_nullifier).to_str_radix(10),
+            })),
+            Self::Multi(w) => {
+                let message_ids_str: Vec<String> = w
+                    .message_ids
+                    .iter()
+                    .map(|id| to_bigint(id).to_str_radix(10))
+                    .collect();
+                let selector_used_str: Vec<String> = w
+                    .selector_used
+                    .iter()
+                    .map(|&v| BigInt::from(v).to_str_radix(10))
+                    .collect();
+                Ok(serde_json::json!({
+                    "identitySecret": to_bigint(&w.identity_secret).to_str_radix(10),
+                    "userMessageLimit": to_bigint(&w.user_message_limit).to_str_radix(10),
+                    "messageId": message_ids_str,
+                    "selectorUsed": selector_used_str,
+                    "pathElements": path_elements_str,
+                    "identityPathIndex": identity_path_index_str,
+                    "x": to_bigint(&w.x).to_str_radix(10),
+                    "externalNullifier": to_bigint(&w.external_nullifier).to_str_radix(10),
+                }))
+            }
+        }
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl RLNWitnessInputV3 {
     pub(super) fn validate_against_graph(&self, graph: &Graph) -> Result<(), ProtocolError> {

--- a/rln/src/protocol/witness.rs
+++ b/rln/src/protocol/witness.rs
@@ -10,18 +10,17 @@ use super::{
     FR_BYTE_SIZE, VEC_LEN_BYTE_SIZE,
 };
 use crate::{
-    circuit::Fr,
+    circuit::{Fr, Graph},
     error::ProtocolError,
     hashers::poseidon_hash,
     utils::{
         bytes_be_to_fr, bytes_be_to_vec_bool, bytes_be_to_vec_fr, bytes_be_to_vec_u8,
         bytes_le_to_fr, bytes_le_to_vec_bool, bytes_le_to_vec_fr, bytes_le_to_vec_u8,
         fr_to_bytes_be, fr_to_bytes_le, to_bigint, vec_bool_to_bytes_be, vec_bool_to_bytes_le,
-        vec_fr_to_bytes_be, vec_fr_to_bytes_le, vec_u8_to_bytes_be, vec_u8_to_bytes_le, IdSecret,
+        vec_fr_to_bytes_be, vec_fr_to_bytes_le, vec_u8_to_bytes_be, vec_u8_to_bytes_le, FrOrSecret,
+        IdSecret,
     },
 };
-#[cfg(not(target_arch = "wasm32"))]
-use crate::{circuit::Graph, utils::FrOrSecret};
 
 /// Variant-specific message inputs for RLN witness.
 #[derive(Debug, PartialEq, Clone)]
@@ -1059,7 +1058,6 @@ impl RLNWitnessInputV3 {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl RLNWitnessInputV3 {
     pub(super) fn validate_against_graph(&self, graph: &Graph) -> Result<(), ProtocolError> {
         let (path_len, index_len) = match self {
@@ -1102,9 +1100,11 @@ impl RLNWitnessInputV3 {
         }
         Ok(())
     }
+}
 
+impl RLNWitnessInputV3 {
     // TODO: redesign — str-keyed map is fragile; replace with a typed circuit input struct
-    pub(super) fn to_circuit_inputs(&self) -> Vec<(&'static str, Vec<FrOrSecret>)> {
+    pub(crate) fn to_circuit_inputs(&self) -> Vec<(&'static str, Vec<FrOrSecret>)> {
         match self {
             Self::Single(w) => {
                 let identity_path_index_fr: Vec<FrOrSecret> = w
@@ -1322,7 +1322,6 @@ impl RLNPartialWitnessInputV3 {
         })
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn validate_against_graph(&self, graph: &Graph) -> Result<(), ProtocolError> {
         if self.path_elements.len() != graph.tree_depth {
             return Err(ProtocolError::FieldLengthMismatch(
@@ -1343,8 +1342,7 @@ impl RLNPartialWitnessInputV3 {
         Ok(())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(super) fn to_circuit_inputs(
+    pub(crate) fn to_circuit_inputs(
         &self,
         max_out: usize,
     ) -> Vec<(&'static str, Vec<Option<FrOrSecret>>)> {

--- a/rln/src/protocol/witness.rs
+++ b/rln/src/protocol/witness.rs
@@ -190,22 +190,20 @@ impl RLNWitnessInput {
         &self.user_message_limit
     }
 
-    /// Returns the message ID (only valid for SingleV1 witnesses).
     pub fn message_id(&self) -> &Fr {
         match &self.message_inputs {
             RLNMessageInputs::SingleV1 { message_id } => message_id,
             RLNMessageInputs::MultiV1 { .. } => {
-                panic!("message_id() is not available for MultiV1 witness; use message_ids()")
+                todo!("message_id() is not available for MultiV1 witness; use message_ids()")
             }
         }
     }
 
-    /// Returns the multi message IDs (only valid for MultiV1 witnesses).
     pub fn message_ids(&self) -> &[Fr] {
         match &self.message_inputs {
             RLNMessageInputs::MultiV1 { message_ids, .. } => message_ids,
             RLNMessageInputs::SingleV1 { .. } => {
-                panic!("message_ids() is not available for SingleV1 witness; use message_id()")
+                todo!("message_ids() is not available for SingleV1 witness; use message_id()")
             }
         }
     }
@@ -230,12 +228,11 @@ impl RLNWitnessInput {
         &self.external_nullifier
     }
 
-    /// Returns the selector flags (only valid for MultiV1 witnesses).
     pub fn selector_used(&self) -> &[bool] {
         match &self.message_inputs {
             RLNMessageInputs::MultiV1 { selector_used, .. } => selector_used,
             RLNMessageInputs::SingleV1 { .. } => {
-                panic!("selector_used() is not available for SingleV1 witness")
+                todo!("selector_used() is not available for SingleV1 witness")
             }
         }
     }
@@ -939,7 +936,6 @@ pub enum RLNWitnessInputV3 {
 }
 
 impl RLNWitnessInputV3 {
-    /// Returns the identity secret.
     pub fn identity_secret(&self) -> &IdSecret {
         match self {
             Self::Single(w) => &w.identity_secret,
@@ -947,7 +943,6 @@ impl RLNWitnessInputV3 {
         }
     }
 
-    /// Returns the user message limit.
     pub fn user_message_limit(&self) -> &Fr {
         match self {
             Self::Single(w) => &w.user_message_limit,
@@ -955,7 +950,6 @@ impl RLNWitnessInputV3 {
         }
     }
 
-    /// Returns the Merkle path elements.
     pub fn path_elements(&self) -> &[Fr] {
         match self {
             Self::Single(w) => &w.path_elements,
@@ -963,7 +957,6 @@ impl RLNWitnessInputV3 {
         }
     }
 
-    /// Returns the identity path index.
     pub fn identity_path_index(&self) -> &[u8] {
         match self {
             Self::Single(w) => &w.identity_path_index,
@@ -971,7 +964,6 @@ impl RLNWitnessInputV3 {
         }
     }
 
-    /// Returns the signal `x` value.
     pub fn x(&self) -> &Fr {
         match self {
             Self::Single(w) => &w.x,
@@ -979,7 +971,6 @@ impl RLNWitnessInputV3 {
         }
     }
 
-    /// Returns the external nullifier.
     pub fn external_nullifier(&self) -> &Fr {
         match self {
             Self::Single(w) => &w.external_nullifier,
@@ -987,39 +978,39 @@ impl RLNWitnessInputV3 {
         }
     }
 
-    /// Returns the version byte corresponding to the message mode of this witness.
-    pub fn version_byte(&self) -> u8 {
+    /// Single only — `Err` if called on Multi.
+    pub fn message_id(&self) -> Result<&Fr, ProtocolError> {
         match self {
-            Self::Single(_) => MessageMode::SingleV1.version_byte(),
-            Self::Multi(_) => MessageMode::MultiV1 { max_out: 0 }.version_byte(),
+            Self::Single(w) => Ok(&w.message_id),
+            Self::Multi(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "message_id",
+                variant: "Multi",
+            }),
         }
     }
 
-    /// Returns the single message ID, or `None` for Multi witnesses.
-    pub fn message_id(&self) -> Option<&Fr> {
+    /// Multi only — `Err` if called on Single.
+    pub fn message_ids(&self) -> Result<&[Fr], ProtocolError> {
         match self {
-            Self::Single(w) => Some(&w.message_id),
-            Self::Multi(_) => None,
+            Self::Multi(w) => Ok(&w.message_ids),
+            Self::Single(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "message_ids",
+                variant: "Single",
+            }),
         }
     }
 
-    /// Returns message IDs slice, or `None` for Single witnesses.
-    pub fn message_ids(&self) -> Option<&[Fr]> {
+    /// Multi only — `Err` if called on Single.
+    pub fn selector_used(&self) -> Result<&[bool], ProtocolError> {
         match self {
-            Self::Multi(w) => Some(&w.message_ids),
-            Self::Single(_) => None,
+            Self::Multi(w) => Ok(&w.selector_used),
+            Self::Single(_) => Err(ProtocolError::FieldNotInVariant {
+                field: "selector_used",
+                variant: "Single",
+            }),
         }
     }
 
-    /// Returns selector flags, or `None` for Single witnesses.
-    pub fn selector_used(&self) -> Option<&[bool]> {
-        match self {
-            Self::Multi(w) => Some(&w.selector_used),
-            Self::Single(_) => None,
-        }
-    }
-
-    /// Serializes this witness to a JSON object suitable for circom witness calculation.
     pub fn to_bigint_json(&self) -> Result<serde_json::Value, ProtocolError> {
         let path_elements_str: Vec<String> = self
             .path_elements()

--- a/rln/src/protocol/zk.rs
+++ b/rln/src/protocol/zk.rs
@@ -6,7 +6,7 @@ use crate::{
     circuit::{
         iden3calc::{calc_witness, calc_witness_partial},
         qap::CircomReduction,
-        ArkGroth16BackendWithGraph, ArkGroth16BackendWithoutGraph, Fr, PartialProof, Proof, Zkey,
+        ArkGroth16Backend, ArkGroth16BackendWithGraph, Fr, PartialProof, Proof, Zkey,
     },
     error::{ProtocolError, RLNError},
     partial_proof::{Groth16Partial, PartialAssignment},
@@ -16,6 +16,7 @@ use crate::{
 };
 
 pub trait RLNZkProof {
+    type CalculatedWitness: AsRef<[Fr]>;
     type Values: RecoverSecret
         + CanonicalSerialize
         + CanonicalDeserialize
@@ -26,7 +27,7 @@ pub trait RLNZkProof {
 
     fn generate_proof_from_calculated_witness(
         &self,
-        calculated_witness: &[Fr],
+        calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error>;
     fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error>;
 }
@@ -71,15 +72,16 @@ pub trait RLNPartialZkProof: RLNZkProofWithGraph {
 }
 
 impl RLNZkProof for ArkGroth16BackendWithGraph {
+    type CalculatedWitness = Vec<Fr>;
     type Values = RLNProofValuesV3;
     type Proof = Proof;
     type Error = RLNError;
 
     fn generate_proof_from_calculated_witness(
         &self,
-        calculated_witness: &[Fr],
+        calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error> {
-        prove(&self.zkey, calculated_witness)
+        prove(&self.zkey, calculated_witness.as_ref())
     }
 
     fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error> {
@@ -110,16 +112,17 @@ impl RLNZkProofWithGraph for ArkGroth16BackendWithGraph {
     }
 }
 
-impl RLNZkProof for ArkGroth16BackendWithoutGraph {
+impl RLNZkProof for ArkGroth16Backend {
+    type CalculatedWitness = Vec<Fr>;
     type Values = RLNProofValuesV3;
     type Proof = Proof;
     type Error = RLNError;
 
     fn generate_proof_from_calculated_witness(
         &self,
-        calculated_witness: &[Fr],
+        calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error> {
-        prove(&self.zkey, calculated_witness)
+        prove(&self.zkey, calculated_witness.as_ref())
     }
 
     fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error> {

--- a/rln/src/protocol/zk.rs
+++ b/rln/src/protocol/zk.rs
@@ -1,38 +1,22 @@
 use ark_groth16::{prepare_verifying_key, Groth16};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::UniformRand;
-use num_bigint::BigInt;
-#[cfg(not(target_arch = "wasm32"))]
-use {
-    crate::{
-        circuit::{
-            iden3calc::{calc_witness, calc_witness_partial},
-            PartialProof,
-        },
-        partial_proof::{Groth16Partial, PartialAssignment},
-        prelude::RLNPartialWitnessInputV3,
-    },
-    ark_std::rand::thread_rng,
-};
+use ark_std::{rand::thread_rng, UniformRand};
 
 use crate::{
-    circuit::{qap::CircomReduction, ArkGroth16Backend, Curve, Fr, Proof},
-    error::{ProtocolError, RLNError},
-    prelude::{CanonicalDeserializeBE, CanonicalSerializeBE},
-    protocol::{
-        proof::{calculated_witness_to_field_elements, RLNProofValuesV3},
-        witness::RLNWitnessInputV3,
+    circuit::{
+        iden3calc::{calc_witness, calc_witness_partial},
+        qap::CircomReduction,
+        ArkGroth16BackendWithGraph, ArkGroth16BackendWithoutGraph, Fr, PartialProof, Proof, Zkey,
     },
+    error::{ProtocolError, RLNError},
+    partial_proof::{Groth16Partial, PartialAssignment},
+    prelude::{CanonicalDeserializeBE, CanonicalSerializeBE, RLNPartialWitnessInputV3},
+    protocol::{proof::RLNProofValuesV3, witness::RLNWitnessInputV3},
     utils::IdSecret,
 };
 
 pub trait RLNZkProof {
-    type Witness: CanonicalSerialize
-        + CanonicalDeserialize
-        + CanonicalSerializeBE
-        + CanonicalDeserializeBE;
     type Values: RecoverSecret
-        + TryFrom<Self::Witness>
         + CanonicalSerialize
         + CanonicalDeserialize
         + CanonicalSerializeBE
@@ -40,18 +24,25 @@ pub trait RLNZkProof {
     type Proof: CanonicalSerialize + CanonicalDeserialize;
     type Error;
 
-    fn generate_proof(
+    fn generate_proof_from_calculated_witness(
         &self,
-        witness: Self::Witness,
-    ) -> Result<(Self::Proof, Self::Values), Self::Error>;
-
-    fn generate_proof_with_witness(
-        &self,
-        calculated_witness: Vec<BigInt>,
-        witness: Self::Witness,
-    ) -> Result<(Self::Proof, Self::Values), Self::Error>;
-
+        calculated_witness: &[Fr],
+    ) -> Result<Self::Proof, Self::Error>;
     fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error>;
+}
+
+pub trait RLNZkProofWithGraph: RLNZkProof {
+    type Witness: CanonicalSerialize
+        + CanonicalDeserialize
+        + CanonicalSerializeBE
+        + CanonicalDeserializeBE;
+
+    fn calculate_witness(&self, witness: &Self::Witness) -> Result<Vec<Fr>, Self::Error>;
+
+    fn generate_proof_from_witness(
+        &self,
+        witness: &Self::Witness,
+    ) -> Result<Self::Proof, Self::Error>;
 }
 
 pub trait RecoverSecret<Rhs = Self> {
@@ -60,7 +51,7 @@ pub trait RecoverSecret<Rhs = Self> {
     fn recover_secret(&self, other: &Rhs) -> Result<IdSecret, Self::Error>;
 }
 
-pub trait RLNPartialZkProof: RLNZkProof {
+pub trait RLNPartialZkProof: RLNZkProofWithGraph {
     type PartialWitness: CanonicalSerialize
         + CanonicalDeserialize
         + CanonicalSerializeBE
@@ -79,107 +70,64 @@ pub trait RLNPartialZkProof: RLNZkProof {
     ) -> Result<Self::Proof, Self::Error>;
 }
 
-impl RLNZkProof for ArkGroth16Backend {
-    type Witness = RLNWitnessInputV3;
+impl RLNZkProof for ArkGroth16BackendWithGraph {
     type Values = RLNProofValuesV3;
     type Proof = Proof;
     type Error = RLNError;
 
-    fn generate_proof(
+    fn generate_proof_from_calculated_witness(
         &self,
-        #[allow(unused_variables)] witness: Self::Witness,
-    ) -> Result<(Self::Proof, Self::Values), Self::Error> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            witness.validate_against_graph(&self.graph)?;
-
-            let inputs = witness
-                .to_circuit_inputs()
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v));
-            let full_assignment = calc_witness(inputs, &self.graph).map_err(ProtocolError::from)?;
-
-            let mut rng = thread_rng();
-            let r = Fr::rand(&mut rng);
-            let s = Fr::rand(&mut rng);
-
-            let proof = Groth16::<_, CircomReduction>::create_proof_with_reduction_and_matrices(
-                &self.zkey.0,
-                r,
-                s,
-                &self.zkey.1,
-                self.zkey.1.num_instance_variables,
-                self.zkey.1.num_constraints,
-                full_assignment.as_slice(),
-            )
-            .map_err(ProtocolError::from)?;
-
-            let values = RLNProofValuesV3::try_from(witness)?;
-            Ok((proof, values))
-        }
-        #[cfg(target_arch = "wasm32")]
-        unreachable!(
-            "generate_proof requires a circuit graph; use generate_proof_with_witness on WASM instead"
-        )
-    }
-
-    fn generate_proof_with_witness(
-        &self,
-        calculated_witness: Vec<BigInt>,
-        witness: Self::Witness,
-    ) -> Result<(Self::Proof, Self::Values), Self::Error> {
-        #[cfg(not(target_arch = "wasm32"))]
-        witness.validate_against_graph(&self.graph)?;
-
-        let full_assignment = calculated_witness_to_field_elements::<Curve>(calculated_witness)
-            .map_err(RLNError::from)?;
-
-        let mut rng = ark_std::rand::thread_rng();
-        let r = Fr::rand(&mut rng);
-        let s = Fr::rand(&mut rng);
-
-        let proof = Groth16::<_, CircomReduction>::create_proof_with_reduction_and_matrices(
-            &self.zkey.0,
-            r,
-            s,
-            &self.zkey.1,
-            self.zkey.1.num_instance_variables,
-            self.zkey.1.num_constraints,
-            full_assignment.as_slice(),
-        )
-        .map_err(ProtocolError::from)?;
-
-        let values = RLNProofValuesV3::try_from(witness)?;
-        Ok((proof, values))
+        calculated_witness: &[Fr],
+    ) -> Result<Self::Proof, Self::Error> {
+        prove(&self.zkey, calculated_witness)
     }
 
     fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error> {
-        let public_inputs: Vec<Fr> = match values {
-            RLNProofValuesV3::Single(v) => {
-                vec![v.y, v.root, v.nullifier, v.x, v.external_nullifier]
-            }
-            RLNProofValuesV3::Multi(v) => {
-                let mut inputs = Vec::with_capacity(3 * v.ys.len() + 3);
-                inputs.extend_from_slice(&v.ys);
-                inputs.push(v.root);
-                inputs.extend_from_slice(&v.nullifiers);
-                inputs.push(v.x);
-                inputs.push(v.external_nullifier);
-                for &used in &v.selector_used {
-                    inputs.push(Fr::from(used));
-                }
-                inputs
-            }
-        };
-        let pvk = prepare_verifying_key(&self.zkey.0.vk);
-        let verified = Groth16::<_, CircomReduction>::verify_proof(&pvk, proof, &public_inputs)
-            .map_err(ProtocolError::from)?;
-        Ok(verified)
+        verify(&self.zkey, proof, values)
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-impl RLNPartialZkProof for ArkGroth16Backend {
+impl RLNZkProofWithGraph for ArkGroth16BackendWithGraph {
+    type Witness = RLNWitnessInputV3;
+
+    fn calculate_witness(&self, witness: &Self::Witness) -> Result<Vec<Fr>, Self::Error> {
+        witness.validate_against_graph(&self.graph)?;
+
+        let inputs = witness
+            .to_circuit_inputs()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v));
+
+        Ok(calc_witness(inputs, &self.graph).map_err(ProtocolError::from)?)
+    }
+
+    fn generate_proof_from_witness(
+        &self,
+        witness: &Self::Witness,
+    ) -> Result<Self::Proof, Self::Error> {
+        let calculated_witness = self.calculate_witness(witness)?;
+        self.generate_proof_from_calculated_witness(&calculated_witness)
+    }
+}
+
+impl RLNZkProof for ArkGroth16BackendWithoutGraph {
+    type Values = RLNProofValuesV3;
+    type Proof = Proof;
+    type Error = RLNError;
+
+    fn generate_proof_from_calculated_witness(
+        &self,
+        calculated_witness: &[Fr],
+    ) -> Result<Self::Proof, Self::Error> {
+        prove(&self.zkey, calculated_witness)
+    }
+
+    fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error> {
+        verify(&self.zkey, proof, values)
+    }
+}
+
+impl RLNPartialZkProof for ArkGroth16BackendWithGraph {
     type PartialWitness = RLNPartialWitnessInputV3;
     type PartialProof = PartialProof;
 
@@ -193,12 +141,11 @@ impl RLNPartialZkProof for ArkGroth16Backend {
             .to_circuit_inputs(self.graph.max_out)
             .into_iter()
             .map(|(k, v)| (k.to_string(), v));
+
         let full_assignment =
             calc_witness_partial(inputs, &self.graph).map_err(ProtocolError::from)?;
 
-        let mut partial_values = Vec::with_capacity(full_assignment.len() - 1);
-        partial_values.extend_from_slice(&full_assignment[1..]);
-        let partial_assignment = PartialAssignment::new(partial_values);
+        let partial_assignment = PartialAssignment::new(full_assignment[1..].to_vec());
         let partial_proof =
             Groth16Partial::<_, CircomReduction>::prove_partial(&self.zkey.0, &partial_assignment)?;
         Ok(partial_proof)
@@ -209,13 +156,7 @@ impl RLNPartialZkProof for ArkGroth16Backend {
         partial: Self::PartialProof,
         witness: Self::Witness,
     ) -> Result<Self::Proof, Self::Error> {
-        witness.validate_against_graph(&self.graph)?;
-
-        let inputs = witness
-            .to_circuit_inputs()
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v));
-        let full_assignment = calc_witness(inputs, &self.graph).map_err(ProtocolError::from)?;
+        let calculated_witness = self.calculate_witness(&witness)?;
 
         let mut rng = thread_rng();
         let r = Fr::rand(&mut rng);
@@ -229,8 +170,49 @@ impl RLNPartialZkProof for ArkGroth16Backend {
             &self.zkey.1,
             self.zkey.1.num_instance_variables,
             self.zkey.1.num_constraints,
-            full_assignment.as_slice(),
+            &calculated_witness,
         )?;
         Ok(proof)
     }
+}
+
+fn prove(zkey: &Zkey, calculated_witness: &[Fr]) -> Result<Proof, RLNError> {
+    let mut rng = thread_rng();
+    let r = Fr::rand(&mut rng);
+    let s = Fr::rand(&mut rng);
+    Groth16::<_, CircomReduction>::create_proof_with_reduction_and_matrices(
+        &zkey.0,
+        r,
+        s,
+        &zkey.1,
+        zkey.1.num_instance_variables,
+        zkey.1.num_constraints,
+        calculated_witness,
+    )
+    .map_err(ProtocolError::from)
+    .map_err(Into::into)
+}
+
+fn verify(zkey: &Zkey, proof: &Proof, values: &RLNProofValuesV3) -> Result<bool, RLNError> {
+    let public_inputs: Vec<Fr> = match values {
+        RLNProofValuesV3::Single(v) => {
+            vec![v.y, v.root, v.nullifier, v.x, v.external_nullifier]
+        }
+        RLNProofValuesV3::Multi(v) => {
+            let mut inputs = Vec::with_capacity(3 * v.ys.len() + 3);
+            inputs.extend_from_slice(&v.ys);
+            inputs.push(v.root);
+            inputs.extend_from_slice(&v.nullifiers);
+            inputs.push(v.x);
+            inputs.push(v.external_nullifier);
+            for &used in &v.selector_used {
+                inputs.push(Fr::from(used));
+            }
+            inputs
+        }
+    };
+    let pvk = prepare_verifying_key(&zkey.0.vk);
+    let verified = Groth16::<_, CircomReduction>::verify_proof(&pvk, proof, &public_inputs)
+        .map_err(ProtocolError::from)?;
+    Ok(verified)
 }

--- a/rln/src/protocol/zk.rs
+++ b/rln/src/protocol/zk.rs
@@ -1,24 +1,28 @@
+use ark_groth16::{prepare_verifying_key, Groth16};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::UniformRand;
+use num_bigint::BigInt;
 #[cfg(not(target_arch = "wasm32"))]
 use {
     crate::{
         circuit::{
             iden3calc::{calc_witness, calc_witness_partial},
-            qap::CircomReduction,
-            ArkGroth16Backend, PartialProof, Proof,
+            PartialProof,
         },
-        error::{ProtocolError, RLNError},
         partial_proof::{Groth16Partial, PartialAssignment},
         prelude::RLNPartialWitnessInputV3,
-        protocol::{RLNProofValuesV3, RLNWitnessInputV3},
     },
-    ark_groth16::{prepare_verifying_key, Groth16},
-    ark_std::{rand::thread_rng, UniformRand},
+    ark_std::rand::thread_rng,
 };
 
 use crate::{
-    circuit::Fr,
+    circuit::{qap::CircomReduction, ArkGroth16Backend, Curve, Fr, Proof},
+    error::{ProtocolError, RLNError},
     prelude::{CanonicalDeserializeBE, CanonicalSerializeBE},
+    protocol::{
+        proof::{calculated_witness_to_field_elements, RLNProofValuesV3},
+        witness::RLNWitnessInputV3,
+    },
     utils::IdSecret,
 };
 
@@ -38,6 +42,12 @@ pub trait RLNZkProof {
 
     fn generate_proof(
         &self,
+        witness: Self::Witness,
+    ) -> Result<(Self::Proof, Self::Values), Self::Error>;
+
+    fn generate_proof_with_witness(
+        &self,
+        calculated_witness: Vec<BigInt>,
         witness: Self::Witness,
     ) -> Result<(Self::Proof, Self::Values), Self::Error>;
 
@@ -69,7 +79,6 @@ pub trait RLNPartialZkProof: RLNZkProof {
     ) -> Result<Self::Proof, Self::Error>;
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl RLNZkProof for ArkGroth16Backend {
     type Witness = RLNWitnessInputV3;
     type Values = RLNProofValuesV3;
@@ -80,15 +89,52 @@ impl RLNZkProof for ArkGroth16Backend {
         &self,
         witness: Self::Witness,
     ) -> Result<(Self::Proof, Self::Values), Self::Error> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            witness.validate_against_graph(&self.graph)?;
+
+            let inputs = witness
+                .to_circuit_inputs()
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v));
+            let full_assignment = calc_witness(inputs, &self.graph).map_err(ProtocolError::from)?;
+
+            let mut rng = thread_rng();
+            let r = Fr::rand(&mut rng);
+            let s = Fr::rand(&mut rng);
+
+            let proof = Groth16::<_, CircomReduction>::create_proof_with_reduction_and_matrices(
+                &self.zkey.0,
+                r,
+                s,
+                &self.zkey.1,
+                self.zkey.1.num_instance_variables,
+                self.zkey.1.num_constraints,
+                full_assignment.as_slice(),
+            )
+            .map_err(ProtocolError::from)?;
+
+            let values = RLNProofValuesV3::try_from(witness)?;
+            Ok((proof, values))
+        }
+        #[cfg(target_arch = "wasm32")]
+        unreachable!(
+            "generate_proof requires a circuit graph; use generate_proof_with_witness on WASM instead"
+        )
+    }
+
+    fn generate_proof_with_witness(
+        &self,
+        calculated_witness: Vec<BigInt>,
+        witness: Self::Witness,
+    ) -> Result<(Self::Proof, Self::Values), Self::Error> {
+        #[cfg(not(target_arch = "wasm32"))]
         witness.validate_against_graph(&self.graph)?;
 
-        let inputs = witness
-            .to_circuit_inputs()
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v));
-        let full_assignment = calc_witness(inputs, &self.graph).map_err(ProtocolError::from)?;
+        let full_assignment = calculated_witness_to_field_elements::<Curve>(calculated_witness)
+            .map_err(RLNError::from)?;
 
-        let mut rng = thread_rng();
+        let mut rng = ark_std::rand::thread_rng();
         let r = Fr::rand(&mut rng);
         let s = Fr::rand(&mut rng);
 

--- a/rln/src/protocol/zk.rs
+++ b/rln/src/protocol/zk.rs
@@ -16,7 +16,10 @@ use crate::{
 };
 
 pub trait RLNZkProof {
-    type CalculatedWitness: AsRef<[Fr]>;
+    type CalculatedWitness: CanonicalSerialize
+        + CanonicalDeserialize
+        + CanonicalSerializeBE
+        + CanonicalDeserializeBE;
     type Values: RecoverSecret
         + CanonicalSerialize
         + CanonicalDeserialize
@@ -25,7 +28,7 @@ pub trait RLNZkProof {
     type Proof: CanonicalSerialize + CanonicalDeserialize;
     type Error;
 
-    fn generate_proof_from_calculated_witness(
+    fn generate_proof(
         &self,
         calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error>;
@@ -77,7 +80,7 @@ impl RLNZkProof for ArkGroth16BackendWithGraph {
     type Proof = Proof;
     type Error = RLNError;
 
-    fn generate_proof_from_calculated_witness(
+    fn generate_proof(
         &self,
         calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error> {
@@ -108,7 +111,7 @@ impl RLNZkProofWithGraph for ArkGroth16BackendWithGraph {
         witness: &Self::Witness,
     ) -> Result<Self::Proof, Self::Error> {
         let calculated_witness = self.calculate_witness(witness)?;
-        self.generate_proof_from_calculated_witness(&calculated_witness)
+        self.generate_proof(&calculated_witness)
     }
 }
 
@@ -118,7 +121,7 @@ impl RLNZkProof for ArkGroth16Backend {
     type Proof = Proof;
     type Error = RLNError;
 
-    fn generate_proof_from_calculated_witness(
+    fn generate_proof(
         &self,
         calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error> {

--- a/rln/src/protocol/zk.rs
+++ b/rln/src/protocol/zk.rs
@@ -84,7 +84,7 @@ impl RLNZkProof for ArkGroth16BackendWithGraph {
         &self,
         calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error> {
-        prove(&self.zkey, calculated_witness.as_ref())
+        generate_proof(&self.zkey, calculated_witness.as_ref())
     }
 
     fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error> {
@@ -125,7 +125,7 @@ impl RLNZkProof for ArkGroth16Backend {
         &self,
         calculated_witness: &Self::CalculatedWitness,
     ) -> Result<Self::Proof, Self::Error> {
-        prove(&self.zkey, calculated_witness.as_ref())
+        generate_proof(&self.zkey, calculated_witness.as_ref())
     }
 
     fn verify(&self, proof: &Self::Proof, values: &Self::Values) -> Result<bool, Self::Error> {
@@ -182,7 +182,7 @@ impl RLNPartialZkProof for ArkGroth16BackendWithGraph {
     }
 }
 
-fn prove(zkey: &Zkey, calculated_witness: &[Fr]) -> Result<Proof, RLNError> {
+fn generate_proof(zkey: &Zkey, calculated_witness: &[Fr]) -> Result<Proof, RLNError> {
     let mut rng = thread_rng();
     let r = Fr::rand(&mut rng);
     let s = Fr::rand(&mut rng);

--- a/rln/src/protocol/zk.rs
+++ b/rln/src/protocol/zk.rs
@@ -87,7 +87,7 @@ impl RLNZkProof for ArkGroth16Backend {
 
     fn generate_proof(
         &self,
-        witness: Self::Witness,
+        #[allow(unused_variables)] witness: Self::Witness,
     ) -> Result<(Self::Proof, Self::Values), Self::Error> {
         #[cfg(not(target_arch = "wasm32"))]
         {

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -837,8 +837,7 @@ where
     ) -> Result<(ZkProof::Proof, ZkProof::Values), RLNError> {
         Ok(self
             .zkp
-            .generate_proof_with_witness(calculated_witness, witness)
-            .map_err(RLNError::from)?)
+            .generate_proof_with_witness(calculated_witness, witness)?)
     }
 
     pub fn verify(
@@ -928,8 +927,7 @@ impl<S> RLNV3<S, ArkGroth16Backend> {
     ) -> Result<RLNProofV3, RLNError> {
         let (proof, proof_values) = self
             .zkp
-            .generate_proof_with_witness(calculated_witness, witness)
-            .map_err(RLNError::from)?;
+            .generate_proof_with_witness(calculated_witness, witness)?;
         Ok(RLNProofV3 {
             proof,
             proof_values,

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -823,13 +823,11 @@ impl<Tree, ZkProof: RLNZkProof> RLNV3<Tree, ZkProof>
 where
     RLNError: From<ZkProof::Error>,
 {
-    pub fn generate_proof_from_calculated_witness(
+    pub fn generate_proof(
         &self,
         calculated_witness: &ZkProof::CalculatedWitness,
     ) -> Result<ZkProof::Proof, RLNError> {
-        Ok(self
-            .zkp
-            .generate_proof_from_calculated_witness(calculated_witness)?)
+        Ok(self.zkp.generate_proof(calculated_witness)?)
     }
 
     pub fn verify(

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -24,8 +24,8 @@ use crate::{
     error::{RLNError, VerifyError},
     protocol::{
         generate_zk_proof_with_witness, proof_values_from_witness, verify_zk_proof,
-        RLNPartialZkProof, RLNProofValues, RLNProofValuesV3, RLNWitnessInput, RLNZkProof, Stateful,
-        Stateless,
+        RLNPartialZkProof, RLNProofV3, RLNProofValues, RLNProofValuesV3, RLNWitnessInput,
+        RLNWitnessInputV3, RLNZkProof, Stateful, Stateless,
     },
 };
 
@@ -768,9 +768,9 @@ impl RLN {
     }
 }
 
-pub struct RLNV3<Mode, ZkProof> {
+pub struct RLNV3<State, ZkProof> {
     pub(crate) zkp: ZkProof,
-    pub(crate) state: Mode,
+    pub(crate) state: State,
 }
 
 impl<ZkProof> RLNV3<Stateless, ZkProof> {
@@ -837,7 +837,8 @@ where
     ) -> Result<(ZkProof::Proof, ZkProof::Values), RLNError> {
         Ok(self
             .zkp
-            .generate_proof_with_witness(calculated_witness, witness)?)
+            .generate_proof_with_witness(calculated_witness, witness)
+            .map_err(RLNError::from)?)
     }
 
     pub fn verify(
@@ -896,6 +897,15 @@ impl RLNV3<Stateless, ArkGroth16Backend> {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+impl RLNV3<Stateless, ArkGroth16Backend> {
+    /// Creates a stateless instance from zkey bytes (WASM — no graph needed).
+    pub fn new_with_params(zkey_data: Vec<u8>) -> Result<Self, RLNError> {
+        let zkey = zkey_from_raw(&zkey_data)?;
+        Ok(Self::new(ArkGroth16Backend::new(zkey)))
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl<S> RLNV3<S, ArkGroth16Backend> {
     /// Returns the message mode inferred from the loaded circuit.
@@ -910,6 +920,22 @@ impl<S> RLNV3<S, ArkGroth16Backend> {
 }
 
 impl<S> RLNV3<S, ArkGroth16Backend> {
+    /// Generates a proof from a pre-computed witness, returning proof and values together.
+    pub fn generate_rln_proof_with_witness(
+        &self,
+        calculated_witness: Vec<BigInt>,
+        witness: RLNWitnessInputV3,
+    ) -> Result<RLNProofV3, RLNError> {
+        let (proof, proof_values) = self
+            .zkp
+            .generate_proof_with_witness(calculated_witness, witness)
+            .map_err(RLNError::from)?;
+        Ok(RLNProofV3 {
+            proof,
+            proof_values,
+        })
+    }
+
     /// Verifies a proof and checks that the root is in the provided set and `x` matches the signal.
     ///
     /// If `roots` is empty, root membership is skipped.

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -12,8 +12,8 @@ use {
 
 use crate::{
     circuit::{
-        graph_from_raw, zkey_from_raw, ArkGroth16BackendWithGraph, ArkGroth16BackendWithoutGraph,
-        Fr, Proof, Zkey,
+        graph_from_raw, zkey_from_raw, ArkGroth16Backend, ArkGroth16BackendWithGraph, Fr, Proof,
+        Zkey,
     },
     error::{RLNError, VerifyError},
     protocol::{
@@ -825,7 +825,7 @@ where
 {
     pub fn generate_proof_from_calculated_witness(
         &self,
-        calculated_witness: &[Fr],
+        calculated_witness: &ZkProof::CalculatedWitness,
     ) -> Result<ZkProof::Proof, RLNError> {
         Ok(self
             .zkp
@@ -882,10 +882,10 @@ impl RLNV3<Stateless, ArkGroth16BackendWithGraph> {
     }
 }
 
-impl RLNV3<Stateless, ArkGroth16BackendWithoutGraph> {
+impl RLNV3<Stateless, ArkGroth16Backend> {
     pub fn new_with_params(zkey_data: Vec<u8>) -> Result<Self, RLNError> {
         let zkey = zkey_from_raw(&zkey_data)?;
-        Ok(Self::new(ArkGroth16BackendWithoutGraph::new(zkey)))
+        Ok(Self::new(ArkGroth16Backend::new(zkey)))
     }
 }
 

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -13,14 +13,14 @@ use {
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{
     circuit::{
-        graph_from_raw, graph_multi_v1, graph_single_v1, zkey_multi_v1, zkey_single_v1,
-        ArkGroth16Backend, Graph, PartialProof,
+        graph_from_raw, graph_multi_v1, graph_single_v1, zkey_multi_v1, zkey_single_v1, Graph,
+        PartialProof,
     },
     prelude::RLNPartialWitnessInput,
     protocol::{finish_zk_proof, generate_partial_zk_proof, generate_zk_proof, MessageMode},
 };
 use crate::{
-    circuit::{zkey_from_raw, Fr, Proof, Zkey},
+    circuit::{zkey_from_raw, ArkGroth16Backend, Fr, Proof, Zkey},
     error::{RLNError, VerifyError},
     protocol::{
         generate_zk_proof_with_witness, proof_values_from_witness, verify_zk_proof,
@@ -830,6 +830,16 @@ where
         Ok(self.zkp.generate_proof(witness)?)
     }
 
+    pub fn generate_proof_with_witness(
+        &self,
+        calculated_witness: Vec<BigInt>,
+        witness: ZkProof::Witness,
+    ) -> Result<(ZkProof::Proof, ZkProof::Values), RLNError> {
+        Ok(self
+            .zkp
+            .generate_proof_with_witness(calculated_witness, witness)?)
+    }
+
     pub fn verify(
         &self,
         proof: &ZkProof::Proof,
@@ -897,10 +907,12 @@ impl<S> RLNV3<S, ArkGroth16Backend> {
     pub fn max_out(&self) -> usize {
         self.zkp.graph.max_out
     }
+}
 
+impl<S> RLNV3<S, ArkGroth16Backend> {
     /// Verifies a proof and checks that the root is in the provided set and `x` matches the signal.
     ///
-    /// If `roots` is empty, root membership is skipped. Equivalent to the old `RLN::verify_with_roots`.
+    /// If `roots` is empty, root membership is skipped.
     pub fn verify_with_roots(
         &self,
         proof: &Proof,
@@ -914,8 +926,7 @@ impl<S> RLNV3<S, ArkGroth16Backend> {
         if x != &values.x() {
             return Err(VerifyError::InvalidSignal.into());
         }
-        let verified = self.zkp.verify(proof, values)?;
-        if !verified {
+        if !self.verify(proof, values)? {
             return Err(VerifyError::InvalidProof.into());
         }
         Ok(true)

--- a/rln/src/public.rs
+++ b/rln/src/public.rs
@@ -10,23 +10,23 @@ use {
     zerokit_utils::merkle_tree::{Hasher, ZerokitMerkleProof, ZerokitMerkleTreeError},
 };
 
-#[cfg(not(target_arch = "wasm32"))]
 use crate::{
     circuit::{
-        graph_from_raw, graph_multi_v1, graph_single_v1, zkey_multi_v1, zkey_single_v1, Graph,
-        PartialProof,
+        graph_from_raw, zkey_from_raw, ArkGroth16BackendWithGraph, ArkGroth16BackendWithoutGraph,
+        Fr, Proof, Zkey,
     },
-    prelude::RLNPartialWitnessInput,
-    protocol::{finish_zk_proof, generate_partial_zk_proof, generate_zk_proof, MessageMode},
-};
-use crate::{
-    circuit::{zkey_from_raw, ArkGroth16Backend, Fr, Proof, Zkey},
     error::{RLNError, VerifyError},
     protocol::{
         generate_zk_proof_with_witness, proof_values_from_witness, verify_zk_proof,
-        RLNPartialZkProof, RLNProofV3, RLNProofValues, RLNProofValuesV3, RLNWitnessInput,
-        RLNWitnessInputV3, RLNZkProof, Stateful, Stateless,
+        RLNPartialZkProof, RLNProofValues, RLNProofValuesV3, RLNWitnessInput, RLNZkProof,
+        RLNZkProofWithGraph, Stateful, Stateless,
     },
+};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::{
+    circuit::{graph_single_v1, zkey_single_v1, Graph, PartialProof},
+    prelude::RLNPartialWitnessInput,
+    protocol::{finish_zk_proof, generate_partial_zk_proof, generate_zk_proof, MessageMode},
 };
 
 /// This trait allows accepting different config input types for tree configuration.
@@ -823,21 +823,13 @@ impl<Tree, ZkProof: RLNZkProof> RLNV3<Tree, ZkProof>
 where
     RLNError: From<ZkProof::Error>,
 {
-    pub fn generate_proof(
+    pub fn generate_proof_from_calculated_witness(
         &self,
-        witness: ZkProof::Witness,
-    ) -> Result<(ZkProof::Proof, ZkProof::Values), RLNError> {
-        Ok(self.zkp.generate_proof(witness)?)
-    }
-
-    pub fn generate_proof_with_witness(
-        &self,
-        calculated_witness: Vec<BigInt>,
-        witness: ZkProof::Witness,
-    ) -> Result<(ZkProof::Proof, ZkProof::Values), RLNError> {
+        calculated_witness: &[Fr],
+    ) -> Result<ZkProof::Proof, RLNError> {
         Ok(self
             .zkp
-            .generate_proof_with_witness(calculated_witness, witness)?)
+            .generate_proof_from_calculated_witness(calculated_witness)?)
     }
 
     pub fn verify(
@@ -846,6 +838,18 @@ where
         values: &ZkProof::Values,
     ) -> Result<bool, RLNError> {
         Ok(self.zkp.verify(proof, values)?)
+    }
+}
+
+impl<Tree, ZkProof: RLNZkProofWithGraph> RLNV3<Tree, ZkProof>
+where
+    RLNError: From<ZkProof::Error>,
+{
+    pub fn generate_proof_from_witness(
+        &self,
+        witness: &ZkProof::Witness,
+    ) -> Result<ZkProof::Proof, RLNError> {
+        Ok(self.zkp.generate_proof_from_witness(witness)?)
     }
 }
 
@@ -870,73 +874,25 @@ where
 }
 
 // TODO: replace these constructors with a unified RLNBuilder (PR 8)
-#[cfg(not(target_arch = "wasm32"))]
-impl RLNV3<Stateless, ArkGroth16Backend> {
-    /// Creates a stateless instance using the embedded Single circuit (tree_depth=20, max_out=1).
-    pub fn new_single() -> Self {
-        Self::new(ArkGroth16Backend::new(
-            zkey_single_v1().to_owned(),
-            graph_single_v1().to_owned(),
-        ))
-    }
-
-    /// Creates a stateless instance using the embedded Multi circuit (tree_depth=20, max_out=4).
-    pub fn new_multi() -> Self {
-        Self::new(ArkGroth16Backend::new(
-            zkey_multi_v1().to_owned(),
-            graph_multi_v1().to_owned(),
-        ))
-    }
-
-    /// Creates a stateless instance from custom zkey and graph bytes.
+impl RLNV3<Stateless, ArkGroth16BackendWithGraph> {
     pub fn new_with_params(zkey_data: Vec<u8>, graph_data: Vec<u8>) -> Result<Self, RLNError> {
         let zkey = zkey_from_raw(&zkey_data)?;
         let graph = graph_from_raw(&graph_data, None, None)?;
-        Ok(Self::new(ArkGroth16Backend::new(zkey, graph)))
+        Ok(Self::new(ArkGroth16BackendWithGraph::new(zkey, graph)))
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-impl RLNV3<Stateless, ArkGroth16Backend> {
-    /// Creates a stateless instance from zkey bytes (WASM — no graph needed).
+impl RLNV3<Stateless, ArkGroth16BackendWithoutGraph> {
     pub fn new_with_params(zkey_data: Vec<u8>) -> Result<Self, RLNError> {
         let zkey = zkey_from_raw(&zkey_data)?;
-        Ok(Self::new(ArkGroth16Backend::new(zkey)))
+        Ok(Self::new(ArkGroth16BackendWithoutGraph::new(zkey)))
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-impl<S> RLNV3<S, ArkGroth16Backend> {
-    /// Returns the message mode inferred from the loaded circuit.
-    pub fn message_mode(&self) -> MessageMode {
-        MessageMode::from(&self.zkp.graph)
-    }
-
-    /// Returns the maximum number of message-id slots for the loaded circuit.
-    pub fn max_out(&self) -> usize {
-        self.zkp.graph.max_out
-    }
-}
-
-impl<S> RLNV3<S, ArkGroth16Backend> {
-    /// Generates a proof from a pre-computed witness, returning proof and values together.
-    pub fn generate_rln_proof_with_witness(
-        &self,
-        calculated_witness: Vec<BigInt>,
-        witness: RLNWitnessInputV3,
-    ) -> Result<RLNProofV3, RLNError> {
-        let (proof, proof_values) = self
-            .zkp
-            .generate_proof_with_witness(calculated_witness, witness)?;
-        Ok(RLNProofV3 {
-            proof,
-            proof_values,
-        })
-    }
-
-    /// Verifies a proof and checks that the root is in the provided set and `x` matches the signal.
-    ///
-    /// If `roots` is empty, root membership is skipped.
+impl<Tree, ZkProof> RLNV3<Tree, ZkProof>
+where
+    ZkProof: RLNZkProof<Values = RLNProofValuesV3, Proof = Proof, Error = RLNError>,
+{
     pub fn verify_with_roots(
         &self,
         proof: &Proof,
@@ -950,7 +906,7 @@ impl<S> RLNV3<S, ArkGroth16Backend> {
         if x != &values.x() {
             return Err(VerifyError::InvalidSignal.into());
         }
-        if !self.verify(proof, values)? {
+        if !self.zkp.verify(proof, values)? {
             return Err(VerifyError::InvalidProof.into());
         }
         Ok(true)

--- a/rln/src/utils.rs
+++ b/rln/src/utils.rs
@@ -8,7 +8,6 @@ use ark_std::UniformRand;
 use num_bigint::{BigInt, BigUint};
 use num_traits::Num;
 use rand::Rng;
-#[cfg(not(target_arch = "wasm32"))]
 use ruint::aliases::U256;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
@@ -499,7 +498,6 @@ impl IdSecret {
 
     /// Warning: this can leak the secret value
     /// Warning: Leaked value is of type 'U256' which implement Copy (every copy will not be zeroized)
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn to_u256(&self) -> U256 {
         let mut big_int = self.0.into_bigint();
         let res = U256::from_limbs(big_int.0);
@@ -528,21 +526,18 @@ impl Deref for IdSecret {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, Zeroize, ZeroizeOnDrop)]
 pub(crate) enum FrOrSecret {
     IdSecret(IdSecret),
     Fr(Fr),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl From<Fr> for FrOrSecret {
     fn from(value: Fr) -> Self {
         FrOrSecret::Fr(value)
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl From<IdSecret> for FrOrSecret {
     fn from(value: IdSecret) -> Self {
         FrOrSecret::IdSecret(value)

--- a/rln/tests/proof.rs
+++ b/rln/tests/proof.rs
@@ -3,30 +3,19 @@
 mod test {
     use rln::prelude::*;
 
-    fn make_rln_single() -> RLNV3<Stateless, ArkGroth16Backend> {
-        RLNV3::<Stateless, ArkGroth16Backend>::new(ArkGroth16Backend::new(
-            zkey_single_v1().clone(),
-            graph_single_v1().clone(),
+    fn make_rln(zkey: &Zkey, graph: &Graph) -> RLNV3<Stateless, ArkGroth16BackendWithGraph> {
+        RLNV3::<Stateless, ArkGroth16BackendWithGraph>::new(ArkGroth16BackendWithGraph::new(
+            zkey.clone(),
+            graph.clone(),
         ))
     }
 
-    fn make_rln_multi() -> RLNV3<Stateless, ArkGroth16Backend> {
-        RLNV3::<Stateless, ArkGroth16Backend>::new(ArkGroth16Backend::new(
-            zkey_multi_v1().clone(),
-            graph_multi_v1().clone(),
-        ))
+    fn make_backend(zkey: &Zkey, graph: &Graph) -> ArkGroth16BackendWithGraph {
+        ArkGroth16BackendWithGraph::new(zkey.clone(), graph.clone())
     }
 
-    fn make_backend() -> ArkGroth16Backend {
-        ArkGroth16Backend::new(zkey_single_v1().clone(), graph_single_v1().clone())
-    }
-
-    fn make_multi_backend() -> ArkGroth16Backend {
-        ArkGroth16Backend::new(zkey_multi_v1().clone(), graph_multi_v1().clone())
-    }
-
-    fn make_single_witness_with_path_elements(
-        identity_secret: IdSecret,
+    fn single_witness(
+        id: IdSecret,
         path_elements: Vec<Fr>,
         message_id: Fr,
         x: Fr,
@@ -35,7 +24,7 @@ mod test {
         let depth = path_elements.len();
         RLNWitnessInputV3::Single(
             RLNWitnessInputSingle::new(
-                identity_secret,
+                id,
                 Fr::from(10u64),
                 path_elements,
                 vec![0u8; depth],
@@ -47,8 +36,8 @@ mod test {
         )
     }
 
-    fn make_multi_witness_with_path_elements(
-        identity_secret: IdSecret,
+    fn multi_witness(
+        id: IdSecret,
         path_elements: Vec<Fr>,
         message_ids: Vec<Fr>,
         selector_used: Vec<bool>,
@@ -58,7 +47,7 @@ mod test {
         let depth = path_elements.len();
         RLNWitnessInputV3::Multi(
             RLNWitnessInputMulti::new(
-                identity_secret,
+                id,
                 Fr::from(10u64),
                 path_elements,
                 vec![0u8; depth],
@@ -71,459 +60,397 @@ mod test {
         )
     }
 
-    fn make_single_witness(
-        identity_secret: IdSecret,
-        x: Fr,
-        external_nullifier: Fr,
-        message_id: Fr,
-    ) -> RLNWitnessInputV3 {
-        make_single_witness_with_path_elements(
-            identity_secret,
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            message_id,
-            x,
-            external_nullifier,
-        )
+    fn default_path() -> Vec<Fr> {
+        vec![Fr::from(0u64); DEFAULT_TREE_DEPTH]
     }
 
-    fn make_multi_witness(
-        identity_secret: IdSecret,
-        x: Fr,
-        external_nullifier: Fr,
-    ) -> RLNWitnessInputV3 {
-        let message_ids: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        make_multi_witness_with_path_elements(
-            identity_secret,
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            message_ids,
-            vec![true; DEFAULT_MAX_OUT],
-            x,
-            external_nullifier,
-        )
+    fn default_message_ids() -> Vec<Fr> {
+        (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect()
     }
 
-    #[test]
-    fn test_rlnv3_stateless_single_generate_and_verify() {
-        let (identity_secret, _) = keygen();
-        let witness = make_single_witness_with_path_elements(
-            identity_secret,
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            Fr::from(1u64),
-            Fr::from(42u64),
-            Fr::from(100u64),
-        );
-
-        let rln = make_rln_single();
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        assert!(rln.verify(&proof, &values).unwrap());
-    }
-
-    #[test]
-    fn test_rlnv3_stateless_multi_generate_and_verify() {
-        let (identity_secret, _) = keygen();
-        let message_ids: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        let witness = make_multi_witness_with_path_elements(
-            identity_secret,
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            message_ids,
-            vec![true; DEFAULT_MAX_OUT],
-            Fr::from(42u64),
-            Fr::from(100u64),
-        );
-
-        let rln = make_rln_multi();
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        assert!(rln.verify(&proof, &values).unwrap());
-    }
-
-    #[test]
-    fn test_rlnv3_stateless_recover_secret_single() {
-        let (identity_secret, _) = keygen();
-        let path = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-
-        let w1 = make_single_witness_with_path_elements(
-            identity_secret.clone(),
-            path.clone(),
-            Fr::from(1u64),
-            Fr::from(11u64),
-            Fr::from(200u64),
-        );
-        let w2 = make_single_witness_with_path_elements(
-            identity_secret.clone(),
-            path,
-            Fr::from(1u64),
-            Fr::from(22u64),
-            Fr::from(200u64),
-        );
-
-        let rln = make_rln_single();
-        let (_, v1) = rln.generate_proof(w1).unwrap();
-        let (_, v2) = rln.generate_proof(w2).unwrap();
-
-        let recovered = v1.recover_secret(&v2).unwrap();
-        assert_eq!(*recovered, *identity_secret);
-    }
-
-    #[test]
-    fn test_rlnv3_stateless_recover_secret_cross_mode() {
-        let (identity_secret, _) = keygen();
-        let path = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-        let external_nullifier = Fr::from(300u64);
-
-        let w_single = make_single_witness_with_path_elements(
-            identity_secret.clone(),
-            path.clone(),
-            Fr::from(1u64),
-            Fr::from(11u64),
-            external_nullifier,
-        );
-        let message_ids: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        let w_multi = make_multi_witness_with_path_elements(
-            identity_secret.clone(),
-            path,
-            message_ids,
-            vec![true; DEFAULT_MAX_OUT],
-            Fr::from(22u64),
-            external_nullifier,
-        );
-
-        let rln_single = make_rln_single();
-        let rln_multi = make_rln_multi();
-
-        let (_, sv) = rln_single.generate_proof(w_single).unwrap();
-        let (_, mv) = rln_multi.generate_proof(w_multi).unwrap();
-
-        assert_eq!(*sv.recover_secret(&mv).unwrap(), *identity_secret);
-        assert_eq!(*mv.recover_secret(&sv).unwrap(), *identity_secret);
+    fn values(witness: RLNWitnessInputV3) -> RLNProofValuesV3 {
+        RLNProofValuesV3::try_from(witness).unwrap()
     }
 
     #[test]
     fn test_generate_and_verify_single() {
-        let (identity_secret, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-        let witness = make_single_witness_with_path_elements(
-            identity_secret,
-            path_elements,
+        let backend = make_backend(zkey_single_v1(), graph_single_v1());
+        let witness = single_witness(
+            keygen().0,
+            default_path(),
             Fr::from(1u64),
             Fr::from(42u64),
             Fr::from(100u64),
         );
-
-        let backend = make_backend();
-        let (proof, values) = backend.generate_proof(witness).unwrap();
-        let verified = backend.verify(&proof, &values).unwrap();
-        assert!(verified);
+        let proof = backend.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        assert!(backend.verify(&proof, &vals).unwrap());
     }
 
     #[test]
     fn test_wrong_proof_fails_verification() {
-        let (id1, _) = keygen();
-        let (id2, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-
-        let w1 = make_single_witness_with_path_elements(
-            id1,
-            path_elements.clone(),
+        let backend = make_backend(zkey_single_v1(), graph_single_v1());
+        let w1 = single_witness(
+            keygen().0,
+            default_path(),
             Fr::from(1u64),
             Fr::from(42u64),
             Fr::from(100u64),
         );
-        let w2 = make_single_witness_with_path_elements(
-            id2,
-            path_elements,
+        let w2 = single_witness(
+            keygen().0,
+            default_path(),
             Fr::from(1u64),
             Fr::from(99u64),
             Fr::from(100u64),
         );
+        let proof1 = backend.generate_proof_from_witness(&w1).unwrap();
+        let vals2 = values(w2);
+        assert!(!backend.verify(&proof1, &vals2).unwrap());
+    }
 
-        let backend = make_backend();
-        let (proof1, _) = backend.generate_proof(w1).unwrap();
-        let (_, values2) = backend.generate_proof(w2).unwrap();
+    #[test]
+    fn test_tree_depth_mismatch_fails() {
+        let backend = make_backend(zkey_single_v1(), graph_single_v1());
+        let witness = single_witness(
+            keygen().0,
+            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH + 1],
+            Fr::from(1u64),
+            Fr::from(1u64),
+            Fr::from(1u64),
+        );
+        assert!(backend.generate_proof_from_witness(&witness).is_err());
+    }
 
-        // proof1 with values2 -- should not verify
-        let verified = backend.verify(&proof1, &values2).unwrap();
-        assert!(!verified);
+    #[test]
+    fn test_generate_and_verify_multi() {
+        let backend = make_backend(zkey_multi_v1(), graph_multi_v1());
+        let witness = multi_witness(
+            keygen().0,
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(42u64),
+            Fr::from(100u64),
+        );
+        let proof = backend.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        assert!(backend.verify(&proof, &vals).unwrap());
+    }
+
+    #[test]
+    fn test_generate_and_verify_multi_partial_selector() {
+        let backend = make_backend(zkey_multi_v1(), graph_multi_v1());
+        let witness = multi_witness(
+            keygen().0,
+            default_path(),
+            default_message_ids(),
+            vec![true, false, true, false],
+            Fr::from(42u64),
+            Fr::from(100u64),
+        );
+        let proof = backend.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        assert!(backend.verify(&proof, &vals).unwrap());
+    }
+
+    #[test]
+    fn test_multi_message_ids_wrong_count_fails() {
+        let backend = make_backend(zkey_multi_v1(), graph_multi_v1());
+        let witness = multi_witness(
+            keygen().0,
+            default_path(),
+            vec![Fr::from(1u64), Fr::from(2u64)],
+            vec![true, true],
+            Fr::from(42u64),
+            Fr::from(100u64),
+        );
+        assert!(backend.generate_proof_from_witness(&witness).is_err());
     }
 
     #[test]
     fn test_recover_secret_single_x_single() {
-        let (identity_secret, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-
-        // Two proofs: same identity, same epoch+message_id (same nullifier), different signal x
-        let w1 = make_single_witness_with_path_elements(
-            identity_secret.clone(),
-            path_elements.clone(),
+        let (id, _) = keygen();
+        let v1 = values(single_witness(
+            id.clone(),
+            default_path(),
             Fr::from(1u64),
             Fr::from(11u64),
             Fr::from(200u64),
-        );
-        let w2 = make_single_witness_with_path_elements(
-            identity_secret.clone(),
-            path_elements,
+        ));
+        let v2 = values(single_witness(
+            id.clone(),
+            default_path(),
             Fr::from(1u64),
             Fr::from(22u64),
             Fr::from(200u64),
-        );
-
-        let backend = make_backend();
-        let (_, values1) = backend.generate_proof(w1).unwrap();
-        let (_, values2) = backend.generate_proof(w2).unwrap();
-
-        let recovered = values1.recover_secret(&values2).unwrap();
-        assert_eq!(*recovered, *identity_secret);
+        ));
+        assert_eq!(*v1.recover_secret(&v2).unwrap(), *id);
     }
 
     #[test]
     fn test_recover_secret_mismatched_nullifier_fails() {
         let (id, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-
-        // Different message_ids -> different nullifiers -> can't recover
-        let w1 = make_single_witness_with_path_elements(
+        let v1 = values(single_witness(
             id.clone(),
-            path_elements.clone(),
+            default_path(),
             Fr::from(1u64),
             Fr::from(11u64),
             Fr::from(200u64),
-        );
-        let w2 = make_single_witness_with_path_elements(
+        ));
+        let v2 = values(single_witness(
             id,
-            path_elements,
+            default_path(),
             Fr::from(2u64),
             Fr::from(22u64),
             Fr::from(200u64),
-        );
-
-        let backend = make_backend();
-        let (_, v1) = backend.generate_proof(w1).unwrap();
-        let (_, v2) = backend.generate_proof(w2).unwrap();
-
+        ));
         assert!(v1.recover_secret(&v2).is_err());
     }
 
     #[test]
-    fn test_tree_depth_mismatch_fails() {
-        let (id, _) = keygen();
-        // path_elements has wrong depth
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH + 1];
-        let witness = make_single_witness_with_path_elements(
-            id,
-            path_elements,
-            Fr::from(1u64),
-            Fr::from(1u64),
-            Fr::from(1u64),
-        );
-
-        let backend = make_backend();
-        assert!(backend.generate_proof(witness).is_err());
-    }
-
-    #[test]
-    fn test_generate_and_verify_multi() {
-        let (identity_secret, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-        let message_ids: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        let selector_used = vec![true; DEFAULT_MAX_OUT];
-
-        let witness = make_multi_witness_with_path_elements(
-            identity_secret,
-            path_elements,
-            message_ids,
-            selector_used,
-            Fr::from(42u64),
-            Fr::from(100u64),
-        );
-
-        let backend = make_multi_backend();
-        let (proof, values) = backend.generate_proof(witness).unwrap();
-        let verified = backend.verify(&proof, &values).unwrap();
-        assert!(verified);
-    }
-
-    #[test]
-    fn test_generate_and_verify_multi_partial_selector() {
-        // Verifies that proofs with only some slots active (selector_used has false entries)
-        // generate and verify correctly. This catches selector-multiplication bugs in proof values.
-        let (identity_secret, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-        // Only slots 0 and 2 active (out of 4)
-        let message_ids: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        let selector_used = vec![true, false, true, false];
-
-        let witness = make_multi_witness_with_path_elements(
-            identity_secret,
-            path_elements,
-            message_ids,
-            selector_used,
-            Fr::from(42u64),
-            Fr::from(100u64),
-        );
-
-        let backend = make_multi_backend();
-        let (proof, values) = backend.generate_proof(witness).unwrap();
-        let verified = backend.verify(&proof, &values).unwrap();
-        assert!(verified);
-    }
-
-    #[test]
     fn test_recover_secret_multi_x_multi() {
-        let (identity_secret, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-
-        // Two multi proofs: same identity + external_nullifier, same message_id[0], different x
-        let message_ids: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        let selector_used = vec![true; DEFAULT_MAX_OUT];
-
-        let w1 = make_multi_witness_with_path_elements(
-            identity_secret.clone(),
-            path_elements.clone(),
-            message_ids.clone(),
-            selector_used.clone(),
+        let (id, _) = keygen();
+        let v1 = values(multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
             Fr::from(11u64),
             Fr::from(200u64),
-        );
-        let w2 = make_multi_witness_with_path_elements(
-            identity_secret.clone(),
-            path_elements,
-            message_ids,
-            selector_used,
+        ));
+        let v2 = values(multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
             Fr::from(22u64),
             Fr::from(200u64),
-        );
-
-        let backend = make_multi_backend();
-        let (_, values1) = backend.generate_proof(w1).unwrap();
-        let (_, values2) = backend.generate_proof(w2).unwrap();
-
-        let recovered = values1.recover_secret(&values2).unwrap();
-        assert_eq!(*recovered, *identity_secret);
-    }
-
-    #[test]
-    fn test_recover_secret_single_x_multi() {
-        let (identity_secret, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-        let external_nullifier = Fr::from(300u64);
-
-        // Single proof using message_id=1
-        let w_single = make_single_witness_with_path_elements(
-            identity_secret.clone(),
-            path_elements.clone(),
-            Fr::from(1u64),
-            Fr::from(11u64),
-            external_nullifier,
-        );
-
-        // Multi proof with message_ids including 1, same external_nullifier, different x
-        let message_ids: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        let selector_used = vec![true; DEFAULT_MAX_OUT];
-        let w_multi = make_multi_witness_with_path_elements(
-            identity_secret.clone(),
-            path_elements,
-            message_ids,
-            selector_used,
-            Fr::from(22u64),
-            external_nullifier,
-        );
-
-        let single_backend = make_backend();
-        let multi_backend = make_multi_backend();
-
-        let (_, single_values) = single_backend.generate_proof(w_single).unwrap();
-        let (_, multi_values) = multi_backend.generate_proof(w_multi).unwrap();
-
-        // single x multi
-        let recovered = single_values.recover_secret(&multi_values).unwrap();
-        assert_eq!(*recovered, *identity_secret);
-
-        // multi x single (symmetric)
-        let recovered2 = multi_values.recover_secret(&single_values).unwrap();
-        assert_eq!(*recovered2, *identity_secret);
+        ));
+        assert_eq!(*v1.recover_secret(&v2).unwrap(), *id);
     }
 
     #[test]
     fn test_recover_secret_multi_mismatched_nullifier_fails() {
         let (id, _) = keygen();
-        let path_elements = vec![Fr::from(0u64); DEFAULT_TREE_DEPTH];
-
-        // Two multi proofs with non-overlapping message_ids
-        let message_ids1: Vec<Fr> = (1..=DEFAULT_MAX_OUT).map(|i| Fr::from(i as u64)).collect();
-        let message_ids2: Vec<Fr> = (1..=DEFAULT_MAX_OUT)
+        let ids2: Vec<Fr> = (1..=DEFAULT_MAX_OUT)
             .map(|i| Fr::from((i + DEFAULT_MAX_OUT) as u64))
             .collect();
-        let selector_used = vec![true; DEFAULT_MAX_OUT];
-
-        let w1 = make_multi_witness_with_path_elements(
+        let v1 = values(multi_witness(
             id.clone(),
-            path_elements.clone(),
-            message_ids1,
-            selector_used.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
             Fr::from(11u64),
             Fr::from(200u64),
-        );
-        let w2 = make_multi_witness_with_path_elements(
+        ));
+        let v2 = values(multi_witness(
             id,
-            path_elements,
-            message_ids2,
-            selector_used,
+            default_path(),
+            ids2,
+            vec![true; DEFAULT_MAX_OUT],
             Fr::from(22u64),
             Fr::from(200u64),
-        );
-
-        let backend = make_multi_backend();
-        let (_, v1) = backend.generate_proof(w1).unwrap();
-        let (_, v2) = backend.generate_proof(w2).unwrap();
-
+        ));
         assert!(v1.recover_secret(&v2).is_err());
     }
 
     #[test]
-    fn test_multi_message_ids_wrong_count_fails() {
-        // message_ids.len() == 2 but graph.max_out == DEFAULT_MAX_OUT (4)
+    fn test_recover_secret_single_x_multi() {
         let (id, _) = keygen();
-        let message_ids = vec![Fr::from(1u64), Fr::from(2u64)];
-        let selector_used = vec![true, true];
-        let witness = make_multi_witness_with_path_elements(
+        let ext = Fr::from(300u64);
+        let sv = values(single_witness(
+            id.clone(),
+            default_path(),
+            Fr::from(1u64),
+            Fr::from(11u64),
+            ext,
+        ));
+        let mv = values(multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(22u64),
+            ext,
+        ));
+        assert_eq!(*sv.recover_secret(&mv).unwrap(), *id);
+        assert_eq!(*mv.recover_secret(&sv).unwrap(), *id);
+    }
+
+    #[test]
+    fn test_rlnv3_stateless_single_generate_and_verify() {
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
+        let (id, _) = keygen();
+        let witness = single_witness(
             id,
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            message_ids,
-            selector_used,
+            default_path(),
+            Fr::from(1u64),
             Fr::from(42u64),
             Fr::from(100u64),
         );
-        let backend = make_multi_backend();
-        assert!(backend.generate_proof(witness).is_err());
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        assert!(rln.verify(&proof, &values(witness)).unwrap());
+    }
+
+    #[test]
+    fn test_rlnv3_stateless_multi_generate_and_verify() {
+        let rln = make_rln(zkey_multi_v1(), graph_multi_v1());
+        let (id, _) = keygen();
+        let witness = multi_witness(
+            id,
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(42u64),
+            Fr::from(100u64),
+        );
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        assert!(rln.verify(&proof, &values(witness)).unwrap());
+    }
+
+    #[test]
+    fn test_rlnv3_stateless_recover_secret_single() {
+        let (id, _) = keygen();
+        let w1 = single_witness(
+            id.clone(),
+            default_path(),
+            Fr::from(1u64),
+            Fr::from(11u64),
+            Fr::from(200u64),
+        );
+        let w2 = single_witness(
+            id.clone(),
+            default_path(),
+            Fr::from(1u64),
+            Fr::from(22u64),
+            Fr::from(200u64),
+        );
+        let v1 = values(w1);
+        let v2 = values(w2);
+        assert_eq!(*v1.recover_secret(&v2).unwrap(), *id);
+    }
+
+    #[test]
+    fn test_rlnv3_stateless_recover_secret_cross_mode() {
+        let (id, _) = keygen();
+        let ext = Fr::from(300u64);
+        let sv = values(single_witness(
+            id.clone(),
+            default_path(),
+            Fr::from(1u64),
+            Fr::from(11u64),
+            ext,
+        ));
+        let mv = values(multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(22u64),
+            ext,
+        ));
+        assert_eq!(*sv.recover_secret(&mv).unwrap(), *id);
+        assert_eq!(*mv.recover_secret(&sv).unwrap(), *id);
+    }
+
+    #[test]
+    fn test_v3_partial_and_finish_single() {
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
+        let (id, _) = keygen();
+        let witness = single_witness(
+            id.clone(),
+            default_path(),
+            Fr::from(1u64),
+            Fr::from(42u64),
+            Fr::from(100u64),
+        );
+        let partial = RLNPartialWitnessInputV3::new(
+            id,
+            Fr::from(10u64),
+            default_path(),
+            vec![0u8; DEFAULT_TREE_DEPTH],
+        )
+        .unwrap();
+        let partial_proof = rln.generate_partial_proof(partial).unwrap();
+        let proof = rln.finish_proof(partial_proof, witness.clone()).unwrap();
+        assert!(rln.verify(&proof, &values(witness)).unwrap());
+    }
+
+    #[test]
+    fn test_v3_partial_and_finish_multi() {
+        let rln = make_rln(zkey_multi_v1(), graph_multi_v1());
+        let (id, _) = keygen();
+        let witness = multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(42u64),
+            Fr::from(100u64),
+        );
+        let partial = RLNPartialWitnessInputV3::new(
+            id,
+            Fr::from(10u64),
+            default_path(),
+            vec![0u8; DEFAULT_TREE_DEPTH],
+        )
+        .unwrap();
+        let partial_proof = rln.generate_partial_proof(partial).unwrap();
+        let proof = rln.finish_proof(partial_proof, witness.clone()).unwrap();
+        assert!(rln.verify(&proof, &values(witness)).unwrap());
+    }
+
+    #[test]
+    fn test_v3_partial_and_finish_verifies() {
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
+        let (id, _) = keygen();
+        let witness = single_witness(
+            id.clone(),
+            default_path(),
+            Fr::from(1u64),
+            Fr::from(55u64),
+            Fr::from(999u64),
+        );
+        let partial = RLNPartialWitnessInputV3::new(
+            id,
+            Fr::from(10u64),
+            default_path(),
+            vec![0u8; DEFAULT_TREE_DEPTH],
+        )
+        .unwrap();
+        let partial_proof = rln.generate_partial_proof(partial).unwrap();
+        let proof = rln.finish_proof(partial_proof, witness.clone()).unwrap();
+        assert!(rln.verify(&proof, &values(witness)).unwrap());
     }
 
     #[test]
     fn test_partial_witness_depth_mismatch_fails() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
         let (id, _) = keygen();
-        let partial_witness = RLNPartialWitnessInputV3::new(
+        let partial = RLNPartialWitnessInputV3::new(
             id,
             Fr::from(10u64),
             vec![Fr::from(0u64); DEFAULT_TREE_DEPTH + 1],
             vec![0u8; DEFAULT_TREE_DEPTH + 1],
         )
         .unwrap();
-        assert!(rln.generate_partial_proof(partial_witness).is_err());
+        assert!(rln.generate_partial_proof(partial).is_err());
     }
 
     #[test]
     fn test_finish_proof_wrong_witness_depth_fails() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
         let (id, _) = keygen();
-        let partial_witness = RLNPartialWitnessInputV3::new(
+        let partial = RLNPartialWitnessInputV3::new(
             id.clone(),
             Fr::from(10u64),
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
+            default_path(),
             vec![0u8; DEFAULT_TREE_DEPTH],
         )
         .unwrap();
-        let partial_proof = rln.generate_partial_proof(partial_witness).unwrap();
-        // witness with wrong depth — valid as a struct but mismatches graph
-        let bad_witness = make_single_witness_with_path_elements(
+        let partial_proof = rln.generate_partial_proof(partial).unwrap();
+        let bad_witness = single_witness(
             id,
             vec![Fr::from(0u64); DEFAULT_TREE_DEPTH + 1],
             Fr::from(1u64),
@@ -534,250 +461,180 @@ mod test {
     }
 
     #[test]
-    fn test_v3_new_with_params_invalid_zkey() {
-        let err = RLNV3::<Stateless, ArkGroth16Backend>::new_with_params(vec![], vec![1, 2, 3])
-            .err()
-            .unwrap();
-        assert!(matches!(err, RLNError::ZKey(_)));
-    }
-
-    #[test]
-    fn test_v3_new_with_params_invalid_graph() {
-        let valid_zkey = include_bytes!("../resources/tree_depth_20/rln_final.arkzkey").to_vec();
-        let err = RLNV3::<Stateless, ArkGroth16Backend>::new_with_params(valid_zkey, vec![0u8; 50])
-            .err()
-            .unwrap();
-        assert!(matches!(err, RLNError::Graph(_)));
-    }
-
-    #[test]
-    fn test_v3_groth16_proof_single() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
+    fn test_v3_verify_with_roots_empty_skips_root_check() {
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
         let (id, _) = keygen();
-        let witness = make_single_witness(id, Fr::from(42u64), Fr::from(100u64), Fr::from(1u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        assert!(rln.verify(&proof, &values).unwrap());
+        let x = Fr::from(42u64);
+        let witness = single_witness(id, default_path(), Fr::from(1u64), x, Fr::from(100u64));
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        assert!(rln.verify_with_roots(&proof, &vals, &x, &[]).unwrap());
     }
 
     #[test]
-    fn test_v3_groth16_proof_multi() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_multi();
+    fn test_v3_verify_with_roots_correct_root_passes() {
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
         let (id, _) = keygen();
-        let witness = make_multi_witness(id, Fr::from(42u64), Fr::from(100u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        assert!(rln.verify(&proof, &values).unwrap());
+        let x = Fr::from(42u64);
+        let witness = single_witness(id, default_path(), Fr::from(1u64), x, Fr::from(100u64));
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        let root = vals.root();
+        assert!(rln.verify_with_roots(&proof, &vals, &x, &[root]).unwrap());
     }
 
     #[test]
-    fn test_v3_partial_and_finish_single() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
+    fn test_v3_verify_with_roots_wrong_root_fails() {
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
         let (id, _) = keygen();
-        let witness = make_single_witness(
-            id.clone(),
-            Fr::from(42u64),
+        let x = Fr::from(42u64);
+        let witness = single_witness(id, default_path(), Fr::from(1u64), x, Fr::from(100u64));
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        assert!(matches!(
+            rln.verify_with_roots(&proof, &vals, &x, &[Fr::from(9999u64)]),
+            Err(RLNError::Verify(VerifyError::InvalidRoot))
+        ));
+    }
+
+    #[test]
+    fn test_v3_verify_with_roots_wrong_signal_fails() {
+        let rln = make_rln(zkey_single_v1(), graph_single_v1());
+        let (id, _) = keygen();
+        let x = Fr::from(42u64);
+        let witness = single_witness(id, default_path(), Fr::from(1u64), x, Fr::from(100u64));
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        assert!(matches!(
+            rln.verify_with_roots(&proof, &vals, &Fr::from(9999u64), &[]),
+            Err(RLNError::Verify(VerifyError::InvalidSignal))
+        ));
+    }
+
+    #[test]
+    fn test_v3_verify_with_roots_multi_correct_root_passes() {
+        let rln = make_rln(zkey_multi_v1(), graph_multi_v1());
+        let (id, _) = keygen();
+        let x = Fr::from(42u64);
+        let witness = multi_witness(
+            id,
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            x,
             Fr::from(100u64),
-            Fr::from(1u64),
         );
-        let partial_witness = RLNPartialWitnessInputV3::new(
-            id,
-            Fr::from(10u64),
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            vec![0u8; DEFAULT_TREE_DEPTH],
-        )
-        .unwrap();
-        let partial_proof = rln.generate_partial_proof(partial_witness).unwrap();
-        // Compute values from the witness before finish_proof consumes it
-        let (_, values) = rln.generate_proof(witness.clone()).unwrap();
-        let proof = rln.finish_proof(partial_proof, witness).unwrap();
-        assert!(rln.verify(&proof, &values).unwrap());
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        let root = vals.root();
+        assert!(rln.verify_with_roots(&proof, &vals, &x, &[root]).unwrap());
     }
 
     #[test]
-    fn test_v3_partial_and_finish_verifies() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
+    fn test_v3_verify_with_roots_multi_wrong_root_fails() {
+        let rln = make_rln(zkey_multi_v1(), graph_multi_v1());
         let (id, _) = keygen();
-        let witness = make_single_witness(
-            id.clone(),
-            Fr::from(55u64),
-            Fr::from(999u64),
-            Fr::from(1u64),
+        let x = Fr::from(42u64);
+        let witness = multi_witness(
+            id,
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            x,
+            Fr::from(100u64),
         );
-        let partial_witness = RLNPartialWitnessInputV3::new(
-            id,
-            Fr::from(10u64),
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            vec![0u8; DEFAULT_TREE_DEPTH],
-        )
-        .unwrap();
-        let partial_proof = rln.generate_partial_proof(partial_witness).unwrap();
-        let proof = rln.finish_proof(partial_proof, witness.clone()).unwrap();
-        let values = rln.generate_proof(witness).unwrap().1;
-        assert!(rln.verify(&proof, &values).unwrap());
-    }
-
-    #[test]
-    fn test_v3_partial_and_finish_multi() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_multi();
-        let (id, _) = keygen();
-        let witness = make_multi_witness(id.clone(), Fr::from(42u64), Fr::from(100u64));
-        let partial_witness = RLNPartialWitnessInputV3::new(
-            id,
-            Fr::from(10u64),
-            vec![Fr::from(0u64); DEFAULT_TREE_DEPTH],
-            vec![0u8; DEFAULT_TREE_DEPTH],
-        )
-        .unwrap();
-        let partial_proof = rln.generate_partial_proof(partial_witness).unwrap();
-        let (_, values) = rln.generate_proof(witness.clone()).unwrap();
-        let proof = rln.finish_proof(partial_proof, witness).unwrap();
-        assert!(rln.verify(&proof, &values).unwrap());
+        let proof = rln.generate_proof_from_witness(&witness).unwrap();
+        let vals = values(witness);
+        assert!(matches!(
+            rln.verify_with_roots(&proof, &vals, &x, &[Fr::from(9999u64)]),
+            Err(RLNError::Verify(VerifyError::InvalidRoot))
+        ));
     }
 
     #[test]
     fn test_v3_recover_id_secret_single() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
         let (id, _) = keygen();
-        let external_nullifier = Fr::from(100u64);
-        let w1 = make_single_witness(
+        let ext = Fr::from(100u64);
+        let v1 = values(single_witness(
             id.clone(),
+            default_path(),
+            Fr::from(1u64),
             Fr::from(11u64),
-            external_nullifier,
-            Fr::from(1u64),
-        );
-        let w2 = make_single_witness(
+            ext,
+        ));
+        let v2 = values(single_witness(
             id.clone(),
-            Fr::from(22u64),
-            external_nullifier,
+            default_path(),
             Fr::from(1u64),
-        );
-        let (_, v1) = rln.generate_proof(w1).unwrap();
-        let (_, v2) = rln.generate_proof(w2).unwrap();
-        let recovered = v1.recover_secret(&v2).unwrap();
-        assert_eq!(*recovered, *id);
+            Fr::from(22u64),
+            ext,
+        ));
+        assert_eq!(*v1.recover_secret(&v2).unwrap(), *id);
     }
 
     #[test]
     fn test_v3_recover_id_secret_multi() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_multi();
         let (id, _) = keygen();
-        let external_nullifier = Fr::from(100u64);
-        let w1 = make_multi_witness(id.clone(), Fr::from(11u64), external_nullifier);
-        let w2 = make_multi_witness(id.clone(), Fr::from(22u64), external_nullifier);
-        let (_, v1) = rln.generate_proof(w1).unwrap();
-        let (_, v2) = rln.generate_proof(w2).unwrap();
-        let recovered = v1.recover_secret(&v2).unwrap();
-        assert_eq!(*recovered, *id);
+        let ext = Fr::from(100u64);
+        let v1 = values(multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(11u64),
+            ext,
+        ));
+        let v2 = values(multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(22u64),
+            ext,
+        ));
+        assert_eq!(*v1.recover_secret(&v2).unwrap(), *id);
     }
 
     #[test]
     fn test_v3_recover_id_secret_cross_mode() {
-        let rln_s = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
-        let rln_m = RLNV3::<Stateless, ArkGroth16Backend>::new_multi();
         let (id, _) = keygen();
-        let external_nullifier = Fr::from(300u64);
-        let w_single = make_single_witness(
+        let ext = Fr::from(300u64);
+        let sv = values(single_witness(
             id.clone(),
-            Fr::from(11u64),
-            external_nullifier,
+            default_path(),
             Fr::from(1u64),
-        );
-        let w_multi = make_multi_witness(id.clone(), Fr::from(22u64), external_nullifier);
-        let (_, sv) = rln_s.generate_proof(w_single).unwrap();
-        let (_, mv) = rln_m.generate_proof(w_multi).unwrap();
+            Fr::from(11u64),
+            ext,
+        ));
+        let mv = values(multi_witness(
+            id.clone(),
+            default_path(),
+            default_message_ids(),
+            vec![true; DEFAULT_MAX_OUT],
+            Fr::from(22u64),
+            ext,
+        ));
         assert_eq!(*sv.recover_secret(&mv).unwrap(), *id);
         assert_eq!(*mv.recover_secret(&sv).unwrap(), *id);
     }
 
     #[test]
-    fn test_v3_verify_with_roots_empty_skips_root_check() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
-        let (id, _) = keygen();
-        let x = Fr::from(42u64);
-        let witness = make_single_witness(id, x, Fr::from(100u64), Fr::from(1u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        // empty roots -> root check skipped, should succeed
-        assert!(rln.verify_with_roots(&proof, &values, &x, &[]).unwrap());
+    fn test_v3_new_with_params_invalid_zkey() {
+        assert!(matches!(
+            RLNV3::<Stateless, ArkGroth16BackendWithGraph>::new_with_params(vec![], vec![1, 2, 3]),
+            Err(RLNError::ZKey(_))
+        ));
     }
 
     #[test]
-    fn test_v3_verify_with_roots_correct_root_passes() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
-        let (id, _) = keygen();
-        let x = Fr::from(42u64);
-        let witness = make_single_witness(id, x, Fr::from(100u64), Fr::from(1u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        let root = values.root();
-        assert!(rln.verify_with_roots(&proof, &values, &x, &[root]).unwrap());
-    }
-
-    #[test]
-    fn test_v3_verify_with_roots_wrong_root_fails() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
-        let (id, _) = keygen();
-        let x = Fr::from(42u64);
-        let witness = make_single_witness(id, x, Fr::from(100u64), Fr::from(1u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        let wrong_root = Fr::from(9999u64);
-        let err = rln
-            .verify_with_roots(&proof, &values, &x, &[wrong_root])
-            .unwrap_err();
-        assert!(matches!(err, RLNError::Verify(VerifyError::InvalidRoot)));
-    }
-
-    #[test]
-    fn test_v3_verify_with_roots_wrong_signal_fails() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
-        let (id, _) = keygen();
-        let x = Fr::from(42u64);
-        let witness = make_single_witness(id, x, Fr::from(100u64), Fr::from(1u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        let wrong_x = Fr::from(9999u64);
-        let err = rln
-            .verify_with_roots(&proof, &values, &wrong_x, &[])
-            .unwrap_err();
-        assert!(matches!(err, RLNError::Verify(VerifyError::InvalidSignal)));
-    }
-
-    #[test]
-    fn test_v3_verify_with_roots_multi_correct_root_passes() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_multi();
-        let (id, _) = keygen();
-        let x = Fr::from(42u64);
-        let witness = make_multi_witness(id, x, Fr::from(100u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        let root = values.root();
-        assert!(rln.verify_with_roots(&proof, &values, &x, &[root]).unwrap());
-    }
-
-    #[test]
-    fn test_v3_verify_with_roots_multi_wrong_root_fails() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_multi();
-        let (id, _) = keygen();
-        let x = Fr::from(42u64);
-        let witness = make_multi_witness(id, x, Fr::from(100u64));
-        let (proof, values) = rln.generate_proof(witness).unwrap();
-        let err = rln
-            .verify_with_roots(&proof, &values, &x, &[Fr::from(9999u64)])
-            .unwrap_err();
-        assert!(matches!(err, RLNError::Verify(VerifyError::InvalidRoot)));
-    }
-
-    #[test]
-    fn test_v3_message_mode_single() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_single();
-        assert_eq!(rln.message_mode(), MessageMode::SingleV1);
-        assert_eq!(rln.max_out(), 1);
-    }
-
-    #[test]
-    fn test_v3_message_mode_multi() {
-        let rln = RLNV3::<Stateless, ArkGroth16Backend>::new_multi();
-        assert_eq!(
-            rln.message_mode(),
-            MessageMode::MultiV1 {
-                max_out: DEFAULT_MAX_OUT
-            }
-        );
-        assert_eq!(rln.max_out(), DEFAULT_MAX_OUT);
+    fn test_v3_new_with_params_invalid_graph() {
+        let valid_zkey = include_bytes!("../resources/tree_depth_20/rln_final.arkzkey").to_vec();
+        assert!(matches!(
+            RLNV3::<Stateless, ArkGroth16BackendWithGraph>::new_with_params(
+                valid_zkey,
+                vec![0u8; 50],
+            ),
+            Err(RLNError::Graph(_))
+        ));
     }
 }

--- a/rln/tests/serialize.rs
+++ b/rln/tests/serialize.rs
@@ -417,6 +417,25 @@ mod test {
     }
 
     #[test]
+    fn test_witness_v3_le_truncated_rejected() {
+        for w in [make_witness_input_single(), make_witness_input_multi()] {
+            let mut buf = Vec::new();
+            w.serialize_compressed(&mut buf).unwrap();
+            assert!(RLNWitnessInputV3::deserialize_compressed(&buf[..buf.len() - 1]).is_err());
+        }
+    }
+
+    #[test]
+    fn test_witness_v3_le_extra_bytes_accepted() {
+        for w in [make_witness_input_single(), make_witness_input_multi()] {
+            let mut buf = Vec::new();
+            w.serialize_compressed(&mut buf).unwrap();
+            buf.push(0xff);
+            assert!(RLNWitnessInputV3::deserialize_compressed(buf.as_slice()).is_ok());
+        }
+    }
+
+    #[test]
     fn test_witness_v3_single_be_roundtrip() {
         let w = make_witness_input_single();
         let mut buf = Vec::new();
@@ -448,6 +467,25 @@ mod test {
     }
 
     #[test]
+    fn test_witness_v3_be_truncated_rejected() {
+        for w in [make_witness_input_single(), make_witness_input_multi()] {
+            let mut buf = Vec::new();
+            w.serialize(&mut buf).unwrap();
+            assert!(RLNWitnessInputV3::deserialize(&buf[..buf.len() - 1]).is_err());
+        }
+    }
+
+    #[test]
+    fn test_witness_v3_be_extra_bytes_accepted() {
+        for w in [make_witness_input_single(), make_witness_input_multi()] {
+            let mut buf = Vec::new();
+            w.serialize(&mut buf).unwrap();
+            buf.push(0xff);
+            assert!(RLNWitnessInputV3::deserialize(buf.as_slice()).is_ok());
+        }
+    }
+
+    #[test]
     fn test_partial_witness_v3_le_compressed_roundtrip() {
         let pw = make_partial_witness();
         let mut buf = Vec::new();
@@ -458,6 +496,23 @@ mod test {
     }
 
     #[test]
+    fn test_partial_witness_v3_le_truncated_rejected() {
+        let pw = make_partial_witness();
+        let mut buf = Vec::new();
+        pw.serialize_compressed(&mut buf).unwrap();
+        assert!(RLNPartialWitnessInputV3::deserialize_compressed(&buf[..buf.len() - 1]).is_err());
+    }
+
+    #[test]
+    fn test_partial_witness_v3_le_extra_bytes_accepted() {
+        let pw = make_partial_witness();
+        let mut buf = Vec::new();
+        pw.serialize_compressed(&mut buf).unwrap();
+        buf.push(0xff);
+        assert!(RLNPartialWitnessInputV3::deserialize_compressed(buf.as_slice()).is_ok());
+    }
+
+    #[test]
     fn test_partial_witness_v3_be_roundtrip() {
         let pw = make_partial_witness();
         let mut buf = Vec::new();
@@ -465,6 +520,23 @@ mod test {
         assert_eq!(buf.len(), CanonicalSerializeBE::serialized_size(&pw));
         let deser = RLNPartialWitnessInputV3::deserialize(buf.as_slice()).unwrap();
         assert_eq!(pw, deser);
+    }
+
+    #[test]
+    fn test_partial_witness_v3_be_truncated_rejected() {
+        let pw = make_partial_witness();
+        let mut buf = Vec::new();
+        pw.serialize(&mut buf).unwrap();
+        assert!(RLNPartialWitnessInputV3::deserialize(&buf[..buf.len() - 1]).is_err());
+    }
+
+    #[test]
+    fn test_partial_witness_v3_be_extra_bytes_accepted() {
+        let pw = make_partial_witness();
+        let mut buf = Vec::new();
+        pw.serialize(&mut buf).unwrap();
+        buf.push(0xff);
+        assert!(RLNPartialWitnessInputV3::deserialize(buf.as_slice()).is_ok());
     }
 
     #[test]
@@ -501,12 +573,31 @@ mod test {
     }
 
     #[test]
-    fn test_proof_values_v3_single_le_invalid_tag_rejected() {
+    fn test_proof_values_v3_le_invalid_tag_rejected() {
         let pv = make_proof_values_single();
         let mut buf = Vec::new();
         pv.serialize_compressed(&mut buf).unwrap();
         buf[0] = 99; // unknown tag
         assert!(RLNProofValuesV3::deserialize_compressed(buf.as_slice()).is_err());
+    }
+
+    #[test]
+    fn test_proof_values_v3_le_truncated_rejected() {
+        for pv in [make_proof_values_single(), make_proof_values_multi()] {
+            let mut buf = Vec::new();
+            pv.serialize_compressed(&mut buf).unwrap();
+            assert!(RLNProofValuesV3::deserialize_compressed(&buf[..buf.len() - 1]).is_err());
+        }
+    }
+
+    #[test]
+    fn test_proof_values_v3_le_extra_bytes_accepted() {
+        for pv in [make_proof_values_single(), make_proof_values_multi()] {
+            let mut buf = Vec::new();
+            pv.serialize_compressed(&mut buf).unwrap();
+            buf.push(0xff);
+            assert!(RLNProofValuesV3::deserialize_compressed(buf.as_slice()).is_ok());
+        }
     }
 
     #[test]
@@ -532,11 +623,30 @@ mod test {
     }
 
     #[test]
-    fn test_proof_values_v3_multi_be_invalid_tag_rejected() {
+    fn test_proof_values_v3_be_invalid_tag_rejected() {
         let pv = make_proof_values_multi();
         let mut buf = Vec::new();
         pv.serialize(&mut buf).unwrap();
         buf[0] = 99; // unknown tag
         assert!(RLNProofValuesV3::deserialize(buf.as_slice()).is_err());
+    }
+
+    #[test]
+    fn test_proof_values_v3_be_truncated_rejected() {
+        for pv in [make_proof_values_single(), make_proof_values_multi()] {
+            let mut buf = Vec::new();
+            pv.serialize(&mut buf).unwrap();
+            assert!(RLNProofValuesV3::deserialize(&buf[..buf.len() - 1]).is_err());
+        }
+    }
+
+    #[test]
+    fn test_proof_values_v3_be_extra_bytes_accepted() {
+        for pv in [make_proof_values_single(), make_proof_values_multi()] {
+            let mut buf = Vec::new();
+            pv.serialize(&mut buf).unwrap();
+            buf.push(0xff);
+            assert!(RLNProofValuesV3::deserialize(buf.as_slice()).is_ok());
+        }
     }
 }

--- a/rln/tests/serialize.rs
+++ b/rln/tests/serialize.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod test {
     use ark_ff::{BigInteger, PrimeField};
-    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
     use ark_std::{rand::thread_rng, UniformRand};
     use num_bigint::BigUint;
     use rln::prelude::*;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,7 +17,7 @@ num-bigint = { version = "0.4.6", default-features = false }
 pmtree = { package = "vacp2p_pmtree", version = "2.0.3", optional = true }
 sled = "0.34.7"
 serde_json = "1.0.149"
-rayon = "1.11.0"
+rayon = "1.12.0"
 thiserror = "2.0.18"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
## Changes:
- Enhanced ArkGroth16Backend and RLNWitnessInputV3 with WASM support and new methods
- Added RLNProofV3 type, Result-returning V3 accessors, new error enum, WASM constructor, and generate_proof_from_calculated_witness method on RLNZkProof trait.
- Enhanced RLNProofV3 with serialization traits and updated related tests.
- Migrated WASM bindings to V3 types, and added truncate/extra byte tests for witness and proof values