### PR TITLE
chore(release): v2.0.2

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -134,12 +134,12 @@ jobs:
       - name: Build rln-wasm package
         run: |
           if [[ ${{ matrix.feature }} == "parallel" ]]; then
-            env CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base" \
+            env CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C link-arg=--export=__heap_base" \
             rustup run nightly wasm-pack build --release --target web --scope waku \
             --features parallel -Z build-std=panic_abort,std
             sed -i.bak 's/rln-wasm/zerokit-rln-wasm-parallel/g' pkg/package.json && rm pkg/package.json.bak
           elif [[ ${{ matrix.feature }} == "parallel-multi-message-id" ]]; then
-            env CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base" \
+            env CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C link-arg=--export=__heap_base" \
             rustup run nightly wasm-pack build --release --target web --scope waku \
             --features parallel,multi-message-id -Z build-std=panic_abort,std
             sed -i.bak 's/rln-wasm/zerokit-rln-wasm-parallel-multi-message-id/g' pkg/package.json && rm pkg/package.json.bak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rln"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -28,7 +28,7 @@ in targetPlatformPkgs.rustPlatform.buildRustPackage {
 
   inherit src;
 
-  cargoHash = "sha256-WXxQ8mAPD/mPBSnLrunhbDyCAQ0D82t1MILbo+Vfcqk=";
+  cargoHash = "sha256-3wFnSJYUSQ01tQLe4nZGUZdoU1A9vsl9dpJU3vPeiHo=";
 
   nativeBuildInputs = with pkgs; [ rust-cbindgen ];
 

--- a/rln-cli/Cargo.lock
+++ b/rln-cli/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "rln"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/rln-cli/Cargo.toml
+++ b/rln-cli/Cargo.toml
@@ -22,7 +22,7 @@ name = "partial"
 path = "src/examples/partial.rs"
 
 [dependencies]
-rln = { path = "../rln", version = "2.0.1", default-features = false }
+rln = { path = "../rln", version = "2.0.2", default-features = false }
 zerokit_utils = { path = "../utils", version = "1.2.0", default-features = false }
 clap = { version = "4.6.0", features = ["cargo", "derive", "env"] }
 

--- a/rln-wasm/Cargo.lock
+++ b/rln-wasm/Cargo.lock
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "rln"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/rln-wasm/Cargo.toml
+++ b/rln-wasm/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-rln = { path = "../rln", version = "2.0.1", default-features = false, features = [
+rln = { path = "../rln", version = "2.0.2", default-features = false, features = [
     "stateless",
 ] }
 zerokit_utils = { path = "../utils", version = "1.2.0", default-features = false }

--- a/rln-wasm/Makefile.toml
+++ b/rln-wasm/Makefile.toml
@@ -40,7 +40,7 @@ script = "sed -i.bak 's/rln-wasm/zerokit-rln-wasm/g' pkg/package.json && rm pkg/
 [tasks.pack_build_parallel]
 command = "env"
 args = [
-    "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS=-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base",
+    "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS=-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C link-arg=--export=__heap_base",
     "rustup",
     "run",
     "nightly",
@@ -79,7 +79,7 @@ script = "sed -i.bak 's/rln-wasm/zerokit-rln-wasm-multi-message-id/g' pkg/packag
 [tasks.pack_build_parallel_multi_message_id]
 command = "env"
 args = [
-    "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS=-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base",
+    "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS=-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C link-arg=--export=__heap_base",
     "rustup",
     "run",
     "nightly",
@@ -152,7 +152,7 @@ dependencies = ["build"]
 [tasks.test_parallel]
 command = "env"
 args = [
-    "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS=-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base",
+    "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS=-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C link-arg=--export=__heap_base",
     "rustup",
     "run",
     "nightly",

--- a/rln/Cargo.toml
+++ b/rln/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rln"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "APIs to manage, compute and verify zkSNARK proofs and RLN primitives"

--- a/rln/ffi_nim_examples/main.nim
+++ b/rln/ffi_nim_examples/main.nim
@@ -413,6 +413,27 @@ proc ffi_bytes_le_to_rln_proof*(bytes: ptr Vec_uint8): CResultProofPtrVecU8 {.im
     cdecl, dynlib: RLN_LIB.}
 proc ffi_bytes_be_to_rln_proof*(bytes: ptr Vec_uint8): CResultProofPtrVecU8 {.importc: "ffi_bytes_be_to_rln_proof",
     cdecl, dynlib: RLN_LIB.}
+when defined(ffiMultiMessageId):
+  proc ffi_rln_proof_new*(
+    groth16_bytes: ptr Vec_uint8,
+    root: ptr CFr,
+    external_nullifier: ptr CFr,
+    x: ptr CFr,
+    ys: ptr Vec_CFr,
+    nullifiers: ptr Vec_CFr,
+    selector_used: ptr Vec_bool
+  ): CResultProofPtrVecU8 {.importc: "ffi_rln_proof_new", cdecl,
+      dynlib: RLN_LIB.}
+else:
+  proc ffi_rln_proof_new*(
+    groth16_bytes: ptr Vec_uint8,
+    root: ptr CFr,
+    external_nullifier: ptr CFr,
+    x: ptr CFr,
+    y: ptr CFr,
+    nullifier: ptr CFr
+  ): CResultProofPtrVecU8 {.importc: "ffi_rln_proof_new", cdecl,
+      dynlib: RLN_LIB.}
 proc ffi_rln_proof_free*(p: ptr FFI_RLNProof) {.importc: "ffi_rln_proof_free",
     cdecl, dynlib: RLN_LIB.}
 
@@ -460,6 +481,25 @@ proc ffi_bytes_le_to_rln_proof_values*(bytes: ptr Vec_uint8): CResultRLNProofVal
     cdecl, dynlib: RLN_LIB.}
 proc ffi_bytes_be_to_rln_proof_values*(bytes: ptr Vec_uint8): CResultRLNProofValuesPtrVecU8 {.importc: "ffi_bytes_be_to_rln_proof_values",
     cdecl, dynlib: RLN_LIB.}
+when defined(ffiMultiMessageId):
+  proc ffi_rln_proof_values_new*(
+    root: ptr CFr,
+    external_nullifier: ptr CFr,
+    x: ptr CFr,
+    ys: ptr Vec_CFr,
+    nullifiers: ptr Vec_CFr,
+    selector_used: ptr Vec_bool
+  ): ptr FFI_RLNProofValues {.importc: "ffi_rln_proof_values_new", cdecl,
+      dynlib: RLN_LIB.}
+else:
+  proc ffi_rln_proof_values_new*(
+    root: ptr CFr,
+    external_nullifier: ptr CFr,
+    x: ptr CFr,
+    y: ptr CFr,
+    nullifier: ptr CFr
+  ): ptr FFI_RLNProofValues {.importc: "ffi_rln_proof_values_new", cdecl,
+      dynlib: RLN_LIB.}
 proc ffi_rln_proof_values_free*(pv: ptr FFI_RLNProofValues) {.importc: "ffi_rln_proof_values_free",
     cdecl, dynlib: RLN_LIB.}
 

--- a/rln/src/ffi/ffi_rln.rs
+++ b/rln/src/ffi/ffi_rln.rs
@@ -1018,6 +1018,44 @@ pub fn ffi_bytes_be_to_rln_proof_values(
     }
 }
 
+#[cfg(not(feature = "multi-message-id"))]
+#[ffi_export]
+pub fn ffi_rln_proof_values_new(
+    root: &CFr,
+    external_nullifier: &CFr,
+    x: &CFr,
+    y: &CFr,
+    nullifier: &CFr,
+) -> repr_c::Box<FFI_RLNProofValues> {
+    Box_::new(FFI_RLNProofValues(RLNProofValues::new(
+        root.0,
+        x.0,
+        external_nullifier.0,
+        y.0,
+        nullifier.0,
+    )))
+}
+
+#[cfg(feature = "multi-message-id")]
+#[ffi_export]
+pub fn ffi_rln_proof_values_new(
+    root: &CFr,
+    external_nullifier: &CFr,
+    x: &CFr,
+    ys: &repr_c::Vec<CFr>,
+    nullifiers: &repr_c::Vec<CFr>,
+    selector_used: &repr_c::Vec<bool>,
+) -> repr_c::Box<FFI_RLNProofValues> {
+    Box_::new(FFI_RLNProofValues(RLNProofValues::new(
+        root.0,
+        x.0,
+        external_nullifier.0,
+        ys.iter().map(|c| c.0).collect(),
+        nullifiers.iter().map(|c| c.0).collect(),
+        selector_used.iter().copied().collect(),
+    )))
+}
+
 #[ffi_export]
 pub fn ffi_rln_proof_values_free(proof_values: repr_c::Box<FFI_RLNProofValues>) {
     drop(proof_values);

--- a/rln/src/ffi/ffi_rln.rs
+++ b/rln/src/ffi/ffi_rln.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+use ark_serialize::CanonicalDeserialize;
 use num_bigint::BigInt;
 use safer_ffi::{boxed::Box_, derive_ReprC, ffi_export, prelude::repr_c};
 #[cfg(not(feature = "stateless"))]
@@ -293,6 +294,104 @@ pub fn ffi_bytes_be_to_rln_proof(
             ok: None,
             err: Some(err.to_string().into()),
         },
+    }
+}
+
+#[cfg(not(feature = "multi-message-id"))]
+#[ffi_export]
+pub fn ffi_rln_proof_new(
+    groth16_bytes: &repr_c::Vec<u8>,
+    root: &CFr,
+    external_nullifier: &CFr,
+    x: &CFr,
+    y: &CFr,
+    nullifier: &CFr,
+) -> CResult<repr_c::Box<FFI_RLNProof>, repr_c::String> {
+    if groth16_bytes.len() != COMPRESS_PROOF_SIZE {
+        return CResult {
+            ok: None,
+            err: Some(
+                format!(
+                    "Invalid Groth16 proof length: expected {} bytes, got {}",
+                    COMPRESS_PROOF_SIZE,
+                    groth16_bytes.len()
+                )
+                .into(),
+            ),
+        };
+    }
+
+    let proof = match Proof::deserialize_compressed(&groth16_bytes[..]) {
+        Ok(p) => p,
+        Err(err) => {
+            return CResult {
+                ok: None,
+                err: Some(err.to_string().into()),
+            }
+        }
+    };
+
+    let proof_values = RLNProofValues::new(root.0, x.0, external_nullifier.0, y.0, nullifier.0);
+
+    CResult {
+        ok: Some(Box_::new(FFI_RLNProof(RLNProof {
+            proof,
+            proof_values,
+        }))),
+        err: None,
+    }
+}
+
+#[cfg(feature = "multi-message-id")]
+#[ffi_export]
+pub fn ffi_rln_proof_new(
+    groth16_bytes: &repr_c::Vec<u8>,
+    root: &CFr,
+    external_nullifier: &CFr,
+    x: &CFr,
+    ys: &repr_c::Vec<CFr>,
+    nullifiers: &repr_c::Vec<CFr>,
+    selector_used: &repr_c::Vec<bool>,
+) -> CResult<repr_c::Box<FFI_RLNProof>, repr_c::String> {
+    if groth16_bytes.len() != COMPRESS_PROOF_SIZE {
+        return CResult {
+            ok: None,
+            err: Some(
+                format!(
+                    "Invalid Groth16 proof length: expected {} bytes, got {}",
+                    COMPRESS_PROOF_SIZE,
+                    groth16_bytes.len()
+                )
+                .into(),
+            ),
+        };
+    }
+
+    let proof = match Proof::deserialize_compressed(&groth16_bytes[..]) {
+        Ok(p) => p,
+        Err(err) => {
+            return CResult {
+                ok: None,
+                err: Some(err.to_string().into()),
+            }
+        }
+    };
+
+    let proof_values = RLNProofValues::new(
+        root.0,
+        x.0,
+        external_nullifier.0,
+        ys.iter().map(|c| c.0).collect(),
+        nullifiers.iter().map(|c| c.0).collect(),
+        selector_used.iter().copied().collect(),
+    );
+
+    CResult {
+        ok: Some(Box_::new(FFI_RLNProof(RLNProof {
+            proof,
+            proof_values,
+        }))),
+        err: None,
     }
 }
 

--- a/rln/src/pm_tree_adapter.rs
+++ b/rln/src/pm_tree_adapter.rs
@@ -284,7 +284,7 @@ impl ZerokitMerkleTree for PmTree {
         values: I,
     ) -> Result<(), ZerokitMerkleTreeError> {
         let v = values.into_iter().collect::<Vec<_>>();
-        self.tree.set_range(start, v.clone().into_iter())?;
+        self.tree.set_range(start, v.clone())?;
         for i in start..v.len() {
             self.cached_leaves_indices[i] = 1
         }

--- a/rln/tests/ffi.rs
+++ b/rln/tests/ffi.rs
@@ -1418,4 +1418,158 @@ mod test {
             "partial witness with zero user_message_limit should be rejected"
         );
     }
+
+    #[test]
+    fn test_ffi_rln_proof_new_roundtrip() {
+        let (ffi_rln_instance, witness) = setup_rln_with_witness();
+
+        let original = match ffi_generate_rln_proof(&ffi_rln_instance, &witness) {
+            CResult {
+                ok: Some(p),
+                err: None,
+            } => p,
+            _ => panic!("generate rln proof failed"),
+        };
+
+        let original_bytes = match ffi_rln_proof_to_bytes_le(&original) {
+            CResult {
+                ok: Some(b),
+                err: None,
+            } => b,
+            _ => panic!("serialize original proof failed"),
+        };
+
+        let proof_values = ffi_rln_proof_get_values(&original);
+        let root = ffi_rln_proof_values_get_root(&proof_values);
+        let x = ffi_rln_proof_values_get_x(&proof_values);
+        let external_nullifier = ffi_rln_proof_values_get_external_nullifier(&proof_values);
+        let y = match ffi_rln_proof_values_get_y(&proof_values) {
+            CResult {
+                ok: Some(v),
+                err: None,
+            } => v,
+            _ => panic!("get y failed"),
+        };
+        let nullifier = match ffi_rln_proof_values_get_nullifier(&proof_values) {
+            CResult {
+                ok: Some(v),
+                err: None,
+            } => v,
+            _ => panic!("get nullifier failed"),
+        };
+
+        // Wire layout: [outer_ver<1> | groth16<COMPRESS_PROOF_SIZE> | inner_ver<1> | ...]
+        let groth16_bytes: repr_c::Vec<u8> = original_bytes
+            .iter()
+            .skip(1)
+            .take(COMPRESS_PROOF_SIZE)
+            .copied()
+            .collect::<Vec<u8>>()
+            .into();
+
+        let reconstructed = match ffi_rln_proof_new(
+            &groth16_bytes,
+            &root,
+            &external_nullifier,
+            &x,
+            &y,
+            &nullifier,
+        ) {
+            CResult {
+                ok: Some(p),
+                err: None,
+            } => p,
+            CResult {
+                ok: None,
+                err: Some(e),
+            } => panic!("ffi_rln_proof_new failed: {}", e),
+            _ => unreachable!(),
+        };
+
+        let reconstructed_bytes = match ffi_rln_proof_to_bytes_le(&reconstructed) {
+            CResult {
+                ok: Some(b),
+                err: None,
+            } => b,
+            _ => panic!("re-serialize failed"),
+        };
+
+        assert_eq!(
+            original_bytes.iter().copied().collect::<Vec<u8>>(),
+            reconstructed_bytes.iter().copied().collect::<Vec<u8>>(),
+            "reconstructed proof must serialize identically to the original"
+        );
+
+        let tree_root = CFr::from(get_tree_root(&ffi_rln_instance));
+        let roots_vec: repr_c::Vec<CFr> = vec![tree_root].into();
+        let verify_result =
+            ffi_verify_with_roots(&ffi_rln_instance, &reconstructed, &roots_vec, &x);
+        assert!(
+            verify_result.ok,
+            "reconstructed proof must verify against the tree root"
+        );
+    }
+
+    #[test]
+    fn test_ffi_rln_proof_new_invalid_groth16_bytes() {
+        let zero = ffi_cfr_zero();
+
+        let short: repr_c::Vec<u8> = vec![0u8; COMPRESS_PROOF_SIZE - 1].into();
+        let result = ffi_rln_proof_new(&short, &zero, &zero, &zero, &zero, &zero);
+        assert!(
+            result.ok.is_none(),
+            "wrong-length groth16 bytes must be rejected"
+        );
+
+        let garbage: repr_c::Vec<u8> = vec![0xffu8; COMPRESS_PROOF_SIZE].into();
+        let result = ffi_rln_proof_new(&garbage, &zero, &zero, &zero, &zero, &zero);
+        assert!(
+            result.ok.is_none(),
+            "garbage groth16 bytes must fail to deserialize"
+        );
+    }
+
+    #[test]
+    fn test_ffi_rln_proof_values_new_roundtrip() {
+        let (ffi_rln_instance, witness) = setup_rln_with_witness();
+
+        let proof = match ffi_generate_rln_proof(&ffi_rln_instance, &witness) {
+            CResult {
+                ok: Some(p),
+                err: None,
+            } => p,
+            _ => panic!("generate rln proof failed"),
+        };
+
+        let original_pv = ffi_rln_proof_get_values(&proof);
+        let original_bytes = ffi_rln_proof_values_to_bytes_le(&original_pv);
+
+        let root = ffi_rln_proof_values_get_root(&original_pv);
+        let x = ffi_rln_proof_values_get_x(&original_pv);
+        let external_nullifier = ffi_rln_proof_values_get_external_nullifier(&original_pv);
+        let y = match ffi_rln_proof_values_get_y(&original_pv) {
+            CResult {
+                ok: Some(v),
+                err: None,
+            } => v,
+            _ => panic!("get y failed"),
+        };
+        let nullifier = match ffi_rln_proof_values_get_nullifier(&original_pv) {
+            CResult {
+                ok: Some(v),
+                err: None,
+            } => v,
+            _ => panic!("get nullifier failed"),
+        };
+
+        let reconstructed_pv =
+            ffi_rln_proof_values_new(&root, &external_nullifier, &x, &y, &nullifier);
+        let reconstructed_bytes = ffi_rln_proof_values_to_bytes_le(&reconstructed_pv);
+
+        assert_eq!(
+            original_bytes.iter().copied().collect::<Vec<u8>>(),
+            reconstructed_bytes.iter().copied().collect::<Vec<u8>>(),
+            "reconstructed proof values must serialize identically"
+        );
+    }
 }


### PR DESCRIPTION
## Description

- **`fix(nix)`** — refresh `nix/default.nix` cargoHash. The v2.0.1 tag shipped with a stale hash; cold nix builds failed because the cache-served FOD masked the mismatch. Verified hash with logos-delivery's downstream override.
- **`feat(rln)`** — add `ffi_rln_proof_new` and `ffi_rln_proof_values_new` constructors. `FFI_RLNProof` and `FFI_RLNProofValues` exposed `_get_*` accessors for every field but no `_new`, so downstream consumers
that decompose a proof into a struct (e.g. waku-rln-relay) had to hand-assemble the 290-byte wire layout and round-trip through `ffi_bytes_le_to_rln_proof`. Closes that asymmetry.
- **`fix(rln)`** — drop a redundant `.into_iter()` in `pm_tree_adapter::set_range` that newer clippy flags as `useless_conversion`. Was blocking CI on default and `multi-message-id` builds.

`FFI_RLNPartialProof` was deliberately not given a `_new` — it has no field accessors either, so there's no symmetry gap to close (the only construction path is `ffi_bytes_le_to_rln_partial_proof`).

## Test plan

- [ ] `cargo check` on default / `--features stateless --no-default-features` / `--features multi-message-id`
- [ ] `cargo clippy --all-targets --tests --release -- -D warnings` clean on all three feature combinations
- [ ] `cargo test --release -p rln --test ffi` — covers 3 new tests (`test_ffi_rln_proof_new_roundtrip`, `test_ffi_rln_proof_new_invalid_groth16_bytes`, `test_ffi_rln_proof_values_new_roundtrip`)
- [ ] Cold `nix build .#rln` succeeds without a hash-mismatch error
- [ ] `cargo run --features headers --bin generate-headers` produces an `rln.h` containing the two new functions