### PR TITLE
Add devcontainer for Zerokit development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,10 +52,7 @@ USER ubuntu
 # Add Cargo to the PATH so the IDE and terminal can find it
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
-# wasm toolchains via the Makefile - both the stable wasm32 target (default/utils
-# builds) and the nightly toolchain (parallel build + cargo make fmt), so the
-# container covers every rln-wasm variant.
-RUN make installdeps-wasm installdeps-wasm-parallel
-
-# Rust tooling (cargo-make, wasm-pack) via the Makefile.
-RUN make installdeps-tools
+# Toolchains via the Makefile (cmake/ninja and node already installed via apt
+# above, so the apt step is skipped and NO_NVM=1 keeps nvm out of the image).
+RUN make installdeps \
+    && make NO_NVM=1 installdeps-wasm installdeps-wasm-parallel

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,24 +1,42 @@
 FROM ubuntu:26.04
-# Set to 2 to force Docker to bypass the cache
-ARG CACHEBUST=1
 
-ENV DEBIAN_FRONTEND=noninteractive
+# Silence apt prompts during the build only. As an ARG (not ENV) it applies to
+# every build RUN but does not leak into the running container's interactive apt.
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+# Base packages, incl. the system build deps (cmake, ninja) the crates need.
+# No sudo: we build as root, and no-new-privileges (devcontainer.json) would
+# block setuid sudo at runtime anyway.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     build-essential \
-    sudo \
+    cmake \
+    ninja-build \
     jq \
-    && curl -fsSL https://deb.nodesource.com/setup_26.x | bash - \
+    make \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bring in the Makefile so the container reuses the same pinned versions and
+# install steps as the host and CI.
+WORKDIR /workspace
+COPY Makefile ./Makefile
+
+# Node.js: same major version as the Makefile's NODE_VERSION pin.
+RUN NODE_MAJOR="$(make -s print-NODE_MAJOR)" \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 ENV HOME=/home/ubuntu
 USER ubuntu
 
-# Install Rust using rustup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# Install Rust (stable) via rustup. The minimal profile skips the bundled
+# rust-docs (thousands of files that bloat the image); clippy and rust-src are
+# added explicitly to match CI clippy and give rust-analyzer std sources.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --profile minimal -c clippy -c rust-src
 
 # WORKAROUND: Appease JetBrains Settings Sync
 # The IDE expects the host's snap path. We symlink the container's binaries
@@ -34,14 +52,10 @@ USER ubuntu
 # Add Cargo to the PATH so the IDE and terminal can find it
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
-# Add nightly toolchain: rustfmt (nightly-only group_imports) and rust-src (parallel wasm build)
-RUN rustup toolchain install nightly \
-    --component rustfmt --component rust-src \
-    --target wasm32-unknown-unknown
-# Add cargo-make (for Makefile)
-RUN cargo install --locked cargo-make --version=0.37.24
-# Add wasm-pack (rln-wasm compilation)
-RUN cargo install --locked wasm-pack --version=0.15.0
+# wasm toolchains via the Makefile - both the stable wasm32 target (default/utils
+# builds) and the nightly toolchain (parallel build + cargo make fmt), so the
+# container covers every rln-wasm variant.
+RUN make installdeps-wasm installdeps-wasm-parallel
 
-# Set the default working directory
-WORKDIR /workspace
+# Rust tooling (cargo-make, wasm-pack) via the Makefile.
+RUN make installdeps-tools

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:26.04
+# Set to 2 to force Docker to bypass the cache
+ARG CACHEBUST=1
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    sudo \
+    jq \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/ubuntu
+USER ubuntu
+
+# Install Rust using rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# WORKAROUND: Appease JetBrains Settings Sync
+# The IDE expects the host's snap path. We symlink the container's binaries
+# to /snap/bin so RustRover finds them automatically.
+USER root
+RUN mkdir -p /snap/bin \
+    && ln -s $HOME/.cargo/bin/cargo /snap/bin/cargo \
+    && ln -s $HOME/.cargo/bin/rustc /snap/bin/rustc \
+    && ln -s $HOME/.cargo/bin/rustfmt /snap/bin/rustfmt \
+    && ln -s $HOME/.cargo/bin/rustup /snap/bin/rustup
+USER ubuntu
+
+# Add Cargo to the PATH so the IDE and terminal can find it
+ENV PATH="$HOME/.cargo/bin:$PATH"
+
+# Add cargo-make (for Makefile)
+RUN cargo install --locked cargo-make --version=0.37.24
+# Add wasm-pack (rln-wasm compilation)
+RUN cargo install --locked wasm-pack --version=0.15.0
+
+# Set the default working directory
+WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,13 @@ USER ubuntu
 # Add Cargo to the PATH so the IDE and terminal can find it
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
+# Add wasm32 target (rln-wasm compilation)
+RUN rustup target add wasm32-unknown-unknown
+# Add nightly toolchain: rustfmt (nightly-only group_imports) and rust-src (parallel wasm build)
+RUN rustup toolchain install nightly \
+    --component rustfmt --component rust-src \
+    --target wasm32-unknown-unknown
+
 # Add cargo-make (for Makefile)
 RUN cargo install --locked cargo-make --version=0.37.24
 # Add wasm-pack (rln-wasm compilation)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     build-essential \
     sudo \
     jq \
-    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_26.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Base packages, incl. the system build deps (cmake, ninja) the crates need.
 # No sudo: we build as root, and no-new-privileges (devcontainer.json) would
 # block setuid sudo at runtime anyway.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     git \
     build-essential \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,13 +34,10 @@ USER ubuntu
 # Add Cargo to the PATH so the IDE and terminal can find it
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
-# Add wasm32 target (rln-wasm compilation)
-RUN rustup target add wasm32-unknown-unknown
 # Add nightly toolchain: rustfmt (nightly-only group_imports) and rust-src (parallel wasm build)
 RUN rustup toolchain install nightly \
     --component rustfmt --component rust-src \
     --target wasm32-unknown-unknown
-
 # Add cargo-make (for Makefile)
 RUN cargo install --locked cargo-make --version=0.37.24
 # Add wasm-pack (rln-wasm compilation)

--- a/.devcontainer/Dockerfile.dockerignore
+++ b/.devcontainer/Dockerfile.dockerignore
@@ -1,0 +1,5 @@
+# BuildKit reads this file for .devcontainer/Dockerfile specifically, scoping
+# the build context. The Dockerfile only COPYs the Makefile, so ignore
+# everything else (notably target/ and .git/) to keep the context tiny.
+*
+!Makefile

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,10 @@
   "name": "Devcontainer Zerokit - Ubuntu 26.04",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": ".."
+    "context": "..",
+    // Pull prebuilt layers from the CI-published image so local builds reuse
+    // them instead of recompiling (see .github/workflows/devcontainer.yml).
+    "cacheFrom": "ghcr.io/vacp2p/zerokit-devcontainer"
   },
   // For IDE server and terminal
   "remoteUser": "ubuntu",
@@ -23,15 +26,16 @@
       ]
     }
   },
-  // Expose port to the host machine
-  "forwardPorts": [],
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "workspaceFolder": "/workspace",
   "runArgs": [
     // ---------------------------------------------------------
-    // SECURITY FEATURES (Uncomment to apply after testing)
+    // SECURITY FEATURES
     // ---------------------------------------------------------
-    // "--cap-drop=ALL",
-    // "--security-opt=no-new-privileges:true"
+    // Low-risk hardening, enabled by default.
+    "--security-opt=no-new-privileges:true"
+    // Dropping all capabilities can break IDE backends that need to write
+    // outside $HOME. Enable once verified in both VSCode and RustRover:
+    // "--cap-drop=ALL"
   ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,13 @@
   "customizations": {
     "jetbrains": {
       "backend": "RustRover"
+    },
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb"
+      ]
     }
   },
   // Expose port to the host machine

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "Devcontainer Zerokit - Ubuntu 26.04",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  // For IDE server and terminal
+  "remoteUser": "ubuntu",
+  // The container user
+  "containerUser": "ubuntu",
+  // Prevent error when building devcontainer in RustRover
+  // error: `ERROR: failed to build: resolve : lstat /tmp/uidUpdate-abcde: no such file or directory`
+  "updateRemoteUserUID": false,
+  "customizations": {
+    "jetbrains": {
+      "backend": "RustRover"
+    }
+  },
+  // Expose port to the host machine
+  "forwardPorts": [],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "workspaceFolder": "/workspace",
+  "runArgs": [
+    // ---------------------------------------------------------
+    // SECURITY FEATURES (Uncomment to apply after testing)
+    // ---------------------------------------------------------
+    // "--cap-drop=ALL",
+    // "--security-opt=no-new-privileges:true"
+  ]
+}

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,12 +36,12 @@
   color: B60205
 - name: infra
   description: Infra, devops, CI and related tasks
+  color: 006b75
 - name: milestone
   description: Milestone issue with a subset of issues within a specific track
   color: 1CC0B0
 
 # Waku Product labels
-  color: 277196
 - name: rqt:platforms
   description: Requirement coming from a platform
   color: A51BB5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Test rln-wasm on browser
         run: cargo make test_browser --release
         working-directory: rln-wasm
+      - name: Test rln-wasm utils on node
+        run: cargo make test_utils --release
+        working-directory: rln-wasm
 
   rln-wasm-parallel-test:
     name: Test - rln-wasm-parallel - ${{ matrix.platform }}
@@ -116,7 +119,7 @@ jobs:
         with:
           components: rustfmt
       - name: Install cargo-make
-        run: cargo install cargo-make
+        run: cargo install --locked cargo-make --version "$(make -s print-CARGO_MAKE_VERSION)"
       - name: Check formatting
         run: cargo make fmt_check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install dependencies
-        run: make installdeps
+        run: make installdeps installdeps-wasm
       - name: Build rln-wasm
         run: cargo make build
         working-directory: rln-wasm
@@ -88,15 +88,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rust-src
-          targets: wasm32-unknown-unknown
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install dependencies
-        run: make installdeps
+        run: make installdeps installdeps-wasm installdeps-wasm-parallel
       - name: Build rln-wasm in parallel mode
         run: cargo make build_parallel
         working-directory: rln-wasm

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,4 +1,4 @@
-name: Devcontainer image
+name: CI
 
 # On master / develop pushes: build the devcontainer image and publish it to
 # GHCR, so contributors pull prebuilt layers (build.cacheFrom in
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    name: Build devcontainer image
+    name: Build - devcontainer
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,39 @@
+name: Devcontainer image
+
+# Builds the devcontainer image once in CI and publishes it to GHCR so that
+# contributors pull prebuilt layers (via build.cacheFrom in devcontainer.json)
+# instead of recompiling locally. Public repo => GHCR storage and these runners
+# are free. Mark the published package Public once for anonymous pulls.
+on:
+  push:
+    branches:
+      - master
+      - "develop/**"
+    paths:
+      - ".devcontainer/**"
+      - "Makefile"
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    name: Build and push devcontainer image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/vacp2p/zerokit-devcontainer
+          cacheFrom: ghcr.io/vacp2p/zerokit-devcontainer
+          push: always

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,9 +1,11 @@
 name: Devcontainer image
 
-# Builds the devcontainer image once in CI and publishes it to GHCR so that
-# contributors pull prebuilt layers (via build.cacheFrom in devcontainer.json)
-# instead of recompiling locally. Public repo => GHCR storage and these runners
-# are free. Mark the published package Public once for anonymous pulls.
+# On master / develop pushes: build the devcontainer image and publish it to
+# GHCR, so contributors pull prebuilt layers (build.cacheFrom in
+# devcontainer.json) instead of compiling locally. On PRs touching the
+# devcontainer or Makefile: build only (no push) to verify it still builds.
+# Public repo => GHCR storage and these runners are free. Mark the published
+# package Public once for anonymous pulls.
 on:
   push:
     branches:
@@ -12,11 +14,15 @@ on:
     paths:
       - ".devcontainer/**"
       - "Makefile"
+  pull_request:
+    paths:
+      - ".devcontainer/**"
+      - "Makefile"
   workflow_dispatch:
 
 jobs:
-  build-and-push:
-    name: Build and push devcontainer image
+  build:
+    name: Build devcontainer image
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -26,14 +32,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v6
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push devcontainer
+      - name: Build devcontainer (push on master/develop only)
         uses: devcontainers/ci@v0.3
         with:
           imageName: ghcr.io/vacp2p/zerokit-devcontainer
           cacheFrom: ghcr.io/vacp2p/zerokit-devcontainer
-          push: always
+          push: ${{ github.event_name == 'pull_request' && 'never' || 'always' }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -97,15 +97,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rust-src
-          targets: wasm32-unknown-unknown
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install dependencies
-        run: make installdeps
+        run: make installdeps installdeps-wasm installdeps-wasm-parallel
       - name: Build rln-wasm package
         run: |
           if [[ ${{ matrix.build.feature }} == "parallel" ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,35 +1,7 @@
-[target.x86_64-pc-windows-gnu]
-image = "ghcr.io/cross-rs/x86_64-pc-windows-gnu:latest"
-
-[target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest"
-
+# Custom cross images for the Linux targets built by nightly-release.yml.
+# Other targets use cross's default images, or are built via Nix (see flake.nix).
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:latest"
 
-[target.arm-unknown-linux-gnueabi]
-image = "ghcr.io/cross-rs/arm-unknown-linux-gnueabi:latest"
-
-[target.i686-pc-windows-gnu]
-image = "ghcr.io/cross-rs/i686-pc-windows-gnu:latest"
-
-[target.i686-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/i686-unknown-linux-gnu:latest"
-
-[target.arm-unknown-linux-gnueabihf]
-image = "ghcr.io/cross-rs/arm-unknown-linux-gnueabihf:latest"
-
-[target.mips-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/mips-unknown-linux-gnu:latest"
-
-[target.mips64-unknown-linux-gnuabi64]
-image = "ghcr.io/cross-rs/mips64-unknown-linux-gnuabi64:latest"
-
-[target.mips64el-unknown-linux-gnuabi64]
-image = "ghcr.io/cross-rs/mips64el-unknown-linux-gnuabi64:latest"
-
-[target.mipsel-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/mipsel-unknown-linux-gnu:latest"
-
-[target.aarch64-linux-android]
-image = "ghcr.io/cross-rs/aarch64-linux-android:edge"
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest"

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,67 @@
-.PHONY: all installdeps build test bench clean
+.PHONY: all installdeps installdeps-system installdeps-tools installdeps-cross \
+        installdeps-node installdeps-wasm installdeps-wasm-parallel \
+        build test bench clean
+
+# Pinned tool and runtime versions.
+CARGO_MAKE_VERSION ?= 0.37.24
+WASM_PACK_VERSION  ?= 0.15.0
+CROSS_VERSION      ?= 0.2.5
+NODE_VERSION       ?= 26.5.0
+# Major version, for NodeSource's setup_<major>.x URL.
+NODE_MAJOR         ?= $(firstword $(subst ., ,$(NODE_VERSION)))
+NVM_VERSION        ?= 0.40.6
 
 all: installdeps build
 
-.fetch-submodules:
-	@git submodule update --init --recursive
-
-.pre-build: .fetch-submodules
-	@cargo install cargo-make
+# Everything a native build needs; adds cross under CI.
+INSTALLDEPS_DEPS := installdeps-system installdeps-tools installdeps-node
 ifdef CI
-	@cargo install cross --version 0.2.5
+INSTALLDEPS_DEPS += installdeps-cross
 endif
+installdeps: $(INSTALLDEPS_DEPS)
 
-installdeps: .pre-build
+# cmake + ninja.
+installdeps-system:
 ifeq ($(shell uname),Darwin)
-	@brew install ninja
+	@brew install cmake ninja
 else ifeq ($(shell uname),Linux)
 	@if [ -f /etc/os-release ] && grep -q "ID=nixos" /etc/os-release; then \
 		echo "Detected NixOS, skipping apt installation."; \
 	else \
-		sudo apt update; \
-		sudo apt install -y cmake ninja-build; \
+		sudo apt-get update; \
+		sudo apt-get install -y cmake ninja-build; \
 	fi
 endif
-	@which wasm-pack > /dev/null && wasm-pack --version | grep -q "0.15.0" || cargo install wasm-pack --version=0.15.0
-	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh | bash
-	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v26.5.0" ] || nvm install 26.5.0; nvm use 26.5.0; nvm alias default 26.5.0'
+
+# cargo-make + wasm-pack, as prebuilt binaries via cargo-binstall.
+installdeps-tools:
+	@command -v cargo-binstall > /dev/null || \
+		curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+	@cargo binstall --no-confirm cargo-make@$(CARGO_MAKE_VERSION) wasm-pack@$(WASM_PACK_VERSION)
+
+# cross, for the release cross-compile matrix.
+installdeps-cross:
+	@cargo install cross --version $(CROSS_VERSION)
+
+# Node via nvm (the devcontainer installs it via apt instead).
+installdeps-node:
+	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash
+	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v$(NODE_VERSION)" ] || nvm install $(NODE_VERSION); nvm use $(NODE_VERSION); nvm alias default $(NODE_VERSION)'
+
+# wasm32 target, for the default and utils rln-wasm builds.
+installdeps-wasm:
+	@rustup target add wasm32-unknown-unknown
+
+# Nightly + rust-src for the parallel wasm build, rustfmt for `cargo make fmt`.
+installdeps-wasm-parallel:
+	@rustup toolchain install nightly --profile minimal \
+		--component rustfmt \
+		--component rust-src \
+		--target wasm32-unknown-unknown
+
+# Print a variable, e.g. `make -s print-NODE_MAJOR`.
+print-%:
+	@echo '$($*)'
 
 build:
 	@cargo make build

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ else ifeq ($(shell uname),Linux)
 	fi
 endif
 	@which wasm-pack > /dev/null && wasm-pack --version | grep -q "0.15.0" || cargo install wasm-pack --version=0.15.0
-	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
-	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v22.14.0" ] || nvm install 22.14.0; nvm use 22.14.0; nvm alias default 22.14.0'
+	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh | bash
+	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v26.5.0" ] || nvm install 26.5.0; nvm use 26.5.0; nvm alias default 26.5.0'
 
-build: installdeps
+build:
 	@cargo make build
 
 test: build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-.PHONY: all installdeps installdeps-system installdeps-tools installdeps-cross \
-        installdeps-node installdeps-wasm installdeps-wasm-parallel \
+.PHONY: all installdeps installdeps-wasm installdeps-wasm-parallel \
         build test bench clean
 
 # Pinned tool and runtime versions.
@@ -13,44 +12,41 @@ NVM_VERSION        ?= 0.40.6
 
 all: installdeps build
 
-# Everything a native build needs; adds cross under CI.
-INSTALLDEPS_DEPS := installdeps-system installdeps-tools installdeps-node
-ifdef CI
-INSTALLDEPS_DEPS += installdeps-cross
-endif
-installdeps: $(INSTALLDEPS_DEPS)
-
-# cmake + ninja.
-installdeps-system:
+# Native build deps: cmake + ninja + cargo-make; cross added under CI.
+installdeps:
 ifeq ($(shell uname),Darwin)
-	@brew install cmake ninja
+	@command -v cmake > /dev/null && command -v ninja > /dev/null || \
+		brew install cmake ninja
 else ifeq ($(shell uname),Linux)
-	@if [ -f /etc/os-release ] && grep -q "ID=nixos" /etc/os-release; then \
+	@if command -v cmake > /dev/null && command -v ninja > /dev/null; then \
+		:; \
+	elif [ -f /etc/os-release ] && grep -q "ID=nixos" /etc/os-release; then \
 		echo "Detected NixOS, skipping apt installation."; \
 	else \
 		sudo apt-get update; \
 		sudo apt-get install -y cmake ninja-build; \
 	fi
 endif
-
-# cargo-make + wasm-pack, as prebuilt binaries via cargo-binstall.
-installdeps-tools:
 	@command -v cargo-binstall > /dev/null || \
 		curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-	@cargo binstall --no-confirm cargo-make@$(CARGO_MAKE_VERSION) wasm-pack@$(WASM_PACK_VERSION)
-
-# cross, for the release cross-compile matrix.
-installdeps-cross:
+	@cargo make --version 2>/dev/null | grep -q "$(CARGO_MAKE_VERSION)" || \
+		cargo binstall --no-confirm --force cargo-make@$(CARGO_MAKE_VERSION)
+ifdef CI
 	@cargo install cross --version $(CROSS_VERSION)
+endif
 
-# Node via nvm (the devcontainer installs it via apt instead).
-installdeps-node:
-	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash
-	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v$(NODE_VERSION)" ] || nvm install $(NODE_VERSION); nvm use $(NODE_VERSION); nvm alias default $(NODE_VERSION)'
-
-# wasm32 target, for the default and utils rln-wasm builds.
+# Everything the default rln-wasm build needs: wasm32 target, wasm-pack, node
+# via nvm. NO_NVM=1 skips the node step (the devcontainer uses apt node instead).
 installdeps-wasm:
 	@rustup target add wasm32-unknown-unknown
+	@command -v cargo-binstall > /dev/null || \
+		curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+	@wasm-pack --version 2>/dev/null | grep -q "$(WASM_PACK_VERSION)" || \
+		cargo binstall --no-confirm --force wasm-pack@$(WASM_PACK_VERSION)
+ifndef NO_NVM
+	@test -s "$$HOME/.nvm/nvm.sh" || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash
+	@bash -c '. "$$HOME/.nvm/nvm.sh"; [ "$$(node -v 2>/dev/null)" = "v$(NODE_VERSION)" ] || nvm install $(NODE_VERSION); nvm use $(NODE_VERSION); nvm alias default $(NODE_VERSION)'
+endif
 
 # Nightly + rust-src for the parallel wasm build, rustfmt for `cargo make fmt`.
 installdeps-wasm-parallel:


### PR DESCRIPTION
## Description

<!-- Provide a clear summary of the changes and motivation behind them. -->
<!-- Link related issues using "Closes #123" or "Related to #456". -->

## Changes

<!-- List the key changes in this PR. -->

-

## Testing

<!-- Describe how the changes were tested. -->
<!-- Include any relevant test commands, scenarios, or edge cases covered. -->

---

## PR Lifecycle

> [!IMPORTANT]
> **Draft PRs** signal that work is still in progress and **will not trigger CI**.
> Only mark your PR as **Ready for review** when you believe it is complete.
> All CI checks **must pass** before requesting a review.

## Code Guidelines

Please keep the following in mind (see [CONTRIBUTING.md](../CONTRIBUTING.md) for full details):

### Commits

- Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (`feat(rln):`, `fix(utils):`, `chore:`, etc.)
- Use the appropriate scope: `rln`, `rln-cli`, `rln-wasm`, `utils`, `ci`
- GPG-sign your commits

### Error Handling

- **No panics in library code.** Do not use `unwrap()`, `expect()`, or `panic!()`
  in production paths inside `rln/src/` or `utils/src/`.
  The only acceptable exception is an internal invariant that is statically guaranteed - and even then, prefer returning an error.
- Use the project's `thiserror`-based error types (`RLNError`, `ProtocolError`, `UtilsError`, etc.)
  and propagate errors with `?`.
- Provide context in error variants (e.g., `InsufficientData { expected, actual }`).
- `unwrap()` is fine in **tests**.

### Code Style

- Run `cargo make fmt` at the root of the repository to auto-format the entire codebase with rules defined in [`rustfmt.toml`](../rustfmt.toml).
- Run `cargo make fmt_check` to verify formatting (CI enforces this on stable).
- Group imports: std first, then external crates, then local modules (see `rustfmt.toml`).
- Use `pub(crate)` for items that should not be part of the public API.
- Apply `Zeroize` / `ZeroizeOnDrop` to any struct holding secret material.

### Linting (mirrors CI)

CI runs clippy across multiple crate/feature combinations. Run the relevant checks locally before pushing:

```bash
# Default features - workspace root (rln + utils)
cargo clippy --all-targets --tests --release -- -D warnings

# Stateless feature - from rln/
cd rln && cargo clippy --all-targets --tests --release \
  --features=stateless --no-default-features -- -D warnings

# WASM target - from rln-wasm/
cd rln-wasm && cargo clippy --target wasm32-unknown-unknown \
  --tests --release -- -D warnings
```

At minimum, run the default-features check. If your changes touch `stateless` or `rln-wasm`, run those checks as well.

## Checklist

- [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] I have linked the related issue(s)
- [ ] I have run `cargo +nightly fmt --all` to apply all `rustfmt.toml` rules (including import grouping)
- [ ] `cargo fmt --all -- --check` produces no changes
- [ ] Clippy passes for all affected crate/feature combinations (see [Linting](#linting-mirrors-ci) above)
- [ ] `make test` passes locally
- [ ] No new `unwrap()` / `expect()` / `panic!()` in library code
- [ ] New code includes appropriate tests (unit / integration / WASM where applicable)
- [ ] I have run the CI coverage report - add the `run-coverage` label to enable it
- [ ] All CI checks pass and the PR is marked **Ready for review**
