### PR TITLE
fix(rln): fix pmtree reload race silently, fix testcase with TempDir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/rln/src/pm_tree.rs
+++ b/rln/src/pm_tree.rs
@@ -49,6 +49,10 @@ impl PmTreeHasher for PoseidonHash {
 pub trait PmTreeBackendConfig: Clone + Default + FromStr {
     /// The tree depth this config expects; rechecked against the requested depth on reload.
     fn tree_depth(&self) -> Option<usize>;
+
+    /// Returns `true` when no persisted tree exists, so a new one is initialized; `false`
+    /// loads the existing tree and propagates load errors. In-memory backends return `true`.
+    fn is_fresh(&self) -> bool;
 }
 
 /// A persistent Merkle tree over a [`pmtree::Database`] backend (sled by default).
@@ -210,6 +214,16 @@ impl PmTreeBackendConfig for PmTreeSledConfig {
     fn tree_depth(&self) -> Option<usize> {
         self.tree_depth
     }
+
+    fn is_fresh(&self) -> bool {
+        // Fresh when the path does not exist yet or is an empty directory.
+        !self.path.exists()
+            || self
+                .path
+                .read_dir()
+                .map(|mut entries| entries.next().is_none())
+                .unwrap_or(false)
+    }
 }
 
 impl<D, H> ZerokitMerkleTree for PmTree<D, H>
@@ -229,7 +243,7 @@ where
         Self::new(depth, Self::Hasher::default_leaf(), default_config)
     }
 
-    /// Creates a new tree, loading the existing one at the configured path if present
+    /// Creates a new tree, loading the existing one when the config is not fresh.
     fn new(
         depth: usize,
         _default_leaf: <H as ZerokitHasher>::Scalar,
@@ -243,15 +257,14 @@ where
                 return Err(ZerokitMerkleTreeError::DepthMismatch.into());
             }
         }
-        let tree_loaded = MerkleTree::load(config.clone());
-        let tree = match tree_loaded {
-            Ok(tree) => {
-                if tree.depth() != depth {
-                    return Err(ZerokitMerkleTreeError::DepthMismatch.into());
-                }
-                tree
+        let tree = if config.is_fresh() {
+            MerkleTree::new(depth, config)?
+        } else {
+            let tree = MerkleTree::load(config)?;
+            if tree.depth() != depth {
+                return Err(ZerokitMerkleTreeError::DepthMismatch.into());
             }
-            Err(_) => MerkleTree::new(depth, config)?,
+            tree
         };
 
         let capacity = 1usize
@@ -540,19 +553,13 @@ impl Database for SledDB {
 
     fn load(config: Self::Config) -> PmtreeResult<Self> {
         let sled_config = Config::from(&config);
-        let db = match sled_config.open() {
-            Ok(db) => db,
-            Err(err) => {
-                return Err(PmtreeError::Database(format!(
-                    "Cannot load database: {err}"
-                )))
-            }
-        };
+        let path = sled_config.path.clone();
+        let SledDB(db) = Self::new_with_tries(sled_config, 0)?;
 
         if !db.was_recovered() {
             return Err(PmtreeError::Database(format!(
                 "Database was not recovered: {}",
-                sled_config.path.display()
+                path.display()
             )));
         }
 

--- a/rln/tests/pm_tree.rs
+++ b/rln/tests/pm_tree.rs
@@ -102,15 +102,19 @@ mod test {
 
     #[test]
     fn test_pmtree_config_from_str() {
-        let json = r#"
-        {
-            "path": "/tmp/pmtree-test-path",
+        let temp_dir = TempDir::new().unwrap();
+        let json = format!(
+            r#"
+        {{
+            "path": "{}",
             "temporary": false,
             "cache_capacity": 1073741824,
             "flush_every_ms": 500,
             "mode": "HighThroughput",
             "use_compression": false
-        }"#;
+        }}"#,
+            temp_dir.path().display()
+        );
 
         let config: PmTreeSledConfig = json.parse().unwrap();
 

--- a/rln/tests/pm_tree.rs
+++ b/rln/tests/pm_tree.rs
@@ -40,6 +40,10 @@ mod test {
         fn tree_depth(&self) -> Option<usize> {
             None
         }
+
+        fn is_fresh(&self) -> bool {
+            true
+        }
     }
 
     #[derive(Default)]


### PR DESCRIPTION
## Problem

- `test_pmtree_reload_rebuilds_empty_leaves_cache` exposed a race condition after failing on CI (`leaves_set() == 0` instead of `3`):  caught in CI https://github.com/vacp2p/zerokit/actions/runs/30363935531/job/90290231977

- A temporary `sled` file-lock (`WouldBlock`) could make `PmTree` think an existing database didn't exist, causing it to recreate the tree and silently lose the persisted state.

## Fix

- `SledDB::load` now retries `WouldBlock` errors like `SledDB::new`, and `PmTree::new` no longer treats load failures as "tree doesn't exist", load errors are now propagated instead.

- Fixed test_pmtree_config_from_str problem by using TempDir.