### PR TITLE
nix: bump release-25.11 rev to pick up fetch-cargo-vendor-util-v2, and update cargoHash for v3.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770464364,
-        "narHash": "sha256-z5NJPSBwsLf/OfD8WTmh79tlSU8XgIbwmk6qB1/TFzY=",
+        "lastModified": 1783375776,
+        "narHash": "sha256-pg6hLjDeAWaUOzh2JM2Cw0BwYpGtOyNr6A4FBwP9Ymo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
+        "rev": "cd648d6ea62bc0ffba91e61fcfe5e33c1e2004b1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
+        "rev": "cd648d6ea62bc0ffba91e61fcfe5e33c1e2004b1",
         "type": "github"
       }
     },
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771297684,
-        "narHash": "sha256-wieWskQxZLPlNXX06JEB0bMoS/ZYQ89xBzF0RL9lyLs=",
+        "lastModified": 1786507911,
+        "narHash": "sha256-w5aZRLbiu7H6TqsYXVMdRKg0S4DRaJpxyqxx86AwxVk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "755d3669699a7c62aef35af187d75dc2728cfd85",
+        "rev": "39db48099ad16834af7e27485a4babf9c28b3897",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,13 @@
   };
 
   inputs = {
-    # Pinning the commit to use same commit across different projects.
     # A commit from nixpkgs 25.11 release : https://github.com/NixOS/nixpkgs/tree/release-25.11
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=23d72dabcb3b12469f57b37170fcbc1789bd7457";
+    # Bumped from rev 23d72dab… (2026-02-07) to a post-2026-04-24 rev so that
+    # rustPlatform.fetchCargoVendor uses `fetch-cargo-vendor-util-v2.py`, which
+    # sets a `nixpkgs-fetchCargoVendor/2` User-Agent. The previous script sent
+    # no User-Agent and crates.io returns 403 for empty-UA requests, breaking
+    # `nix build .#rln` for anyone without a warm vendor cache.
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=cd648d6ea62bc0ffba91e61fcfe5e33c1e2004b1";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,6 @@
 
   inputs = {
     # A commit from nixpkgs 25.11 release : https://github.com/NixOS/nixpkgs/tree/release-25.11
-    # Bumped from rev 23d72dab… (2026-02-07) to a post-2026-04-24 rev so that
-    # rustPlatform.fetchCargoVendor uses `fetch-cargo-vendor-util-v2.py`, which
-    # sets a `nixpkgs-fetchCargoVendor/2` User-Agent. The previous script sent
-    # no User-Agent and crates.io returns 403 for empty-UA requests, breaking
-    # `nix build .#rln` for anyone without a warm vendor cache.
     nixpkgs.url = "github:NixOS/nixpkgs?rev=cd648d6ea62bc0ffba91e61fcfe5e33c1e2004b1";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -28,7 +28,7 @@ in targetPlatformPkgs.rustPlatform.buildRustPackage {
 
   inherit src;
 
-  cargoHash = "sha256-WXxQ8mAPD/mPBSnLrunhbDyCAQ0D82t1MILbo+Vfcqk=";
+  cargoHash = "sha256-/wSh0vuBcBV8DGfA39af3W600hTv+Kkeo6bLFPq4pNo=";
 
   nativeBuildInputs = with pkgs; [ rust-cbindgen ];
 


### PR DESCRIPTION
## Summary

Two fixes bundled — the flake is unbuildable end-to-end on a downstream consumer without a warm vendor cache.

- **`flake.nix`**: bump the `release-25.11` rev from `23d72dab…` (2026-02-07) → `cd648d6e…` (2026-07-06). At the previous rev, `rustPlatform.fetchCargoVendor` used the v1 `fetch-cargo-vendor-util.py`, which issued crates.io requests without a `User-Agent` header — and crates.io returns 403 for empty-UA requests. As of nixpkgs commit `0fb82de3fbc3` (2026-04-24), the derivation switched to `fetch-cargo-vendor-util-v2.py`, which sets a `nixpkgs-fetchCargoVendor/2` User-Agent (and a follow-up commit switches it to `static.crates.io`, avoiding the API entirely). 
- **`nix/default.nix`**: update `cargoHash` from the v2.0.0-era value (`sha256-WXxQ8mA…`) → `sha256-/wSh0vuBcBV8DGfA39af3W600hTv+Kkeo6bLFPq4pNo=`, matching the current `rln/Cargo.lock` (v3.0.0). This second fix was the one @[maintainer] originally flagged; it only surfaces once the vendor step above succeeds
