### PR TITLE
nix: add rln-stateless output; disable defaults when features are set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
       in rec {
         rln = buildRln;
 
+        # mix-rln-spam-protection-plugin's Nim binding calls the zero-arg
+        # form of ffi_rln_new, which zerokit exposes only under `stateless`.
+        rln-stateless = buildRln.override (old: { features = "stateless"; });
+
         rln-linux-arm64 = buildRln {
           target-platform = "aarch64-multiplatform";
           rust-target = "aarch64-unknown-linux-gnu";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -28,7 +28,7 @@ in targetPlatformPkgs.rustPlatform.buildRustPackage {
 
   inherit src;
 
-  cargoHash = "sha256-3wFnSJYUSQ01tQLe4nZGUZdoU1A9vsl9dpJU3vPeiHo=";
+  cargoHash = "sha256-PNwEdZLgGQPqQDrEK2hsQtSybVfBbD6xn4K47fPFJUU=";
 
   nativeBuildInputs = with pkgs; [ rust-cbindgen ];
 
@@ -37,7 +37,7 @@ in targetPlatformPkgs.rustPlatform.buildRustPackage {
     cargo build --lib \
       ${if release             then "--release" else ""} \
       ${if rust-target != null then "--target=${rust-target}" else ""} \
-      ${if features != null    then "--features=${features}" else ""} \
+      ${if features != null    then "--no-default-features --features=${features}" else ""} \
       --manifest-path rln/Cargo.toml
   '';
 


### PR DESCRIPTION
> **Not for merge.** Draft opened for visibility only. `master` (v3.0.0) removed the `stateless` feature entirely, so this fix does not apply there as-is. We'll re-do the equivalent against v3 once we migrate our consumers off `ffi_rln_new`'s v2 zero-argument form. Filing here so the v2.x nix packaging is at least reproducible in the meantime.

The `stateless` feature exposes the zero-argument form of `ffi_rln_new`, which downstream Nim/C bindings (e.g. `mix-rln-spam-protection-plugin`) rely on. There is currently no packaged way to consume it — every caller has to fork this flake to add `override { features = "stateless"; }`.

### Changes

- **`flake.nix`**: expose `rln-stateless = buildRln.override { features = "stateless"; }` alongside `rln`, so callers can pull it in directly.
- **`nix/default.nix`**: when the caller passes `features`, add `--no-default-features`. Without this, `--features=stateless` still pulls in `parallel` (the current default), and the stateless build fails to compile with `parallel` enabled.
- **`cargoHash`** bumped: the previous value no longer matches the vendor set that `rustPlatform.buildRustPackage` computes on the current nixpkgs 25.11 pin.

### Verification

\`\`\`
nix build .#rln           # unchanged output, still works
nix build .#rln-stateless # produces librln.{a,so} without parallel
\`\`\`